### PR TITLE
Added partial support for PSQL messages, fixed lack of error on invalid database

### DIFF
--- a/testing/framework_test.go
+++ b/testing/framework_test.go
@@ -149,7 +149,7 @@ func CreateServer(t *testing.T, database string) (context.Context, *pgx.Conn, *s
 	}()
 	require.NoError(t, err)
 
-	conn, err := pgx.Connect(ctx, fmt.Sprintf("postgres://postgres:password@127.0.0.1:%d/postgres?sslmode=disable", port))
+	conn, err := pgx.Connect(ctx, fmt.Sprintf("postgres://postgres:password@127.0.0.1:%d/%s?sslmode=disable", port, database))
 	require.NoError(t, err)
 	return ctx, conn, serverClosed
 }


### PR DESCRIPTION
Fixes:
* https://github.com/dolthub/doltgresql/issues/9
* https://github.com/dolthub/doltgresql/issues/11

Partially Fixes:
* https://github.com/dolthub/doltgresql/issues/15

All of these rely on PostgreSQL's `INFORMATION_SCHEMA`-equivalent tables, which we do not currently have any support for. As a workaround, PSQL sends specific strings to retrieve the information needed for these commands, so this just recognizes those strings and returns a set of results that PSQL is okay with. This works with all of the commands except for `\d table_name`, hence the partial support (the issue also lists `\d`, which is supported now).

`\d table_name` sends _at least_ 15 different statements to determine the full state of a table, and each query builds on the last. In addition, it seems that the queries sent are relative to the data returned for the given table, so this current hardcoded approach will not work. We probably need to get the catalog emulation working before we can actually tackle `\d table_name`. I did make an attempt at the >=15 statements, but I kept running into new issues of things that we do not yet support, so I decided that it's not worth the time investment right now.