### PR TITLE
Added similar Postgres/MySQL types

### DIFF
--- a/postgres/messages/row_description.go
+++ b/postgres/messages/row_description.go
@@ -151,12 +151,20 @@ func VitessFieldToDataTypeObjectID(field *query.Field) (int32, error) {
 		return 700, nil
 	case query.Type_FLOAT64:
 		return 701, nil
+	case query.Type_DECIMAL:
+		return 1700, nil
 	case query.Type_CHAR:
 		return 1042, nil
 	case query.Type_VARCHAR:
 		return 1043, nil
 	case query.Type_TEXT:
 		return 25, nil
+	case query.Type_JSON:
+		return 114, nil
+	case query.Type_TIMESTAMP, query.Type_DATETIME:
+		return 1114, nil
+	case query.Type_DATE:
+		return 1082, nil
 	default:
 		return 0, fmt.Errorf("unsupported type returned from engine")
 	}
@@ -179,12 +187,20 @@ func VitessFieldToDataTypeSize(field *query.Field) (int16, error) {
 		return 4, nil
 	case query.Type_FLOAT64:
 		return 8, nil
+	case query.Type_DECIMAL:
+		return -1, nil
 	case query.Type_CHAR:
 		return -1, nil
 	case query.Type_VARCHAR:
 		return -1, nil
 	case query.Type_TEXT:
 		return -1, nil
+	case query.Type_JSON:
+		return -1, nil
+	case query.Type_TIMESTAMP, query.Type_DATETIME:
+		return 8, nil
+	case query.Type_DATE:
+		return 4, nil
 	default:
 		return 0, fmt.Errorf("unsupported type returned from engine")
 	}
@@ -207,6 +223,15 @@ func VitessFieldToDataTypeModifier(field *query.Field) (int32, error) {
 		return -1, nil
 	case query.Type_FLOAT64:
 		return -1, nil
+	case query.Type_DECIMAL:
+		// This is how we encode the precision and scale for some reason
+		precision := int32(field.ColumnLength - 1)
+		scale := int32(field.Decimals)
+		if scale > 0 {
+			precision--
+		}
+		// PostgreSQL adds 4 to the length for an unknown reason
+		return (precision<<16 + scale) + 4, nil
 	case query.Type_CHAR:
 		// PostgreSQL adds 4 to the length for an unknown reason
 		return int32(int64(field.ColumnLength)/sql.CharacterSetID(field.Charset).MaxLength()) + 4, nil
@@ -214,6 +239,12 @@ func VitessFieldToDataTypeModifier(field *query.Field) (int32, error) {
 		// PostgreSQL adds 4 to the length for an unknown reason
 		return int32(int64(field.ColumnLength)/sql.CharacterSetID(field.Charset).MaxLength()) + 4, nil
 	case query.Type_TEXT:
+		return -1, nil
+	case query.Type_JSON:
+		return -1, nil
+	case query.Type_TIMESTAMP, query.Type_DATETIME:
+		return -1, nil
+	case query.Type_DATE:
 		return -1, nil
 	default:
 		return 0, fmt.Errorf("unsupported type returned from engine")

--- a/postgres/parser/types/types.go
+++ b/postgres/parser/types/types.go
@@ -1657,8 +1657,7 @@ func (t *T) SQLString() string {
 			return fmt.Sprintf("DECIMAL(%d)", t.Precision())
 		}
 	case JsonFamily:
-		// Only binary JSON is currently supported.
-		return "JSONB"
+		return "JSON"
 	case TimestampFamily, TimestampTZFamily, TimeFamily, TimeTZFamily:
 		if t.InternalType.Precision > 0 || t.InternalType.TimePrecisionIsSet {
 			return fmt.Sprintf("%s(%d)", strings.ToUpper(t.Name()), t.Precision())

--- a/testing/go/main_test.go
+++ b/testing/go/main_test.go
@@ -32,61 +32,6 @@ import (
 func TestSmokeTests(t *testing.T) {
 	RunScripts(t, []ScriptTest{
 		{
-			Name: "String types",
-			SetUpScript: []string{
-				"CREATE TABLE test (pk BIGINT PRIMARY KEY, v1 VARCHAR(13), v2 CHAR(11), v3 TEXT);",
-			},
-			Assertions: []ScriptTestAssertion{
-				{
-					Query:    "INSERT INTO test VALUES (1, 'hey1', 'heythere2', 'hellofellow3');",
-					Expected: []sql.Row{},
-				},
-				{
-					Query:    "INSERT INTO test VALUES (2, 'hey44', 'heythere55', 'hellofellow66');",
-					Expected: []sql.Row{},
-				},
-				{
-					Query: "SELECT * FROM test;",
-					Expected: []sql.Row{
-						{1, "hey1", "heythere2", "hellofellow3"},
-						{2, "hey44", "heythere55", "hellofellow66"},
-					},
-				},
-			},
-		},
-		{
-			Name: "Int types",
-			SetUpScript: []string{
-				"CREATE TABLE test (v1 SMALLINT, v2 INTEGER, v3 BIGINT);",
-				"INSERT INTO test VALUES (1, 2, 3), (4, 5, 6);",
-			},
-			Assertions: []ScriptTestAssertion{
-				{
-					Query: "SELECT * FROM test ORDER BY 1;",
-					Expected: []sql.Row{
-						{1, 2, 3},
-						{4, 5, 6},
-					},
-				},
-			},
-		},
-		{
-			Name: "Float types",
-			SetUpScript: []string{
-				"CREATE TABLE test (v1 REAL, v2 DOUBLE PRECISION);",
-				"INSERT INTO test VALUES (1.5, 2.25), (10.125, 15.0625);",
-			},
-			Assertions: []ScriptTestAssertion{
-				{
-					Query: "SELECT * FROM test ORDER BY 1;",
-					Expected: []sql.Row{
-						{1.5, 2.25},
-						{10.125, 15.0625},
-					},
-				},
-			},
-		},
-		{
 			Name: "Commit and diff across branches",
 			SetUpScript: []string{
 				"CREATE TABLE test (pk BIGINT PRIMARY KEY, v1 BIGINT);",
@@ -141,6 +86,128 @@ func TestSmokeTests(t *testing.T) {
 				{
 					Query:       "SHOW CREATE TABLE;",
 					ExpectedErr: true,
+				},
+			},
+		},
+	})
+}
+
+func TestSameTypes(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "Integer types",
+			SetUpScript: []string{
+				"CREATE TABLE test1 (v1 SMALLINT, v2 INTEGER, v3 BIGINT);",
+				"CREATE TABLE test2 (v1 INT2, v2 INT4, v3 INT8);",
+				"INSERT INTO test1 VALUES (1, 2, 3), (4, 5, 6);",
+				"INSERT INTO test2 VALUES (1, 2, 3), (4, 5, 6);",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT * FROM test1 ORDER BY 1;",
+					Expected: []sql.Row{
+						{1, 2, 3},
+						{4, 5, 6},
+					},
+				},
+				{
+					Query: "SELECT * FROM test2 ORDER BY 1;",
+					Expected: []sql.Row{
+						{1, 2, 3},
+						{4, 5, 6},
+					},
+				},
+			},
+		},
+		{
+			Name: "Arbitrary precision types",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 DECIMAL(10, 1), v2 NUMERIC(11, 2));",
+				"INSERT INTO test VALUES (14854.5, 2504.25), (566821525.5, 735134574.75);",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT * FROM test ORDER BY 1;",
+					Expected: []sql.Row{
+						{14854.5, 2504.25},
+						{566821525.5, 735134574.75},
+					},
+				},
+			},
+		},
+		{
+			Name: "Floating point types",
+			SetUpScript: []string{
+				"CREATE TABLE test1 (v1 REAL, v2 DOUBLE PRECISION);",
+				"CREATE TABLE test2 (v1 FLOAT4, v2 FLOAT8);",
+				"INSERT INTO test1 VALUES (10.125, 20.4), (40.875, 81.6);",
+				"INSERT INTO test2 VALUES (10.125, 20.4), (40.875, 81.6);",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT * FROM test1 ORDER BY 1;",
+					Expected: []sql.Row{
+						{10.125, 20.4},
+						{40.875, 81.6},
+					},
+				},
+				{
+					Query: "SELECT * FROM test2 ORDER BY 1;",
+					Expected: []sql.Row{
+						{10.125, 20.4},
+						{40.875, 81.6},
+					},
+				},
+			},
+		},
+		{
+			// TIME has the same name, but operates a bit differently, so it's not included as a "same type"
+			Name: "Date and time types",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 TIMESTAMP, v2 DATE);",
+				"INSERT INTO test VALUES ('1986-08-02 17:04:22', '2023-09-03');",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT * FROM test ORDER BY 1;",
+					Expected: []sql.Row{
+						{"1986-08-02 17:04:22", "2023-09-03 00:00:00"},
+					},
+				},
+			},
+		},
+		{
+			// ENUM exists, but features too many differences to incorporate as a "same type"
+			// BLOB exists, but functions as a BYTEA, which operates differently than a BINARY/VARBINARY in MySQL
+			Name: "Text types",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 CHARACTER VARYING(255), v2 CHARACTER(3), v3 TEXT);",
+				"INSERT INTO test VALUES ('abc', 'def', 'ghi'), ('jkl', 'mno', 'pqr');",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT * FROM test ORDER BY 1;",
+					Expected: []sql.Row{
+						{"abc", "def", "ghi"},
+						{"jkl", "mno", "pqr"},
+					},
+				},
+			},
+		},
+		{
+			Name: "JSON type",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 INT, v2 JSON);",
+				`INSERT INTO test VALUES (1, '{"key1": {"key": "value"}}'), (2, '{"key1": "value1", "key2": "value2"}'), (3, '{"key1": {"key": [2,3]}}');`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT * FROM test ORDER BY 1;",
+					Expected: []sql.Row{
+						{1, `{"key1":{"key":"value"}}`},
+						{2, `{"key1":"value1","key2":"value2"}`},
+						{3, `{"key1":{"key":[2,3]}}`},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
This adds the remaining Postgres/MySQL types that I think are "similar enough". Some types, like the `TIME` type, seem fairly similar, but have a different enough set of restrictions and behavior that I couldn't figure out a good way to easily incorporate them, so there are quite a few types that I'm leaving on the table for when we tackle the non-MySQL types. I think this selection will be good enough for now though. The only real "major" omission are the lack of any binary string types, as Postgres' `BYTEA` type is just too different.

AFAICT, these types also cover all types used by Dolt procedures and system tables.