### PR TITLE
Fixed INT8 handling, support for testing statements, proper connection error handling

### DIFF
--- a/postgres/connection/connection.go
+++ b/postgres/connection/connection.go
@@ -220,6 +220,20 @@ TopLevelLoop:
 	return allPossibleMessages, nil
 }
 
+// DiscardToSync discards all messages in the buffer until a Sync has been reached. If a Sync was never sent, then this
+// may cause the connection to lock until the client send a Sync, as their request structure was malformed.
+func DiscardToSync(conn net.Conn) error {
+	for {
+		message, err := Receive(conn)
+		if err != nil {
+			return err
+		}
+		if message.DefaultMessage().Name == "Sync" {
+			return nil
+		}
+	}
+}
+
 // Send sends the given message over the connection.
 func Send(conn net.Conn, message Message) error {
 	encodedMessage, err := message.Encode()

--- a/testing/go/smoke_test.go
+++ b/testing/go/smoke_test.go
@@ -23,20 +23,52 @@ import (
 func TestSmokeTests(t *testing.T) {
 	RunScripts(t, []ScriptTest{
 		{
-			Name: "simple statements",
+			Name: "Simple statements",
 			SetUpScript: []string{
 				"CREATE TABLE test (pk BIGINT PRIMARY KEY, v1 BIGINT);",
 			},
 			Assertions: []ScriptTestAssertion{
 				{
-					Query:            "insert into test values (1, 1), (2, 2);",
-					SkipResultsCheck: true,
+					Query:    "CREATE TABLE test2 (pk BIGINT PRIMARY KEY, v1 BIGINT);",
+					Expected: []sql.Row{},
 				},
 				{
-					Query: "select * from test;",
+					Query:    "INSERT INTO test VALUES (1, 1), (2, 2);",
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    "INSERT INTO test2 VALUES (3, 3), (4, 4);",
+					Expected: []sql.Row{},
+				},
+				{
+					Query: "SELECT * FROM test;",
 					Expected: []sql.Row{
 						{1, 1},
 						{2, 2},
+					},
+				},
+				{
+					Query: "SELECT * FROM test2;",
+					Expected: []sql.Row{
+						{3, 3},
+						{4, 4},
+					},
+				},
+			},
+		},
+		{
+			Name: "Boolean results",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT 1 IN (2);",
+					Expected: []sql.Row{
+						{0},
+					},
+				},
+				{
+					Query: "SELECT 2 IN (2);",
+					Expected: []sql.Row{
+						{1},
 					},
 				},
 			},

--- a/testing/go/ssl_test.go
+++ b/testing/go/ssl_test.go
@@ -55,5 +55,7 @@ func TestSSL(t *testing.T) {
 	require.NoError(t, err)
 	rows, err := conn.Query(ctx, "SELECT * FROM test;")
 	require.NoError(t, err)
-	assert.Equal(t, NormalizeRows([]sql.Row{{3645, 37643}}), ReadRows(t, rows))
+	readRows, err := ReadRows(rows)
+	require.NoError(t, err)
+	assert.Equal(t, NormalizeRows([]sql.Row{{3645, 37643}}), readRows)
 }


### PR DESCRIPTION
This primarily implements four things:
1) We now discard all messages until we reach a `Sync` message when an error occurs, which is consistent with the [documentation](https://www.postgresql.org/docs/15/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY).
2) Proper support for boolean results. The `sqllogictests` make use of them, and GMS doesn't have a native boolean type, so we treat all booleans as `Int32` types. You can read more in the comments.
3) Proper error handling is the multi-message test case. Our `conn.Query` calls in tests only return specific kinds of errors, and all other errors are put into the returned `rows`. This differs from `conn.Exec`, which returns _all_ errors. Previously, we never checked for an error in `rows` (since I never knew an error would be put there), so it was getting swallowed. We now properly handle those errors.
4) Expanded statement support for `Describe` messages. I noticed in the `zachmu/err-handling-repro` branch that the test file `testing/go/prepared_statement_test.go` is inconsistent with the general test framework, as it runs the setup statements using `conn.Query` rather than `conn.Execute`. We don't support `Describe` at all right now, as GMS currently requires analyzing a statement to determine the output schema, and analyzing some statements produces execution side effects. As a workaround, we start a transaction, execute the query, record the schema, and rollback the transaction. This does not work for any commands that implicitly commit the transaction, so this adds another hack to fake it by running an equivalent `DROP` to select `CREATE` statements. This does cause an implicit commit, but it's better than failing for now.