### PR TITLE
Added permutation counting, variable definitions to parser test generation

### DIFF
--- a/testing/generation/command_docs/token.go
+++ b/testing/generation/command_docs/token.go
@@ -23,9 +23,7 @@ const (
 	TokenType_VariableDefinition
 	TokenType_Or
 	TokenType_Repeat
-	TokenType_CommaRepeat
 	TokenType_OptionalRepeat
-	TokenType_OptionalCommaRepeat
 	TokenType_ShortSpace
 	TokenType_MediumSpace
 	TokenType_LongSpace
@@ -83,12 +81,12 @@ func (t Token) String() string {
 		return "|"
 	case TokenType_Repeat:
 		return "..."
-	case TokenType_CommaRepeat:
-		return ", ..."
 	case TokenType_OptionalRepeat:
-		return "[ ... ]"
-	case TokenType_OptionalCommaRepeat:
-		return "[ , ... ]"
+		if len(t.Literal) > 0 {
+			return "[ " + t.Literal + " ... ]"
+		} else {
+			return "[ ... ]"
+		}
 	case TokenType_ShortSpace:
 		return " "
 	case TokenType_MediumSpace:

--- a/testing/generation/command_docs/token_reader.go
+++ b/testing/generation/command_docs/token_reader.go
@@ -39,7 +39,7 @@ func NewTokenReader(tokens []Token) *TokenReader {
 // Next returns the next token while advancing the reader. Returns false if there are no more tokens.
 func (reader *TokenReader) Next() (Token, bool) {
 	if reader.index+1 >= len(reader.tokens) {
-		return Token{}, false
+		return Token{Type: TokenType_EOF}, false
 	}
 	reader.index++
 	return reader.tokens[reader.index], true
@@ -48,7 +48,7 @@ func (reader *TokenReader) Next() (Token, bool) {
 // Peek returns the next token. Does not advance the reader. Returns false if there are no more tokens.
 func (reader *TokenReader) Peek() (Token, bool) {
 	if reader.index+1 >= len(reader.tokens) {
-		return Token{}, false
+		return Token{Type: TokenType_EOF}, false
 	}
 	return reader.tokens[reader.index+1], true
 }
@@ -57,7 +57,7 @@ func (reader *TokenReader) Peek() (Token, bool) {
 // if we are peeking beyond the slice.
 func (reader *TokenReader) PeekBy(n int) (Token, bool) {
 	if reader.index+n >= len(reader.tokens) || reader.index+n < 0 {
-		return Token{}, false
+		return Token{Type: TokenType_EOF}, false
 	}
 	return reader.tokens[reader.index+n], true
 }


### PR DESCRIPTION
This adds the ability to count the number of permutations without having to actually loop through them all and increment one by one. This also adds variable declaration support (the `where VAR is one of:` in the synopsis). With those two, I can now verify that with _some_ of the variables defined in `SELECT`, we're up to **144 septillion** variations lol. I also removed the repetition strategy, which cut out a _ton_ of tests that probably weren't necessary (exponential on top of combinatorial).

This is a prelude to the next PR. I've found a strategy to be able to grab a deterministic set of tests (we can randomly decide the set, but given the proper input it's deterministic), but it requires knowing the number of possible permutations ahead of time, hence this PR.