### PR TITLE
starting doltgres server creates db in defined directory

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -212,9 +212,9 @@ func runServer(ctx context.Context, args []string, dEnv *env.DoltEnv) (*svcs.Con
 			// We'll use a temporary environment to instantiate the subdirectory
 			tempDEnv := env.Load(ctx, env.GetCurrentUserHomeDir, subdirectoryFS, dEnv.UrlStr(), Version)
 			// username and user email is needed to create a new database.
-			//name := dEnv.Config.GetStringOrDefault(config.UserNameKey, DefUserName)
-			//email := dEnv.Config.GetStringOrDefault(config.UserEmailKey, DefUserEmail)
-			res := commands.InitCmd{}.Exec(ctx, "init", []string{}, tempDEnv, configCliContext{tempDEnv})
+			name := dEnv.Config.GetStringOrDefault(config.UserNameKey, DefUserName)
+			email := dEnv.Config.GetStringOrDefault(config.UserEmailKey, DefUserEmail)
+			res := commands.InitCmd{}.Exec(ctx, "init", []string{"--name", name, "--email", email}, tempDEnv, configCliContext{tempDEnv})
 			if res != 0 {
 				return nil, fmt.Errorf("failed to initialize doltgres database")
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -211,7 +211,7 @@ func runServer(ctx context.Context, args []string, dEnv *env.DoltEnv) (*svcs.Con
 
 			// We'll use a temporary environment to instantiate the subdirectory
 			tempDEnv := env.Load(ctx, env.GetCurrentUserHomeDir, subdirectoryFS, dEnv.UrlStr(), Version)
-			// username and user email is needed for creating a database.
+			// username and user email is needed to create a new database.
 			name := dEnv.Config.GetStringOrDefault(config.UserNameKey, DefUserName)
 			email := dEnv.Config.GetStringOrDefault(config.UserEmailKey, DefUserEmail)
 			res := commands.InitCmd{}.Exec(ctx, "init", []string{"--name", name, "--email", email}, tempDEnv, configCliContext{tempDEnv})

--- a/server/server.go
+++ b/server/server.go
@@ -212,8 +212,8 @@ func runServer(ctx context.Context, args []string, dEnv *env.DoltEnv) (*svcs.Con
 			// We'll use a temporary environment to instantiate the subdirectory
 			tempDEnv := env.Load(ctx, env.GetCurrentUserHomeDir, subdirectoryFS, dEnv.UrlStr(), Version)
 			// username and user email is needed to create a new database.
-			name := dEnv.Config.GetStringOrDefault(config.UserNameKey, DefUserName)
-			email := dEnv.Config.GetStringOrDefault(config.UserEmailKey, DefUserEmail)
+			name := tempDEnv.Config.GetStringOrDefault(config.UserNameKey, DefUserName)
+			email := tempDEnv.Config.GetStringOrDefault(config.UserEmailKey, DefUserEmail)
 			res := commands.InitCmd{}.Exec(ctx, "init", []string{"--name", name, "--email", email}, tempDEnv, configCliContext{tempDEnv})
 			if res != 0 {
 				return nil, fmt.Errorf("failed to initialize doltgres database")

--- a/server/server.go
+++ b/server/server.go
@@ -212,9 +212,9 @@ func runServer(ctx context.Context, args []string, dEnv *env.DoltEnv) (*svcs.Con
 			// We'll use a temporary environment to instantiate the subdirectory
 			tempDEnv := env.Load(ctx, env.GetCurrentUserHomeDir, subdirectoryFS, dEnv.UrlStr(), Version)
 			// username and user email is needed to create a new database.
-			name := dEnv.Config.GetStringOrDefault(config.UserNameKey, DefUserName)
-			email := dEnv.Config.GetStringOrDefault(config.UserEmailKey, DefUserEmail)
-			res := commands.InitCmd{}.Exec(ctx, "init", []string{"--name", name, "--email", email}, tempDEnv, configCliContext{tempDEnv})
+			//name := dEnv.Config.GetStringOrDefault(config.UserNameKey, DefUserName)
+			//email := dEnv.Config.GetStringOrDefault(config.UserEmailKey, DefUserEmail)
+			res := commands.InitCmd{}.Exec(ctx, "init", []string{}, tempDEnv, configCliContext{tempDEnv})
 			if res != 0 {
 				return nil, fmt.Errorf("failed to initialize doltgres database")
 			}

--- a/testing/bats/doltgres.bats
+++ b/testing/bats/doltgres.bats
@@ -3,15 +3,9 @@ load $BATS_TEST_DIRNAME/setup/common.bash
 
 setup() {
     setup_common
-    # dolt config was being used to create a new doltgres database
-    # so unset user name and email for testing
-    dolt config --global --unset user.name
-    dolt config --global --unset user.email
 }
 
 teardown() {
-    dolt config --global --add user.name "Bats Tests"
-    dolt config --global --add user.email "bats@email.fake"
     teardown_common
 }
 

--- a/testing/bats/doltgres.bats
+++ b/testing/bats/doltgres.bats
@@ -3,56 +3,48 @@ load $BATS_TEST_DIRNAME/setup/common.bash
 
 setup() {
     setup_common
+    # dolt config was being used to create a new doltgres database
+    # so unset user name and email for testing
+    dolt config --global --unset user.name
+    dolt config --global --unset user.email
 }
 
 teardown() {
+    dolt config --global --add user.name "Bats Tests"
+    dolt config --global --add user.email "bats@email.fake"
     teardown_common
 }
 
-@test 'doltgres: no args' {
-    export DOLTGRES_DATA_DIR=
-    start_sql_server_with_args "--host 0.0.0.0"
-    run query_server -c "\l"
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "information_schema" ]] || false
-    [[ "$output" =~ "doltgres" ]] || false
-    [[ "$output" =~ "postgres" ]] || false
-
+@test 'doltgres: DOLTGRES_DATA_DIR set to current dir' {
     [ ! -d "doltgres" ]
-}
 
-@test 'doltgres: with --data-dir' {
-    export DOLTGRES_DATA_DIR=
-    start_sql_server_with_args "--host 0.0.0.0" "--data-dir=."
-    run query_server -c "\l"
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "information_schema" ]] || false
-    [[ "$output" =~ "doltgres" ]] || false
+    export SQL_USER="doltgres"
+    start_sql_server_with_args "--host 0.0.0.0" "--user doltgres" > log.txt 2>&1
 
+    run cat log.txt
+    [[ ! "$output" =~ "Author identity unknown" ]] || false
     [ -d "doltgres" ]
-}
 
-@test 'doltgres: with DOLTGRES_DATA_DIR' {
-    export DOLTGRES_DATA_DIR="$(pwd)/test"
-    start_sql_server_with_args "--host 0.0.0.0"
-    run query_server -c "\l"
-    [ "$status" -eq 0 ]
-    [[ "$output" =~ "information_schema" ]] || false
-    [[ "$output" =~ "doltgres" ]] || false
-
-    [ -d "test/doltgres" ]
-    [ ! -d "doltgres" ]
-}
-
-@test 'doltgres: with both --data-dir and DOLTGRES_DATA_DIR' {
-    export DOLTGRES_DATA_DIR="$(pwd)/test1"
-    start_sql_server_with_args "--host 0.0.0.0" "--data-dir=./test2"
     run query_server -c "\l"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "information_schema" ]] || false
     [[ "$output" =~ "doltgres" ]] || false
     [[ "$output" =~ "postgres" ]] || false
+}
 
-    [ -d "test2/doltgres" ]
-    [ ! -d "test1/doltgres" ]
+@test 'doltgres: setting both --data-dir and DOLTGRES_DATA_DIR should use --data-dir value' {
+    [ ! -d "doltgres" ]
+
+    export SQL_USER="doltgres"
+    start_sql_server_with_args "--host 0.0.0.0" "--user doltgres" "--data-dir=./test" > log.txt 2>&1
+
+    run cat log.txt
+    [[ ! "$output" =~ "Author identity unknown" ]] || false
+    [ ! -d "doltgres" ]
+    [ -d "test/doltgres" ]
+
+    run query_server -c "\l"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "information_schema" ]] || false
+    [[ "$output" =~ "doltgres" ]] || false
 }

--- a/testing/bats/doltgres.bats
+++ b/testing/bats/doltgres.bats
@@ -10,6 +10,7 @@ teardown() {
 }
 
 @test 'doltgres: no args' {
+    export DOLTGRES_DATA_DIR=
     start_sql_server_with_args "--host 0.0.0.0"
     run query_server -c "\l"
     [ "$status" -eq 0 ]
@@ -21,31 +22,30 @@ teardown() {
 }
 
 @test 'doltgres: with --data-dir' {
+    export DOLTGRES_DATA_DIR=
     start_sql_server_with_args "--host 0.0.0.0" "--data-dir=."
     run query_server -c "\l"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "information_schema" ]] || false
     [[ "$output" =~ "doltgres" ]] || false
-    [[ "$output" =~ "postgres" ]] || false
 
     [ -d "doltgres" ]
 }
 
 @test 'doltgres: with DOLTGRES_DATA_DIR' {
-    DOLTGRES_DATA_DIR="$BATS_TEST_DIRNAME/test"
+    export DOLTGRES_DATA_DIR="$(pwd)/test"
     start_sql_server_with_args "--host 0.0.0.0"
     run query_server -c "\l"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "information_schema" ]] || false
     [[ "$output" =~ "doltgres" ]] || false
-    [[ "$output" =~ "postgres" ]] || false
 
     [ -d "test/doltgres" ]
     [ ! -d "doltgres" ]
 }
 
 @test 'doltgres: with both --data-dir and DOLTGRES_DATA_DIR' {
-    DOLTGRES_DATA_DIR="$BATS_TEST_DIRNAME/test1"
+    export DOLTGRES_DATA_DIR="$(pwd)/test1"
     start_sql_server_with_args "--host 0.0.0.0" "--data-dir=./test2"
     run query_server -c "\l"
     [ "$status" -eq 0 ]

--- a/testing/bats/doltgres.bats
+++ b/testing/bats/doltgres.bats
@@ -3,9 +3,12 @@ load $BATS_TEST_DIRNAME/setup/common.bash
 
 setup() {
     setup_common
+    stash_current_dolt_user
+    unset_dolt_user
 }
 
 teardown() {
+    restore_stashed_dolt_user
     teardown_common
 }
 

--- a/testing/bats/doltgres.bats
+++ b/testing/bats/doltgres.bats
@@ -21,7 +21,7 @@ teardown() {
 }
 
 @test 'doltgres: with --data-dir' {
-    start_sql_server_with_args "--host 0.0.0.0 --data-dir=."
+    start_sql_server_with_args "--host 0.0.0.0" "--data-dir=."
     run query_server -c "\l"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "information_schema" ]] || false
@@ -46,7 +46,7 @@ teardown() {
 
 @test 'doltgres: with both --data-dir and DOLTGRES_DATA_DIR' {
     DOLTGRES_DATA_DIR="$BATS_TEST_DIRNAME/test1"
-    start_sql_server_with_args "--host 0.0.0.0 --data-dir=./test2"
+    start_sql_server_with_args "--host 0.0.0.0" "--data-dir=./test2"
     run query_server -c "\l"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "information_schema" ]] || false

--- a/testing/bats/doltgres.bats
+++ b/testing/bats/doltgres.bats
@@ -3,6 +3,7 @@ load $BATS_TEST_DIRNAME/setup/common.bash
 
 setup() {
     setup_common
+    # tests are run without setting doltgres config user.name and user.email
     stash_current_dolt_user
     unset_dolt_user
 }
@@ -14,7 +15,7 @@ teardown() {
 
 @test 'doltgres: DOLTGRES_DATA_DIR set to current dir' {
     [ ! -d "doltgres" ]
-
+    export DOLTGRES_DATA_DIR="$(pwd)"
     export SQL_USER="doltgres"
     start_sql_server_with_args "--host 0.0.0.0" "--user doltgres" > log.txt 2>&1
 
@@ -32,6 +33,7 @@ teardown() {
 @test 'doltgres: setting both --data-dir and DOLTGRES_DATA_DIR should use --data-dir value' {
     [ ! -d "doltgres" ]
 
+    export DOLTGRES_DATA_DIR="$(pwd)"
     export SQL_USER="doltgres"
     start_sql_server_with_args "--host 0.0.0.0" "--user doltgres" "--data-dir=./test" > log.txt 2>&1
 

--- a/testing/bats/doltgres.bats
+++ b/testing/bats/doltgres.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/setup/common.bash
+
+setup() {
+    setup_common
+}
+
+teardown() {
+    teardown_common
+}
+
+@test 'doltgres: no args' {
+    start_sql_server_with_args "--host 0.0.0.0"
+    run query_server -c "\l"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "information_schema" ]] || false
+    [[ "$output" =~ "doltgres" ]] || false
+    [[ "$output" =~ "postgres" ]] || false
+
+    [ ! -d "doltgres" ]
+}
+
+@test 'doltgres: with --data-dir' {
+    start_sql_server_with_args "--host 0.0.0.0 --data-dir=."
+    run query_server -c "\l"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "information_schema" ]] || false
+    [[ "$output" =~ "doltgres" ]] || false
+    [[ "$output" =~ "postgres" ]] || false
+
+    [ -d "doltgres" ]
+}
+
+@test 'doltgres: with DOLTGRES_DATA_DIR' {
+    DOLTGRES_DATA_DIR="$BATS_TEST_DIRNAME/test"
+    start_sql_server_with_args "--host 0.0.0.0"
+    run query_server -c "\l"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "information_schema" ]] || false
+    [[ "$output" =~ "doltgres" ]] || false
+    [[ "$output" =~ "postgres" ]] || false
+
+    [ -d "test/doltgres" ]
+    [ ! -d "doltgres" ]
+}
+
+@test 'doltgres: with both --data-dir and DOLTGRES_DATA_DIR' {
+    DOLTGRES_DATA_DIR="$BATS_TEST_DIRNAME/test1"
+    start_sql_server_with_args "--host 0.0.0.0 --data-dir=./test2"
+    run query_server -c "\l"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "information_schema" ]] || false
+    [[ "$output" =~ "doltgres" ]] || false
+    [[ "$output" =~ "postgres" ]] || false
+
+    [ -d "test2/doltgres" ]
+    [ ! -d "test1/doltgres" ]
+}

--- a/testing/bats/psql-commands.bats
+++ b/testing/bats/psql-commands.bats
@@ -3,6 +3,7 @@ load $BATS_TEST_DIRNAME/setup/common.bash
 
 setup() {
     setup_common
+    start_sql_server
     query_server <<SQL
     CREATE TABLE test1 (pk BIGINT PRIMARY KEY, v1 SMALLINT);
     CREATE TABLE test2 (pk BIGINT PRIMARY KEY, v1 INTEGER, v2 SMALLINT);

--- a/testing/bats/setup/common.bash
+++ b/testing/bats/setup/common.bash
@@ -26,8 +26,8 @@ set_dolt_user() {
 }
 
 unset_dolt_user() {
-  doltgresql config --global --unset user.name
-  doltgresql config --global --unset user.email
+    doltgresql config --global --unset user.name
+    doltgresql config --global --unset user.email
 }
 
 current_dolt_user_name() {

--- a/testing/bats/setup/common.bash
+++ b/testing/bats/setup/common.bash
@@ -66,8 +66,6 @@ setup_common() {
     if [ -z "$DOLT_TEST_RETRIES" ]; then
         export BATS_TEST_RETRIES="$DOLT_TEST_RETRIES"
     fi
-
-    start_sql_server
 }
 
 teardown_common() {

--- a/testing/bats/setup/query-server-common.bash
+++ b/testing/bats/setup/query-server-common.bash
@@ -48,7 +48,6 @@ start_sql_server() {
 start_sql_server_with_args() {
     DEFAULT_DB=""
     nativevar DEFAULT_DB "$DEFAULT_DB" /w
-    nativevar DOLTGRES_DATA_DIR "$(pwd)" /p
     PORT=$( definePORT )
     doltgresql "$@" --port=$PORT &
     SERVER_PID=$!

--- a/testing/bats/setup/query-server-common.bash
+++ b/testing/bats/setup/query-server-common.bash
@@ -43,7 +43,7 @@ start_sql_server() {
 }
 
 # like start_sql_server, but the second argument is a string with all
-# arguments to dolt-sql-server (excluding --port, which is defined in
+# arguments to doltgres (excluding --port, which is defined in
 # this func)
 start_sql_server_with_args() {
     DEFAULT_DB=""


### PR DESCRIPTION
Currently, doltgres uses dolt init when starting doltgres server with data dir set to empty directory. When there is no dolt or doltgres config `user.name` and `user.email`, it fails to create a new database with error message from `dolt init`, which suggests to set `dolt` user info. Current fix will not return error; instead, it will use user name, `postgres` and email, `postgres@somewhere.com` if it's not set.