### PR TITLE
INT4 ORDER BY Workaround

### DIFF
--- a/postgres/parser/parser/parse.go
+++ b/postgres/parser/parser/parse.go
@@ -101,11 +101,8 @@ type Parser struct {
 	stmtBuf    [1]Statement
 }
 
-// INT8 is the historical interpretation of INT. This should be left
-// alone in the future, since there are many sql fragments stored
-// in various descriptors.  Any user input that was created after
-// INT := INT4 will simply use INT4 in any resulting code.
-var defaultNakedIntType = types.Int
+// This is the default integer type when no integer type is explicitly specified.
+var defaultNakedIntType = types.Int4
 
 // Parse parses the sql and returns a list of statements.
 func (p *Parser) Parse(sql string) (Statements, error) {

--- a/postgres/parser/parser/sql.y
+++ b/postgres/parser/parser/sql.y
@@ -10411,11 +10411,11 @@ opt_numeric_modifiers:
 numeric:
   INT
   {
-    $$.val = sqllex.(*lexer).nakedIntType
+    $$.val = types.Int4
   }
 | INTEGER
   {
-    $$.val = sqllex.(*lexer).nakedIntType
+    $$.val = types.Int4
   }
 | SMALLINT
   {

--- a/testing/go/types_test.go
+++ b/testing/go/types_test.go
@@ -824,7 +824,6 @@ func TestSameTypes(t *testing.T) {
 				},
 				{
 					Query: "SELECT * FROM test2 ORDER BY 1;",
-					Skip:  true, // TODO: why does this fail now, and why does it pass if we change v2 to INT8?
 					Expected: []sql.Row{
 						{1, 2, 3},
 						{4, 5, 6},
@@ -923,6 +922,14 @@ func TestSameTypes(t *testing.T) {
 				`INSERT INTO test VALUES (1, '{"key1": {"key": "value"}}'), (2, '{"key1": "value1", "key2": "value2"}'), (3, '{"key1": {"key": [2,3]}}');`,
 			},
 			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT * FROM test ORDER BY 1;",
+					Expected: []sql.Row{
+						{1, `{"key1":{"key":"value"}}`},
+						{2, `{"key1":"value1","key2":"value2"}`},
+						{3, `{"key1":{"key":[2,3]}}`},
+					},
+				},
 				{
 					Query: "SELECT * FROM test ORDER BY v1;",
 					Expected: []sql.Row{


### PR DESCRIPTION
There are two bugs here. The first is that `INTEGER` and `INT` were parsing as `INT8`. The second is that `ORDER BY 1` was failing for tables that had an `INT4` but not an `INT8`. For the first, our parser simply used the wrong bit width, which is fairly straightforward.

The second bug was _far_ trickier to track down. Essentially, `ORDER BY 1` has been broken, however some combinations of tables and rows would result in the correct order _on accident_, and that's what led to the confusion on how the second bug worked. It's even more coincidental that the literal `1` in `ORDER BY 1` happened to correspond to the first value in the affected tests, further masking the issue.

Fundamentally, the issue has not been **fixed**, and this submits a workaround. The root of the issue is that GMS expects the `vitess.SQLVal` type, and does not handle our case (Postgres literals). As a workaround, we're converting our Postgres literals to `vitess.SQLVal` specifically for this exact case. The real fix would be for GMS to defer to Doltgres when encountering types that it cannot hardcode (or to un-hardcode types, which seems relatively bad for GMS just to work better with Doltgres). We do not have a standard way of implementing this differing interface yet, so we'll punt on that and just get this workaround in.