### PR TITLE
All Array Types

### DIFF
--- a/postgres/parser/sem/tree/expr.go
+++ b/postgres/parser/sem/tree/expr.go
@@ -141,6 +141,10 @@ type typeAnnotation struct {
 	typ *types.T
 }
 
+func (ta typeAnnotation) HasResolvedType() bool {
+	return ta.typ != nil
+}
+
 func (ta typeAnnotation) ResolvedType() *types.T {
 	ta.assertTyped()
 	return ta.typ

--- a/server/ast/expr.go
+++ b/server/ast/expr.go
@@ -484,7 +484,7 @@ func nodeExpr(node tree.Expr) (vitess.Expr, error) {
 				Expression: intLiteral,
 			}, err
 		case constant.Float:
-			numericLiteral, err := pgexprs.NewFloatLiteral(node.FormattedString())
+			numericLiteral, err := pgexprs.NewNumericLiteral(node.FormattedString())
 			return vitess.InjectedExpr{
 				Expression: numericLiteral,
 			}, err

--- a/server/expression/array.go
+++ b/server/expression/array.go
@@ -19,64 +19,69 @@ import (
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/vitess/go/vt/proto/query"
 	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
 
+	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
 // Array represents an ARRAY[...] expression.
 type Array struct {
-	sqlChildren    []sql.Expression
-	vitessChildren vitess.Exprs
-	vitessIndexes  []int
-	coercedType    sql.Type
+	children    []sql.Expression
+	coercedType pgtypes.DoltgresArrayType
 }
 
 var _ vitess.InjectableExpression = (*Array)(nil)
 var _ sql.Expression = (*Array)(nil)
 
 // NewArray returns a new *Array.
-func NewArray(expressions []sql.Expression, unresolvedChildren vitess.Exprs, unresolvedIndexes []int, coercedType sql.Type) (*Array, error) {
-	if len(unresolvedChildren) != len(unresolvedIndexes) {
-		return nil, fmt.Errorf("ARRAY has an invalid number of unresolved children (%d) and indexes (%d)",
-			len(unresolvedChildren), len(unresolvedIndexes))
-	}
-	for _, index := range unresolvedIndexes {
-		if index >= len(expressions) || index < 0 {
-			return nil, fmt.Errorf("ARRAY unresolved index (%d) is out of bounds (expression count: %d)",
-				index, len(expressions))
-		}
-		if expressions[index] != nil {
-			return nil, fmt.Errorf("ARRAY unresolved index (%d) points to a resolved expression", index)
-		}
+func NewArray(coercedType sql.Type) (*Array, error) {
+	var arrayCoercedType pgtypes.DoltgresArrayType
+	if dat, ok := coercedType.(pgtypes.DoltgresArrayType); ok {
+		arrayCoercedType = dat
+	} else if coercedType != nil {
+		return nil, fmt.Errorf("cannot cast array to %s", coercedType.String())
 	}
 	return &Array{
-		sqlChildren:    expressions,
-		vitessChildren: unresolvedChildren,
-		vitessIndexes:  unresolvedIndexes,
-		coercedType:    coercedType,
+		children:    nil,
+		coercedType: arrayCoercedType,
 	}, nil
 }
 
 // Children implements the sql.Expression interface.
 func (array *Array) Children() []sql.Expression {
-	return array.sqlChildren
+	return array.children
 }
 
 // Eval implements the sql.Expression interface.
 func (array *Array) Eval(ctx *sql.Context, row sql.Row) (any, error) {
-	// TODO: make this an actual implementation instead of the mock boolean implementation
-	values := make([]bool, len(array.sqlChildren))
-	for i, expr := range array.sqlChildren {
+	resultArrayType, requiresCasting := array.typeRequiresCasting()
+	if resultArrayType.Equals(pgtypes.AnyArray) {
+		// TODO: error should look like "ARRAY types XXXX and YYYY cannot be matched", need to display conflicting types
+		return nil, fmt.Errorf("ARRAY types cannot be matched")
+	}
+	values := make([]any, len(array.children))
+	for i, expr := range array.children {
 		val, err := expr.Eval(ctx, row)
 		if err != nil {
 			return nil, err
 		}
-		boolVal, ok := val.(bool)
-		if !ok {
-			return nil, fmt.Errorf("only boolean values are supported within an ARRAY for now")
+		values[i] = val
+	}
+	// The ARRAY expression may require automatic casting, so this handles that
+	if requiresCasting {
+		baseResultTypeID := resultArrayType.BaseType().BaseID()
+		var err error
+		for i := range values {
+			if values[i] == nil {
+				continue
+			}
+			values[i], err = array.handleEvaluationCast(ctx, baseResultTypeID, array.children[i].Type(), &values[i])
+			if err != nil {
+				return nil, err
+			}
 		}
-		values[i] = boolVal
 	}
 	return values, nil
 }
@@ -89,7 +94,7 @@ func (array *Array) IsNullable() bool {
 
 // Resolved implements the sql.Expression interface.
 func (array *Array) Resolved() bool {
-	for _, child := range array.sqlChildren {
+	for _, child := range array.children {
 		if child == nil || !child.Resolved() {
 			return false
 		}
@@ -101,7 +106,7 @@ func (array *Array) Resolved() bool {
 func (array *Array) String() string {
 	sb := strings.Builder{}
 	sb.WriteString("ARRAY[")
-	for i, child := range array.sqlChildren {
+	for i, child := range array.children {
 		if i > 0 {
 			sb.WriteString(", ")
 		}
@@ -117,47 +122,226 @@ func (array *Array) String() string {
 
 // Type implements the sql.Expression interface.
 func (array *Array) Type() sql.Type {
-	if array.coercedType != nil {
-		return array.coercedType
-	}
-	// TODO: how do we handle multiple children with different types?
-	for _, child := range array.sqlChildren {
-		if child != nil {
-			childType := child.Type()
-			if _, ok := childType.(pgtypes.BoolType); ok {
-				return pgtypes.BoolArray
-			}
-		}
-	}
-	// TODO: remove mock boolean array demonstration
-	return pgtypes.BoolArray
+	// We'll ignore whether we need casting here, as that's only relevant while evaluating.
+	t, _ := array.typeRequiresCasting()
+	return t
 }
 
 // WithChildren implements the sql.Expression interface.
 func (array *Array) WithChildren(children ...sql.Expression) (sql.Expression, error) {
 	return &Array{
-		sqlChildren: children,
+		children:    children,
 		coercedType: array.coercedType,
 	}, nil
 }
 
 // WithResolvedChildren implements the vitess.InjectableExpression interface.
 func (array *Array) WithResolvedChildren(children []any) (any, error) {
-	if len(children) != len(array.vitessIndexes) {
-		return nil, fmt.Errorf("invalid vitess child count, expected `%d` but got `%d`",
-			len(array.vitessIndexes), len(children))
-	}
-	newExpressions := make([]sql.Expression, len(array.sqlChildren))
-	copy(newExpressions, array.sqlChildren)
+	newExpressions := make([]sql.Expression, len(children))
 	for i, resolvedChild := range children {
 		resolvedExpression, ok := resolvedChild.(sql.Expression)
 		if !ok {
 			return nil, fmt.Errorf("expected vitess child to be an expression but has type `%T`", resolvedChild)
 		}
-		newExpressions[array.vitessIndexes[i]] = resolvedExpression
+		newExpressions[i] = resolvedExpression
 	}
 	return &Array{
-		sqlChildren: newExpressions,
+		children:    newExpressions,
 		coercedType: array.coercedType,
 	}, nil
+}
+
+// castable returns the largest type if both types are automatically castable to each other. Returns false if neither
+// type allows for automatic casting.
+func (array *Array) castable(t1, t2 pgtypes.DoltgresType) (pgtypes.DoltgresType, bool) {
+	t1BaseID := t1.BaseID()
+	t2BaseID := t2.BaseID()
+	// We set these to different negative numbers so that the default matching behavior will fail, since it checks for
+	// the equivalence of these two numbers. This is in an array so that we can simply loop over the logic.
+	generalTyping := [2]int16{-1, -2}
+	// Check for castable groups specific to the ARRAY expression. We'll assign integers to broadly represent each group.
+	for i, baseID := range []pgtypes.DoltgresTypeBaseID{t1BaseID, t2BaseID} {
+		switch baseID {
+		// TODO: fill out the remaining convertable groups
+		case pgtypes.Float32.BaseID(), pgtypes.Float64.BaseID(), pgtypes.Int16.BaseID(), pgtypes.Int32.BaseID(),
+			pgtypes.Int64.BaseID(), pgtypes.Numeric.BaseID():
+			generalTyping[i] = 1
+		}
+	}
+	// If the types are not in the same group, then we'll return false
+	if generalTyping[0] != generalTyping[1] {
+		return nil, false
+	}
+	// Check for each cast group
+	if generalTyping[0] == 1 {
+		if array.numberCastGroupPriority(t1BaseID) < array.numberCastGroupPriority(t2BaseID) {
+			return t1, true
+		} else {
+			return t2, true
+		}
+	}
+	return nil, false
+}
+
+// handleEvaluationCast handles the casts performed during evaluation. This is only called if casting is required.
+func (array *Array) handleEvaluationCast(ctx *sql.Context, baseResultTypeID pgtypes.DoltgresTypeBaseID, paramSqlType sql.Type, val *any) (any, error) {
+	var paramType pgtypes.DoltgresType
+	if doltgresType, ok := paramSqlType.(pgtypes.DoltgresType); ok {
+		paramType = doltgresType
+	} else {
+		// TODO: we need to remove GMS types from all of our expressions so that we can remove this. For now, we have to
+		// handle all possible GMS types and make any conversions for types that are not supported by Postgres
+		switch paramType.Type() {
+		case query.Type_INT8:
+			*val = int16((*val).(int8))
+			paramType = pgtypes.Int16
+		case query.Type_INT16:
+			paramType = pgtypes.Int16
+		case query.Type_INT24, query.Type_INT32:
+			paramType = pgtypes.Int32
+		case query.Type_INT64:
+			paramType = pgtypes.Int64
+		case query.Type_UINT8:
+			*val = int64((*val).(uint8))
+			paramType = pgtypes.Int64
+		case query.Type_UINT16:
+			*val = int64((*val).(uint16))
+			paramType = pgtypes.Int64
+		case query.Type_UINT24, query.Type_UINT32:
+			*val = int64((*val).(uint32))
+			paramType = pgtypes.Int64
+		case query.Type_UINT64:
+			*val = int64((*val).(uint64))
+			paramType = pgtypes.Int64
+		case query.Type_YEAR:
+			paramType = pgtypes.Int16
+		case query.Type_FLOAT32:
+			paramType = pgtypes.Float32
+		case query.Type_FLOAT64:
+			paramType = pgtypes.Float64
+		case query.Type_DECIMAL:
+			paramType = pgtypes.Numeric
+		case query.Type_DATE, query.Type_DATETIME, query.Type_TIMESTAMP:
+			return nil, fmt.Errorf("need to add DoltgresType equivalents to DATETIME")
+		case query.Type_CHAR, query.Type_VARCHAR, query.Type_TEXT:
+			paramType = pgtypes.VarCharMax
+		case query.Type_ENUM:
+			paramType = pgtypes.Int16
+		case query.Type_SET:
+			paramType = pgtypes.Int64
+		case query.Type_NULL_TYPE:
+			paramType = pgtypes.Null
+		default:
+			return nil, fmt.Errorf("encountered an unknown GMS type")
+		}
+	}
+	castFunc := framework.GetCast(paramType.BaseID(), baseResultTypeID)
+	if castFunc == nil {
+		// This should never happen, but we'll check here just to be safe
+		resultType, _ := array.typeRequiresCasting()
+		return nil, fmt.Errorf("cannot cast type %s to %s", resultType.BaseType().String(), paramType.String())
+	}
+	return castFunc(framework.Context{Context: ctx}, *val)
+}
+
+// isNullType returns whether the given type is a NULL type.
+func (array *Array) isNullType(t sql.Type) bool {
+	return t.Type() == query.Type_NULL_TYPE
+}
+
+// numberCastGroupPriority returns the priority for the given type belonging to the number group. The lower the value,
+// the higher the priority.
+func (array *Array) numberCastGroupPriority(t pgtypes.DoltgresTypeBaseID) int {
+	switch t {
+	case pgtypes.Float64.BaseID():
+		return 1
+	case pgtypes.Float32.BaseID():
+		return 2
+	case pgtypes.Numeric.BaseID():
+		return 3
+	case pgtypes.Int64.BaseID():
+		return 4
+	case pgtypes.Int32.BaseID():
+		return 5
+	case pgtypes.Int16.BaseID():
+		return 6
+	default:
+		return 8
+	}
+}
+
+// typeRequiresCasting returns the evaluated type for this expression, along with whether the evaluation will require
+// casting. If all of the array's contents have the same type, then no casting will be necessary. Returns the "anyarray"
+// type if the type combination is invalid.
+func (array *Array) typeRequiresCasting() (pgtypes.DoltgresArrayType, bool) {
+	// TODO: figure out the conditions that result in this being set
+	if array.coercedType != nil {
+		return array.coercedType, true
+	}
+	var lastChildType pgtypes.DoltgresType
+	requiresCasting := false
+	for _, child := range array.children {
+		if child != nil {
+			gmsChildType := child.Type()
+			// We ignore NULL values here since they do not affect the array's type
+			if array.isNullType(gmsChildType) {
+				continue
+			}
+			// Ensure that the type is a DoltgresType
+			childType, ok := gmsChildType.(pgtypes.DoltgresType)
+			if !ok {
+				// TODO: we need to remove GMS types from all of our expressions so that we can remove this.
+				// It is worth noting that this switch block is different than the one found above
+				switch gmsChildType.Type() {
+				case query.Type_INT8, query.Type_INT16:
+					childType = pgtypes.Int16
+				case query.Type_INT24, query.Type_INT32:
+					childType = pgtypes.Int32
+				case query.Type_INT64:
+					childType = pgtypes.Int64
+				case query.Type_UINT8, query.Type_UINT16, query.Type_UINT24, query.Type_UINT32, query.Type_UINT64:
+					childType = pgtypes.Int64
+				case query.Type_YEAR:
+					childType = pgtypes.Int16
+				case query.Type_FLOAT32:
+					childType = pgtypes.Float32
+				case query.Type_FLOAT64:
+					childType = pgtypes.Float64
+				case query.Type_DECIMAL:
+					childType = pgtypes.Numeric
+				case query.Type_DATE, query.Type_DATETIME, query.Type_TIMESTAMP:
+					// TODO: add the Doltgres equivalents for these
+					return pgtypes.AnyArray, false
+				case query.Type_CHAR, query.Type_VARCHAR, query.Type_TEXT:
+					childType = pgtypes.VarCharMax
+				case query.Type_ENUM:
+					childType = pgtypes.Int16
+				case query.Type_SET:
+					childType = pgtypes.Int64
+				case query.Type_NULL_TYPE:
+					childType = pgtypes.Null
+				default:
+					return pgtypes.AnyArray, false
+				}
+			}
+			// Ensure that all of the types align to a common type
+			if lastChildType == nil {
+				lastChildType = childType
+			} else if !lastChildType.Equals(childType) {
+				if castableType, ok := array.castable(lastChildType, childType); ok {
+					lastChildType = castableType
+					requiresCasting = true
+				} else {
+					lastChildType = nil
+					break
+				}
+			}
+		}
+	}
+	// If this is not nil, then all types either match this type, or are automatically castable to this type
+	if lastChildType != nil {
+		return lastChildType.ToArrayType(), requiresCasting
+	}
+	// We use "anyarray" as the indeterminate/invalid type
+	return pgtypes.AnyArray, false
 }

--- a/server/expression/literal.go
+++ b/server/expression/literal.go
@@ -44,8 +44,8 @@ func NewBoolLiteral(val bool) *Literal {
 	}
 }
 
-// NewFloatLiteral returns a new *Literal containing a NUMERIC value.
-func NewFloatLiteral(numericValue string) (*Literal, error) {
+// NewNumericLiteral returns a new *Literal containing a NUMERIC value.
+func NewNumericLiteral(numericValue string) (*Literal, error) {
 	d, err := decimal.NewFromString(numericValue)
 	return &Literal{
 		value: d,

--- a/server/types/any_array.go
+++ b/server/types/any_array.go
@@ -1,0 +1,152 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/dolthub/vitess/go/sqltypes"
+	"github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/lib/pq/oid"
+)
+
+// AnyArray is an array that may contain elements of any type.
+var AnyArray = AnyArrayType{}
+
+// AnyArrayType is the extended type implementation of the PostgreSQL anyarray.
+type AnyArrayType struct{}
+
+var _ DoltgresType = AnyArrayType{}
+var _ DoltgresArrayType = AnyArrayType{}
+
+// BaseID implements the DoltgresType interface.
+func (aa AnyArrayType) BaseID() DoltgresTypeBaseID {
+	return DoltgresTypeBaseID_AnyArray
+}
+
+// BaseType implements the DoltgresArrayType interface.
+func (aa AnyArrayType) BaseType() DoltgresType {
+	return Unknown
+}
+
+// CollationCoercibility implements the DoltgresType interface.
+func (aa AnyArrayType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
+// Compare implements the DoltgresType interface.
+func (aa AnyArrayType) Compare(v1 any, v2 any) (int, error) {
+	return 0, fmt.Errorf("%s cannot compare values", aa.String())
+}
+
+// Convert implements the DoltgresType interface.
+func (aa AnyArrayType) Convert(val any) (any, sql.ConvertInRange, error) {
+	return nil, sql.OutOfRange, fmt.Errorf("%s cannot convert values", aa.String())
+}
+
+// Equals implements the DoltgresType interface.
+func (aa AnyArrayType) Equals(otherType sql.Type) bool {
+	_, ok := otherType.(AnyArrayType)
+	return ok
+}
+
+// FormatSerializedValue implements the DoltgresType interface.
+func (aa AnyArrayType) FormatSerializedValue(val []byte) (string, error) {
+	return "", fmt.Errorf("%s cannot format serialized values", aa.String())
+}
+
+// FormatValue implements the DoltgresType interface.
+func (aa AnyArrayType) FormatValue(val any) (string, error) {
+	return "", fmt.Errorf("%s cannot format values", aa.String())
+}
+
+// MaxSerializedWidth implements the DoltgresType interface.
+func (aa AnyArrayType) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
+	return types.ExtendedTypeSerializedWidth_Unbounded
+}
+
+// MaxTextResponseByteLength implements the DoltgresType interface.
+func (aa AnyArrayType) MaxTextResponseByteLength(ctx *sql.Context) uint32 {
+	return math.MaxUint32
+}
+
+// OID implements the DoltgresType interface.
+func (aa AnyArrayType) OID() uint32 {
+	return uint32(oid.T_anyarray)
+}
+
+// Promote implements the DoltgresType interface.
+func (aa AnyArrayType) Promote() sql.Type {
+	return aa
+}
+
+// SerializedCompare implements the DoltgresType interface.
+func (aa AnyArrayType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
+	return 0, fmt.Errorf("%s cannot compare serialized values", aa.String())
+}
+
+// SerializeType implements the DoltgresType interface.
+func (aa AnyArrayType) SerializeType() ([]byte, error) {
+	return nil, fmt.Errorf("%s cannot be serialized", aa.String())
+}
+
+// SQL implements the DoltgresType interface.
+func (aa AnyArrayType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
+	return sqltypes.Value{}, fmt.Errorf("%s cannot output values in the wire format", aa.String())
+}
+
+// String implements the DoltgresType interface.
+func (aa AnyArrayType) String() string {
+	return "anyarray"
+}
+
+// ToArrayType implements the DoltgresType interface.
+func (aa AnyArrayType) ToArrayType() DoltgresArrayType {
+	return aa
+}
+
+// Type implements the DoltgresType interface.
+func (aa AnyArrayType) Type() query.Type {
+	return sqltypes.Text
+}
+
+// ValueType implements the DoltgresType interface.
+func (aa AnyArrayType) ValueType() reflect.Type {
+	return reflect.TypeOf([]any{})
+}
+
+// Zero implements the DoltgresType interface.
+func (aa AnyArrayType) Zero() any {
+	return []any{}
+}
+
+// SerializeValue implements the DoltgresType interface.
+func (aa AnyArrayType) SerializeValue(val any) ([]byte, error) {
+	return nil, fmt.Errorf("%s cannot serialize values", aa.String())
+}
+
+// DeserializeValue implements the DoltgresType interface.
+func (aa AnyArrayType) DeserializeValue(val []byte) (any, error) {
+	return nil, fmt.Errorf("%s cannot deserialize values", aa.String())
+}
+
+// withInnerDeserialization implements the DoltgresArrayType interface.
+func (aa AnyArrayType) withInnerDeserialization(innerSerializedType []byte) (types.ExtendedType, error) {
+	return nil, fmt.Errorf("%s cannot be deserialized", aa.String())
+}

--- a/server/types/array.go
+++ b/server/types/array.go
@@ -286,6 +286,8 @@ func (ac arrayContainer) SerializeValue(valInterface any) ([]byte, error) {
 	arrayBuffer := bytes.Buffer{}
 	innerSerializedWidth := ac.innerType.MaxSerializedWidth()
 	// Write the total length to a buffer. We'll reuse this buffer for all uint-to-bytes operations.
+	// This does not seem to require the use of a pool, as it remains on the stack and does not escape to the heap.
+	// I am unsure of what changes could modify this behavior.
 	lengthBuffer := make([]byte, 8)
 	binary.BigEndian.PutUint64(lengthBuffer, uint64(len(vals)))
 	arrayBuffer.Write(lengthBuffer)

--- a/server/types/array.go
+++ b/server/types/array.go
@@ -1,0 +1,433 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/dolthub/vitess/go/sqltypes"
+	"github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/lib/pq/oid"
+
+	"github.com/dolthub/doltgresql/utils"
+)
+
+// arrayContainer is a type that wraps non-array types, giving them array functionality without requiring a bespoke
+// implementation.
+type arrayContainer struct {
+	innerType       DoltgresType
+	serializationID SerializationID
+	oid             oid.Oid
+	funcs           arrayContainerFunctions
+}
+
+// arrayContainerFunctions are overrides for the default array implementations of specific functions. If they are left
+// nil, then it uses the default implementation.
+type arrayContainerFunctions struct {
+	// SQL is similar to the function with the same name that is found on sql.Type. This just takes an additional
+	// arrayContainer parameter.
+	SQL func(ctx *sql.Context, ac arrayContainer, dest []byte, valInterface any) (sqltypes.Value, error)
+}
+
+var _ DoltgresType = arrayContainer{}
+var _ DoltgresArrayType = arrayContainer{}
+
+// createArrayType creates an array variant of the given type. Uses the default array implementations for all possible
+// overrides.
+func createArrayType(innerType DoltgresType, serializationID SerializationID, arrayOid oid.Oid) DoltgresArrayType {
+	return createArrayTypeWithFuncs(innerType, serializationID, arrayOid, arrayContainerFunctions{})
+}
+
+// createArrayTypeWithFuncs creates an array variant of the given type. Uses the provided function overrides if they're
+// not nil. If any are nil, then they use the default array implementations.
+func createArrayTypeWithFuncs(innerType DoltgresType, serializationID SerializationID, arrayOid oid.Oid, funcs arrayContainerFunctions) DoltgresArrayType {
+	if funcs.SQL == nil {
+		funcs.SQL = arrayContainerSQL
+	}
+	return arrayContainer{
+		innerType:       innerType,
+		serializationID: serializationID,
+		oid:             arrayOid,
+		funcs:           funcs,
+	}
+}
+
+// BaseID implements the DoltgresType interface.
+func (ac arrayContainer) BaseID() DoltgresTypeBaseID {
+	// The serializationID might be enough, but it's technically possible for us to use the same serialization ID with
+	// different inner types, so this ensures uniqueness. It is safe to change base IDs in the future (unlike
+	// serialization IDs, which must never be changed, only added to), so we can change this at any time if we feel it
+	// is necessary to.
+	return (DoltgresTypeBaseID(ac.serializationID) << 16) | ac.innerType.BaseID()
+}
+
+// BaseType implements the DoltgresArrayType interface.
+func (ac arrayContainer) BaseType() DoltgresType {
+	return ac.innerType
+}
+
+// CollationCoercibility implements the DoltgresType interface.
+func (ac arrayContainer) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
+// Compare implements the DoltgresType interface.
+func (ac arrayContainer) Compare(v1 any, v2 any) (int, error) {
+	if v1 == nil && v2 == nil {
+		return 0, nil
+	} else if v1 != nil && v2 == nil {
+		return 1, nil
+	} else if v1 == nil && v2 != nil {
+		return -1, nil
+	}
+
+	ab, ok := v1.([]any)
+	if !ok {
+		return 0, sql.ErrInvalidType.New(ac)
+	}
+	bb, ok := v2.([]any)
+	if !ok {
+		return 0, sql.ErrInvalidType.New(ac)
+	}
+
+	minLength := utils.Min(len(ab), len(bb))
+	for i := 0; i < minLength; i++ {
+		res, err := ac.innerType.Compare(ab[i], bb[i])
+		if err != nil {
+			return 0, err
+		}
+		if res != 0 {
+			return res, nil
+		}
+	}
+	if len(ab) == len(bb) {
+		return 0, nil
+	} else if len(ab) < len(bb) {
+		return -1, nil
+	} else {
+		return 1, nil
+	}
+}
+
+// Convert implements the DoltgresType interface.
+func (ac arrayContainer) Convert(val any) (any, sql.ConvertInRange, error) {
+	if val == nil {
+		return nil, sql.InRange, nil
+	}
+	valSlice, ok := val.([]any)
+	if !ok {
+		return nil, sql.OutOfRange, sql.ErrInvalidType.New(ac)
+	}
+	// TODO: should we create a new slice or update the current slice? New slice every time seems wasteful
+	newSlice := make([]any, len(valSlice))
+	for i := range valSlice {
+		var err error
+		newSlice[i], _, err = ac.innerType.Convert(valSlice[i])
+		if err != nil {
+			return nil, sql.OutOfRange, err
+		}
+	}
+	return newSlice, sql.InRange, nil
+}
+
+// Equals implements the DoltgresType interface.
+func (ac arrayContainer) Equals(otherType sql.Type) bool {
+	if otherExtendedType, ok := otherType.(types.ExtendedType); ok {
+		return bytes.Equal(MustSerializeType(ac), MustSerializeType(otherExtendedType))
+	}
+	return false
+}
+
+// FormatSerializedValue implements the DoltgresType interface.
+func (ac arrayContainer) FormatSerializedValue(val []byte) (string, error) {
+	//TODO: write a far more optimized version of this that does not deserialize the entire array at once
+	deserialized, err := ac.DeserializeValue(val)
+	if err != nil {
+		return "", err
+	}
+	return ac.FormatValue(deserialized)
+}
+
+// FormatValue implements the DoltgresType interface.
+func (ac arrayContainer) FormatValue(val any) (string, error) {
+	if val == nil {
+		return "", nil
+	}
+	converted, _, err := ac.Convert(val)
+	if err != nil {
+		return "", err
+	}
+	sb := strings.Builder{}
+	for i, v := range converted.([]any) {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		if v != nil {
+			str, err := ac.innerType.FormatValue(v)
+			if err != nil {
+				return "", err
+			}
+			sb.WriteString(str)
+		} else {
+			sb.WriteString("NULL")
+		}
+	}
+	return sb.String(), nil
+}
+
+// MaxSerializedWidth implements the DoltgresType interface.
+func (ac arrayContainer) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
+	return types.ExtendedTypeSerializedWidth_Unbounded
+}
+
+// MaxTextResponseByteLength implements the DoltgresType interface.
+func (ac arrayContainer) MaxTextResponseByteLength(ctx *sql.Context) uint32 {
+	return math.MaxUint32
+}
+
+// OID implements the DoltgresType interface.
+func (ac arrayContainer) OID() uint32 {
+	return uint32(ac.oid)
+}
+
+// Promote implements the DoltgresType interface.
+func (ac arrayContainer) Promote() sql.Type {
+	return ac
+}
+
+// SerializedCompare implements the DoltgresType interface.
+func (ac arrayContainer) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
+	//TODO: write a far more optimized version of this that does not deserialize the entire arrays at once
+	dv1, err := ac.DeserializeValue(v1)
+	if err != nil {
+		return 0, err
+	}
+	dv2, err := ac.DeserializeValue(v2)
+	if err != nil {
+		return 0, err
+	}
+	return ac.Compare(dv1, dv2)
+}
+
+// SerializeType implements the DoltgresType interface.
+func (ac arrayContainer) SerializeType() ([]byte, error) {
+	innerSerialized, err := ac.innerType.SerializeType()
+	if err != nil {
+		return nil, err
+	}
+	serialized := make([]byte, len(innerSerialized)+2)
+	binary.LittleEndian.PutUint16(serialized, uint16(ac.serializationID))
+	copy(serialized[2:], innerSerialized)
+	return serialized, nil
+}
+
+// SQL implements the DoltgresType interface.
+func (ac arrayContainer) SQL(ctx *sql.Context, dest []byte, valInterface any) (sqltypes.Value, error) {
+	return ac.funcs.SQL(ctx, ac, dest, valInterface)
+}
+
+// String implements the DoltgresType interface.
+func (ac arrayContainer) String() string {
+	return ac.innerType.String() + "[]"
+}
+
+// ToArrayType implements the DoltgresType interface.
+func (ac arrayContainer) ToArrayType() DoltgresArrayType {
+	return ac
+}
+
+// Type implements the DoltgresType interface.
+func (ac arrayContainer) Type() query.Type {
+	return sqltypes.Text
+}
+
+// ValueType implements the DoltgresType interface.
+func (ac arrayContainer) ValueType() reflect.Type {
+	return reflect.TypeOf([]any{})
+}
+
+// Zero implements the DoltgresType interface.
+func (ac arrayContainer) Zero() any {
+	return []any{}
+}
+
+// SerializeValue implements the DoltgresType interface.
+func (ac arrayContainer) SerializeValue(valInterface any) ([]byte, error) {
+	// Check for a nil value and convert to the expected type
+	if valInterface == nil {
+		return nil, nil
+	}
+	converted, _, err := ac.Convert(valInterface)
+	if err != nil {
+		return nil, err
+	}
+	vals := converted.([]any)
+
+	// Create the buffer that we'll write the array's contents to
+	arrayBuffer := bytes.Buffer{}
+	innerSerializedWidth := ac.innerType.MaxSerializedWidth()
+	// Write the total length to a buffer. We'll reuse this buffer for all uint-to-bytes operations.
+	lengthBuffer := make([]byte, 8)
+	binary.BigEndian.PutUint64(lengthBuffer, uint64(len(vals)))
+	arrayBuffer.Write(lengthBuffer)
+
+	// Each value is serialized as the following: IsNull, Size, Data
+	// IsNull is one byte that represents whether the value is null. If this is true/1, then Size and Data are absent.
+	// Size is 2 or 8 bytes and states the size of the Data. It is valid for this to equal zero for some types (like strings).
+	// Data contains the actual data representing a value.
+	for i := range vals {
+		val, err := ac.innerType.SerializeValue(vals[i])
+		if err != nil {
+			return nil, err
+		}
+
+		if val == nil {
+			arrayBuffer.WriteByte(1)
+		} else {
+			arrayBuffer.WriteByte(0)
+			switch innerSerializedWidth {
+			case types.ExtendedTypeSerializedWidth_64K:
+				binary.BigEndian.PutUint16(lengthBuffer, uint16(len(val)))
+				arrayBuffer.Write(lengthBuffer[:2])
+			case types.ExtendedTypeSerializedWidth_Unbounded:
+				binary.BigEndian.PutUint64(lengthBuffer, uint64(len(val)))
+				arrayBuffer.Write(lengthBuffer)
+			default:
+				return nil, fmt.Errorf("array type encountered unexpected serializable width")
+			}
+			arrayBuffer.Write(val)
+		}
+	}
+	return arrayBuffer.Bytes(), nil
+}
+
+// DeserializeValue implements the DoltgresType interface.
+func (ac arrayContainer) DeserializeValue(val []byte) (any, error) {
+	// Check for the nil value, then ensure the minimum length of the slice
+	if val == nil {
+		return nil, nil
+	}
+	if len(val) < 8 {
+		return nil, fmt.Errorf("deserializing non-nil array value has invalid length of %d", len(val))
+	}
+	// Read the length and construct the output slice
+	length := binary.BigEndian.Uint64(val)
+	val = val[8:]
+	output := make([]any, length)
+	innerSerializedWidth := ac.innerType.MaxSerializedWidth()
+	// TODO: faster/better to remove length checks and defer-recover for panics?
+	for i := range output {
+		// Check if the value is null
+		if len(val) < 1 {
+			return nil, fmt.Errorf("deserializing array encountered missing null check for value")
+		}
+		if val[0] == 1 {
+			// output is filled with nil values on initialization, so we only need to move the val slice forward
+			val = val[1:]
+			continue
+		}
+		val = val[1:]
+
+		// Read the length of the data for this value
+		var dataLength uint64
+		switch innerSerializedWidth {
+		case types.ExtendedTypeSerializedWidth_64K:
+			if len(val) < 2 {
+				return nil, fmt.Errorf("deserializing array encountered missing size for value")
+			}
+			dataLength = uint64(binary.BigEndian.Uint16(val))
+			val = val[2:]
+		case types.ExtendedTypeSerializedWidth_Unbounded:
+			if len(val) < 8 {
+				return nil, fmt.Errorf("deserializing array encountered missing size for value")
+			}
+			dataLength = binary.BigEndian.Uint64(val)
+			val = val[8:]
+		default:
+			return nil, fmt.Errorf("array type encountered unexpected serializable width")
+		}
+		if uint64(len(val)) < dataLength {
+			return nil, fmt.Errorf("deserializing array encountered size too large for data")
+		}
+
+		// Read the data using the length from the previous step
+		deserializedValue, err := ac.innerType.DeserializeValue(val[:dataLength])
+		if err != nil {
+			return nil, err
+		}
+		val = val[dataLength:]
+		output[i] = deserializedValue
+	}
+
+	// Make sure that we read everything
+	if len(val) > 0 {
+		return nil, fmt.Errorf("deserialized array has extra data at the end")
+	}
+	return output, nil
+}
+
+// withInnerDeserialization implements the DoltgresArrayType interface.
+func (ac arrayContainer) withInnerDeserialization(innerSerializedType []byte) (types.ExtendedType, error) {
+	innerType, err := DeserializeType(innerSerializedType[2:])
+	if err != nil {
+		return nil, err
+	}
+	return arrayContainer{
+		innerType:       innerType.(DoltgresType),
+		serializationID: ac.serializationID,
+		oid:             ac.oid,
+		funcs:           ac.funcs,
+	}, nil
+}
+
+// arrayContainerSQL implements the default SQL function for arrayContainer.
+func arrayContainerSQL(ctx *sql.Context, ac arrayContainer, dest []byte, valInterface any) (sqltypes.Value, error) {
+	if valInterface == nil {
+		return sqltypes.NULL, nil
+	}
+	converted, _, err := ac.Convert(valInterface)
+	if err != nil {
+		return sqltypes.Value{}, err
+	}
+	vals := converted.([]any)
+	if len(vals) == 0 {
+		return sqltypes.MakeTrusted(ac.Type(), types.AppendAndSliceBytes(dest, []byte{'{', '}'})), nil
+	}
+	bb := bytes.Buffer{}
+	bb.WriteRune('{')
+	for i := range vals {
+		if i > 0 {
+			bb.WriteRune(',')
+		}
+		if vals[i] == nil {
+			bb.WriteString("NULL")
+			continue
+		}
+		valBytes, err := ac.innerType.SQL(ctx, nil, vals[i])
+		if err != nil {
+			return sqltypes.Value{}, err
+		}
+		bb.Write(valBytes.Raw())
+	}
+	bb.WriteRune('}')
+	return sqltypes.MakeTrusted(sqltypes.Text, types.AppendAndSliceBytes(dest, bb.Bytes())), nil
+}

--- a/server/types/base_ids.go
+++ b/server/types/base_ids.go
@@ -1,0 +1,68 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+// DoltgresTypeBaseID is an ID that is common between all variations of a DoltgresType. For example, VARCHAR(3) and
+// VARCHAR(6) are different types, however they will return the same DoltgresTypeBaseID. This ID is not suitable for
+// serialization, as it may change over time. Many types use their SerializationID as their base ID, so for types that
+// are not serializable (such as the "any" types), it is recommended that they start way after the largest
+// SerializationID to prevent base ID conflicts.
+type DoltgresTypeBaseID uint32
+
+const (
+	DoltgresTypeBaseID_Any DoltgresTypeBaseID = iota + 2147483648
+	DoltgresTypeBaseID_AnyElement
+	DoltgresTypeBaseID_AnyArray
+	DoltgresTypeBaseID_AnyNonArray
+	DoltgresTypeBaseID_AnyEnum
+	DoltgresTypeBaseID_AnyRange
+	DoltgresTypeBaseID_AnyMultirange
+	DoltgresTypeBaseID_AnyCompatible
+	DoltgresTypeBaseID_AnyCompatibleArray
+	DoltgresTypeBaseID_AnyCompatibleNonArray
+	DoltgresTypeBaseID_AnyCompatibleRange
+	DoltgresTypeBaseID_AnyCompatibleMultirange
+	DoltgresTypeBaseID_CString
+	DoltgresTypeBaseID_Internal
+	DoltgresTypeBaseID_Language_Handler
+	DoltgresTypeBaseID_FDW_Handler
+	DoltgresTypeBaseID_Table_AM_Handler
+	DoltgresTypeBaseID_Index_AM_Handler
+	DoltgresTypeBaseID_TSM_Handler
+	DoltgresTypeBaseID_Record
+	DoltgresTypeBaseID_Trigger
+	DoltgresTypeBaseID_Event_Trigger
+	DoltgresTypeBaseID_PG_DDL_Command
+	DoltgresTypeBaseID_Void
+	DoltgresTypeBaseID_Unknown
+)
+
+// baseIDArrayTypes contains a map of all base IDs that represent array variants.
+var baseIDArrayTypes = map[DoltgresTypeBaseID]DoltgresArrayType{}
+
+// init reads the list of all types and creates a mapping of the base ID for each array variant.
+func init() {
+	for _, t := range typesFromBaseID {
+		if dat, ok := t.(DoltgresArrayType); ok {
+			baseIDArrayTypes[t.BaseID()] = dat
+		}
+	}
+}
+
+// IsBaseIDArrayType returns whether the given base ID is an array type. If it is, it also returns the type.
+func IsBaseIDArrayType(id DoltgresTypeBaseID) (DoltgresArrayType, bool) {
+	dat, ok := baseIDArrayTypes[id]
+	return dat, ok
+}

--- a/server/types/bool.go
+++ b/server/types/bool.go
@@ -205,6 +205,11 @@ func (b BoolType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	}
 }
 
+// SerializeType implements the DoltgresType interface.
+func (b BoolType) SerializeType() ([]byte, error) {
+	return SerializationID_Bool.ToByteSlice(), nil
+}
+
 // SQL implements the DoltgresType interface.
 func (b BoolType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
 	if v == nil {
@@ -227,6 +232,11 @@ func (b BoolType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, err
 // String implements the DoltgresType interface.
 func (b BoolType) String() string {
 	return "boolean"
+}
+
+// ToArrayType implements the DoltgresType interface.
+func (b BoolType) ToArrayType() DoltgresArrayType {
+	return BoolArray
 }
 
 // Type implements the DoltgresType interface.

--- a/server/types/float32.go
+++ b/server/types/float32.go
@@ -196,6 +196,11 @@ func (b Float32Type) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	return bytes.Compare(v1, v2), nil
 }
 
+// SerializeType implements the DoltgresType interface.
+func (b Float32Type) SerializeType() ([]byte, error) {
+	return SerializationID_Float32.ToByteSlice(), nil
+}
+
 // SQL implements the DoltgresType interface.
 func (b Float32Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
 	if v == nil {
@@ -211,6 +216,11 @@ func (b Float32Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, 
 // String implements the DoltgresType interface.
 func (b Float32Type) String() string {
 	return "real"
+}
+
+// ToArrayType implements the DoltgresType interface.
+func (b Float32Type) ToArrayType() DoltgresArrayType {
+	return Float32Array
 }
 
 // Type implements the DoltgresType interface.

--- a/server/types/float32_array.go
+++ b/server/types/float32_array.go
@@ -14,9 +14,7 @@
 
 package types
 
-import (
-	"github.com/lib/pq/oid"
-)
+import "github.com/lib/pq/oid"
 
-// BoolArray is the array variant of Bool.
-var BoolArray = createArrayType(Bool, SerializationID_BoolArray, oid.T__bool)
+// Float32Array is the array variant of Float32.
+var Float32Array = createArrayType(Float32, SerializationID_Float32Array, oid.T__float4)

--- a/server/types/float64.go
+++ b/server/types/float64.go
@@ -195,6 +195,11 @@ func (b Float64Type) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	return bytes.Compare(v1, v2), nil
 }
 
+// SerializeType implements the DoltgresType interface.
+func (b Float64Type) SerializeType() ([]byte, error) {
+	return SerializationID_Float64.ToByteSlice(), nil
+}
+
 // SQL implements the DoltgresType interface.
 func (b Float64Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
 	if v == nil {
@@ -210,6 +215,11 @@ func (b Float64Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, 
 // String implements the DoltgresType interface.
 func (b Float64Type) String() string {
 	return "double precision"
+}
+
+// ToArrayType implements the DoltgresType interface.
+func (b Float64Type) ToArrayType() DoltgresArrayType {
+	return Float64Array
 }
 
 // Type implements the DoltgresType interface.

--- a/server/types/float64_array.go
+++ b/server/types/float64_array.go
@@ -14,9 +14,7 @@
 
 package types
 
-import (
-	"github.com/lib/pq/oid"
-)
+import "github.com/lib/pq/oid"
 
-// BoolArray is the array variant of Bool.
-var BoolArray = createArrayType(Bool, SerializationID_BoolArray, oid.T__bool)
+// Float64Array is the array variant of Float64.
+var Float64Array = createArrayType(Float64, SerializationID_Float64Array, oid.T__float8)

--- a/server/types/int16.go
+++ b/server/types/int16.go
@@ -194,6 +194,11 @@ func (b Int16Type) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	return bytes.Compare(v1, v2), nil
 }
 
+// SerializeType implements the DoltgresType interface.
+func (b Int16Type) SerializeType() ([]byte, error) {
+	return SerializationID_Int16.ToByteSlice(), nil
+}
+
 // SQL implements the DoltgresType interface.
 func (b Int16Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
 	if v == nil {
@@ -209,6 +214,11 @@ func (b Int16Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, er
 // String implements the DoltgresType interface.
 func (b Int16Type) String() string {
 	return "smallint"
+}
+
+// ToArrayType implements the DoltgresType interface.
+func (b Int16Type) ToArrayType() DoltgresArrayType {
+	return Int16Array
 }
 
 // Type implements the DoltgresType interface.

--- a/server/types/int16_array.go
+++ b/server/types/int16_array.go
@@ -14,9 +14,7 @@
 
 package types
 
-import (
-	"github.com/lib/pq/oid"
-)
+import "github.com/lib/pq/oid"
 
-// BoolArray is the array variant of Bool.
-var BoolArray = createArrayType(Bool, SerializationID_BoolArray, oid.T__bool)
+// Int16Array is the array variant of Int16.
+var Int16Array = createArrayType(Int16, SerializationID_Int16Array, oid.T__int2)

--- a/server/types/int32.go
+++ b/server/types/int32.go
@@ -193,6 +193,11 @@ func (b Int32Type) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	return bytes.Compare(v1, v2), nil
 }
 
+// SerializeType implements the DoltgresType interface.
+func (b Int32Type) SerializeType() ([]byte, error) {
+	return SerializationID_Int32.ToByteSlice(), nil
+}
+
 // SQL implements the DoltgresType interface.
 func (b Int32Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
 	if v == nil {
@@ -208,6 +213,11 @@ func (b Int32Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, er
 // String implements the DoltgresType interface.
 func (b Int32Type) String() string {
 	return "integer"
+}
+
+// ToArrayType implements the DoltgresType interface.
+func (b Int32Type) ToArrayType() DoltgresArrayType {
+	return Int32Array
 }
 
 // Type implements the DoltgresType interface.

--- a/server/types/int32_array.go
+++ b/server/types/int32_array.go
@@ -14,9 +14,7 @@
 
 package types
 
-import (
-	"github.com/lib/pq/oid"
-)
+import "github.com/lib/pq/oid"
 
-// BoolArray is the array variant of Bool.
-var BoolArray = createArrayType(Bool, SerializationID_BoolArray, oid.T__bool)
+// Int32Array is the array variant of Int32.
+var Int32Array = createArrayType(Int32, SerializationID_Int32Array, oid.T__int4)

--- a/server/types/int64.go
+++ b/server/types/int64.go
@@ -193,6 +193,11 @@ func (b Int64Type) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	return bytes.Compare(v1, v2), nil
 }
 
+// SerializeType implements the DoltgresType interface.
+func (b Int64Type) SerializeType() ([]byte, error) {
+	return SerializationID_Int64.ToByteSlice(), nil
+}
+
 // SQL implements the DoltgresType interface.
 func (b Int64Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
 	if v == nil {
@@ -208,6 +213,11 @@ func (b Int64Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, er
 // String implements the DoltgresType interface.
 func (b Int64Type) String() string {
 	return "bigint"
+}
+
+// ToArrayType implements the DoltgresType interface.
+func (b Int64Type) ToArrayType() DoltgresArrayType {
+	return Int64Array
 }
 
 // Type implements the DoltgresType interface.

--- a/server/types/int64_array.go
+++ b/server/types/int64_array.go
@@ -14,9 +14,7 @@
 
 package types
 
-import (
-	"github.com/lib/pq/oid"
-)
+import "github.com/lib/pq/oid"
 
-// BoolArray is the array variant of Bool.
-var BoolArray = createArrayType(Bool, SerializationID_BoolArray, oid.T__bool)
+// Int64Array is the array variant of Int64.
+var Int64Array = createArrayType(Int64, SerializationID_Int64Array, oid.T__int8)

--- a/server/types/null.go
+++ b/server/types/null.go
@@ -104,6 +104,11 @@ func (b NullType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	return 0, nil
 }
 
+// SerializeType implements the DoltgresType interface.
+func (b NullType) SerializeType() ([]byte, error) {
+	return SerializationID_Null.ToByteSlice(), nil
+}
+
 // SQL implements the DoltgresType interface.
 func (b NullType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
 	return sqltypes.NULL, nil
@@ -112,6 +117,11 @@ func (b NullType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, err
 // String implements the DoltgresType interface.
 func (b NullType) String() string {
 	return "null"
+}
+
+// ToArrayType implements the DoltgresType interface.
+func (b NullType) ToArrayType() DoltgresArrayType {
+	return Unknown
 }
 
 // Type implements the DoltgresType interface.

--- a/server/types/numeric.go
+++ b/server/types/numeric.go
@@ -203,6 +203,11 @@ func (b NumericType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	return ab.Cmp(bb), nil
 }
 
+// SerializeType implements the DoltgresType interface.
+func (b NumericType) SerializeType() ([]byte, error) {
+	return SerializationID_Numeric.ToByteSlice(), nil
+}
+
 // SQL implements the DoltgresType interface.
 func (b NumericType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
 	if v == nil {
@@ -218,6 +223,11 @@ func (b NumericType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, 
 // String implements the DoltgresType interface.
 func (b NumericType) String() string {
 	return "numeric"
+}
+
+// ToArrayType implements the DoltgresType interface.
+func (b NumericType) ToArrayType() DoltgresArrayType {
+	return NumericArray
 }
 
 // Type implements the DoltgresType interface.

--- a/server/types/numeric_array.go
+++ b/server/types/numeric_array.go
@@ -14,9 +14,7 @@
 
 package types
 
-import (
-	"github.com/lib/pq/oid"
-)
+import "github.com/lib/pq/oid"
 
-// BoolArray is the array variant of Bool.
-var BoolArray = createArrayType(Bool, SerializationID_BoolArray, oid.T__bool)
+// NumericArray is the array variant of Numeric.
+var NumericArray = createArrayType(Numeric, SerializationID_NumericArray, oid.T__numeric)

--- a/server/types/unknown.go
+++ b/server/types/unknown.go
@@ -1,0 +1,152 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/dolthub/vitess/go/sqltypes"
+	"github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/lib/pq/oid"
+)
+
+// Unknown represents an invalid or indeterminate type. This is primarily used internally.
+var Unknown = UnknownType{}
+
+// UnknownType is the extended type implementation of the PostgreSQL unknown type.
+type UnknownType struct{}
+
+var _ DoltgresType = UnknownType{}
+var _ DoltgresArrayType = UnknownType{}
+
+// BaseID implements the DoltgresType interface.
+func (u UnknownType) BaseID() DoltgresTypeBaseID {
+	return DoltgresTypeBaseID_Unknown
+}
+
+// BaseType implements the DoltgresArrayType interface.
+func (u UnknownType) BaseType() DoltgresType {
+	return Unknown
+}
+
+// CollationCoercibility implements the DoltgresType interface.
+func (u UnknownType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
+// Compare implements the DoltgresType interface.
+func (u UnknownType) Compare(v1 any, v2 any) (int, error) {
+	return 0, fmt.Errorf("%s cannot compare values", u.String())
+}
+
+// Convert implements the DoltgresType interface.
+func (u UnknownType) Convert(val any) (any, sql.ConvertInRange, error) {
+	return nil, sql.OutOfRange, fmt.Errorf("%s cannot convert values", u.String())
+}
+
+// Equals implements the DoltgresType interface.
+func (u UnknownType) Equals(otherType sql.Type) bool {
+	_, ok := otherType.(UnknownType)
+	return ok
+}
+
+// FormatSerializedValue implements the DoltgresType interface.
+func (u UnknownType) FormatSerializedValue(val []byte) (string, error) {
+	return "", fmt.Errorf("%s cannot format serialized values", u.String())
+}
+
+// FormatValue implements the DoltgresType interface.
+func (u UnknownType) FormatValue(val any) (string, error) {
+	return "", fmt.Errorf("%s cannot format values", u.String())
+}
+
+// MaxSerializedWidth implements the DoltgresType interface.
+func (u UnknownType) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
+	return types.ExtendedTypeSerializedWidth_Unbounded
+}
+
+// MaxTextResponseByteLength implements the DoltgresType interface.
+func (u UnknownType) MaxTextResponseByteLength(ctx *sql.Context) uint32 {
+	return math.MaxUint32
+}
+
+// OID implements the DoltgresType interface.
+func (u UnknownType) OID() uint32 {
+	return uint32(oid.T_unknown)
+}
+
+// Promote implements the DoltgresType interface.
+func (u UnknownType) Promote() sql.Type {
+	return u
+}
+
+// SerializedCompare implements the DoltgresType interface.
+func (u UnknownType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
+	return 0, fmt.Errorf("%s cannot compare serialized values", u.String())
+}
+
+// SerializeType implements the DoltgresType interface.
+func (u UnknownType) SerializeType() ([]byte, error) {
+	return nil, fmt.Errorf("%s cannot be serialized", u.String())
+}
+
+// SQL implements the DoltgresType interface.
+func (u UnknownType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
+	return sqltypes.Value{}, fmt.Errorf("%s cannot output values in the wire format", u.String())
+}
+
+// String implements the DoltgresType interface.
+func (u UnknownType) String() string {
+	return "unknown"
+}
+
+// ToArrayType implements the DoltgresType interface.
+func (u UnknownType) ToArrayType() DoltgresArrayType {
+	return u
+}
+
+// Type implements the DoltgresType interface.
+func (u UnknownType) Type() query.Type {
+	return sqltypes.Text
+}
+
+// ValueType implements the DoltgresType interface.
+func (u UnknownType) ValueType() reflect.Type {
+	return reflect.TypeOf(any(nil))
+}
+
+// Zero implements the DoltgresType interface.
+func (u UnknownType) Zero() any {
+	return any(nil)
+}
+
+// SerializeValue implements the DoltgresType interface.
+func (u UnknownType) SerializeValue(val any) ([]byte, error) {
+	return nil, fmt.Errorf("%s cannot serialize values", u.String())
+}
+
+// DeserializeValue implements the DoltgresType interface.
+func (u UnknownType) DeserializeValue(val []byte) (any, error) {
+	return nil, fmt.Errorf("%s cannot deserialize values", u.String())
+}
+
+// withInnerDeserialization implements the DoltgresArrayType interface.
+func (u UnknownType) withInnerDeserialization(innerSerializedType []byte) (types.ExtendedType, error) {
+	return nil, fmt.Errorf("%s cannot be deserialized", u.String())
+}

--- a/server/types/uuid.go
+++ b/server/types/uuid.go
@@ -151,6 +151,11 @@ func (b UuidType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	return bytes.Compare(v1, v2), nil
 }
 
+// SerializeType implements the DoltgresType interface.
+func (b UuidType) SerializeType() ([]byte, error) {
+	return SerializationID_Uuid.ToByteSlice(), nil
+}
+
 // SQL implements the DoltgresType interface.
 func (b UuidType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
 	if v == nil {
@@ -166,6 +171,11 @@ func (b UuidType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, err
 // String implements the DoltgresType interface.
 func (b UuidType) String() string {
 	return "uuid"
+}
+
+// ToArrayType implements the DoltgresType interface.
+func (b UuidType) ToArrayType() DoltgresArrayType {
+	return UuidArray
 }
 
 // Type implements the DoltgresType interface.

--- a/server/types/uuid_array.go
+++ b/server/types/uuid_array.go
@@ -14,9 +14,7 @@
 
 package types
 
-import (
-	"github.com/lib/pq/oid"
-)
+import "github.com/lib/pq/oid"
 
-// BoolArray is the array variant of Bool.
-var BoolArray = createArrayType(Bool, SerializationID_BoolArray, oid.T__bool)
+// UuidArray is the array variant of Uuid.
+var UuidArray = createArrayType(Uuid, SerializationID_UuidArray, oid.T__uuid)

--- a/server/types/varchar_array.go
+++ b/server/types/varchar_array.go
@@ -1,0 +1,71 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/dolthub/vitess/go/sqltypes"
+	"github.com/lib/pq/oid"
+)
+
+// VarCharArray is the array variant of VarChar.
+var VarCharArray = createArrayTypeWithFuncs(VarCharMax, SerializationID_VarCharArray, oid.T__varchar, arrayContainerFunctions{
+	SQL: varCharArraySQL,
+})
+
+// varCharArraySQL is the SQL implementation for VarCharArray.
+func varCharArraySQL(ctx *sql.Context, ac arrayContainer, dest []byte, valInterface any) (sqltypes.Value, error) {
+	if valInterface == nil {
+		return sqltypes.NULL, nil
+	}
+	converted, _, err := ac.Convert(valInterface)
+	if err != nil {
+		return sqltypes.Value{}, err
+	}
+	vals := converted.([]any)
+	if len(vals) == 0 {
+		return sqltypes.MakeTrusted(ac.Type(), types.AppendAndSliceBytes(dest, []byte{'{', '}'})), nil
+	}
+	bb := bytes.Buffer{}
+	bb.WriteRune('{')
+	for i := range vals {
+		if i > 0 {
+			bb.WriteRune(',')
+		}
+		if vals[i] == nil {
+			bb.WriteString("NULL")
+			continue
+		}
+		val := vals[i].(string)
+		containsDoubleQuote := strings.Contains(val, `"`)
+		if containsDoubleQuote {
+			val = strings.ReplaceAll(val, `"`, `\"`)
+		}
+		if containsDoubleQuote || strings.Contains(val, `,`) ||
+			strings.Contains(val, `{`) || strings.Contains(val, `}`) {
+			bb.WriteRune('"')
+			bb.WriteString(val)
+			bb.WriteRune('"')
+		} else {
+			bb.WriteString(val)
+		}
+	}
+	bb.WriteRune('}')
+	return sqltypes.MakeTrusted(sqltypes.Text, types.AppendAndSliceBytes(dest, bb.Bytes())), nil
+}

--- a/testing/go/smoke_test.go
+++ b/testing/go/smoke_test.go
@@ -156,23 +156,56 @@ func TestSmokeTests(t *testing.T) {
 		{
 			Name: "ARRAY expression",
 			SetUpScript: []string{
-				"CREATE TABLE test (id INTEGER primary key, v1 BOOLEAN);",
-				"INSERT INTO test VALUES (1, 'true'), (2, 'false');",
+				"CREATE TABLE test1 (id INTEGER primary key, v1 BOOLEAN);",
+				"INSERT INTO test1 VALUES (1, 'true'), (2, 'false');",
 			},
 			Assertions: []ScriptTestAssertion{
 				{
-					Query: "SELECT ARRAY[v1] FROM test ORDER BY id;",
+					Query: "SELECT ARRAY[v1]::boolean[] FROM test1 ORDER BY id;",
 					Expected: []sql.Row{
 						{"{t}"},
 						{"{f}"},
 					},
 				},
 				{
-					Query: "SELECT ARRAY[v1, true, v1] FROM test ORDER BY id;",
+					Query: "SELECT ARRAY[v1] FROM test1 ORDER BY id;",
+					Expected: []sql.Row{
+						{"{t}"},
+						{"{f}"},
+					},
+				},
+				{
+					Query: "SELECT ARRAY[v1, true, v1] FROM test1 ORDER BY id;",
 					Expected: []sql.Row{
 						{"{t,t,t}"},
 						{"{f,t,f}"},
 					},
+				},
+				{
+					Query: "SELECT ARRAY[1::float8, 2::numeric];",
+					Expected: []sql.Row{
+						{"{1,2}"},
+					},
+				},
+				{
+					Query: "SELECT ARRAY[1::float8, NULL];",
+					Expected: []sql.Row{
+						{"{1,NULL}"},
+					},
+				},
+				{
+					Query: "SELECT ARRAY[1::int2, 2::int4, 3::int8]::varchar[];",
+					Expected: []sql.Row{
+						{"{1,2,3}"},
+					},
+				},
+				{
+					Query:       "SELECT ARRAY[1::int8]::int;",
+					ExpectedErr: true,
+				},
+				{
+					Query:       "SELECT ARRAY[1::int8, 2::varchar];",
+					ExpectedErr: true,
 				},
 			},
 		},

--- a/testing/go/types_test.go
+++ b/testing/go/types_test.go
@@ -272,7 +272,7 @@ var typesTests = []ScriptTest{
 		},
 	},
 	{
-		Name:  "Character varying array type, with length",
+		Name: "Character varying array type, with length",
 		SetUpScript: []string{
 			"CREATE TABLE t_varchar1 (v1 CHARACTER VARYING[]);",
 			"CREATE TABLE t_varchar2 (v1 CHARACTER VARYING(1)[]);",

--- a/testing/go/types_test.go
+++ b/testing/go/types_test.go
@@ -38,6 +38,23 @@ var typesTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "Bigint array type",
+		SetUpScript: []string{
+			"CREATE TABLE t_bigint (id INTEGER primary key, v1 BIGINT[]);",
+			"INSERT INTO t_bigint VALUES (1, ARRAY[123456789012345, NULL]), (2, ARRAY[987654321098765, 5]), (3, ARRAY[4, 5]);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT * FROM t_bigint ORDER BY id;",
+				Expected: []sql.Row{
+					{1, "{123456789012345,NULL}"},
+					{2, "{987654321098765,5}"},
+					{3, "{4,5}"},
+				},
+			},
+		},
+	},
+	{
 		Name: "Bit type",
 		Skip: true,
 		SetUpScript: []string{
@@ -58,7 +75,7 @@ var typesTests = []ScriptTest{
 		Name: "Boolean type",
 		SetUpScript: []string{
 			"CREATE TABLE t_boolean (id INTEGER primary key, v1 BOOLEAN);",
-			"INSERT INTO t_boolean VALUES (1, 'true'), (2, 'false'), (3, NULL);", //TODO: "INSERT INTO t_boolean VALUES (1, true), (2, false), (3, NULL);",
+			"INSERT INTO t_boolean VALUES (1, true), (2, 'false'), (3, NULL);",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -255,8 +272,30 @@ var typesTests = []ScriptTest{
 		},
 	},
 	{
+		Name:  "Character varying array type, with length",
+		SetUpScript: []string{
+			"CREATE TABLE t_varchar1 (v1 CHARACTER VARYING[]);",
+			"CREATE TABLE t_varchar2 (v1 CHARACTER VARYING(1)[]);",
+			"INSERT INTO t_varchar1 VALUES (ARRAY['ab''cdef', 'what', 'is,hi', 'wh\"at']);",
+			"INSERT INTO t_varchar2 VALUES (ARRAY['ab''cdef', 'what', 'is,hi', 'wh\"at']);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `SELECT v1::varchar(1)[] FROM t_varchar1;`,
+				Expected: []sql.Row{
+					{"{a,w,i,w}"},
+				},
+			},
+			{
+				Query: `SELECT * FROM t_varchar2;`,
+				Expected: []sql.Row{
+					{"{a,w,i,w}"},
+				},
+			},
+		},
+	},
+	{
 		Name: "Character varying type, no length",
-		Skip: true, // no length param not correctly handled yet
 		SetUpScript: []string{
 			"CREATE TABLE t_varchar (id INTEGER primary key, v1 CHARACTER VARYING);",
 			"INSERT INTO t_varchar VALUES (1, 'abcdefghij'), (2, 'klmnopqrst');",
@@ -267,6 +306,22 @@ var typesTests = []ScriptTest{
 				Expected: []sql.Row{
 					{1, "abcdefghij"},
 					{2, "klmnopqrst"},
+				},
+			},
+		},
+	},
+	{
+		Name: "Character varying array type, no length",
+		SetUpScript: []string{
+			"CREATE TABLE t_varchar (id INTEGER primary key, v1 CHARACTER VARYING[]);",
+			"INSERT INTO t_varchar VALUES (1, ARRAY['abcdefghij', NULL]), (2, ARRAY['ab''cdef', 'what', 'is,hi', 'wh\"at', '}', '{', '{}']);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT * FROM t_varchar ORDER BY id;",
+				Expected: []sql.Row{
+					{1, "{abcdefghij,NULL}"},
+					{2, `{ab'cdef,what,"is,hi","wh\"at","}","{","{}"}`},
 				},
 			},
 		},
@@ -340,6 +395,22 @@ var typesTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "Double precision array type",
+		SetUpScript: []string{
+			"CREATE TABLE t_double_precision (id INTEGER primary key, v1 DOUBLE PRECISION[]);",
+			"INSERT INTO t_double_precision VALUES (1, ARRAY[123.456, NULL]), (2, ARRAY[789.012, 125.125]);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT * FROM t_double_precision ORDER BY id;",
+				Expected: []sql.Row{
+					{1, "{123.456,NULL}"},
+					{2, "{789.012,125.125}"},
+				},
+			},
+		},
+	},
+	{
 		Name: "Inet type",
 		Skip: true,
 		SetUpScript: []string{
@@ -368,6 +439,22 @@ var typesTests = []ScriptTest{
 				Expected: []sql.Row{
 					{1, 123},
 					{2, 456},
+				},
+			},
+		},
+	},
+	{
+		Name: "Integer array type",
+		SetUpScript: []string{
+			"CREATE TABLE t_integer (id INTEGER primary key, v1 INTEGER[]);",
+			"INSERT INTO t_integer VALUES (1, ARRAY[123,NULL]), (2, ARRAY[456,823753913]);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT * FROM t_integer ORDER BY id;",
+				Expected: []sql.Row{
+					{1, "{123,NULL}"},
+					{2, "{456,823753913}"},
 				},
 			},
 		},
@@ -507,6 +594,38 @@ var typesTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "Numeric type, no scale or precision",
+		SetUpScript: []string{
+			"CREATE TABLE t_numeric (id INTEGER primary key, v1 NUMERIC);",
+			"INSERT INTO t_numeric VALUES (1, 123.45), (2, 67.875);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT * FROM t_numeric ORDER BY id;",
+				Expected: []sql.Row{
+					{1, 123.45},
+					{2, 67.875},
+				},
+			},
+		},
+	},
+	{
+		Name: "Numeric array type, no scale or precision",
+		SetUpScript: []string{
+			"CREATE TABLE t_numeric (id INTEGER primary key, v1 NUMERIC[]);",
+			"INSERT INTO t_numeric VALUES (1, ARRAY[NULL,123.45]), (2, ARRAY[67.89,572903.1468]);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT * FROM t_numeric ORDER BY id;",
+				Expected: []sql.Row{
+					{1, "{NULL,123.45}"},
+					{2, "{67.89,572903.1468}"},
+				},
+			},
+		},
+	},
+	{
 		Name: "Path type",
 		Skip: true,
 		SetUpScript: []string{
@@ -591,6 +710,22 @@ var typesTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "Real array type",
+		SetUpScript: []string{
+			"CREATE TABLE t_real (id INTEGER primary key, v1 REAL[]);",
+			"INSERT INTO t_real VALUES (1, ARRAY[NULL,123.875]), (2, ARRAY[67.125, 84256]);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT * FROM t_real ORDER BY id;",
+				Expected: []sql.Row{
+					{1, "{NULL,123.875}"},
+					{2, "{67.125,84256}"},
+				},
+			},
+		},
+	},
+	{
 		Name: "Smallint type",
 		SetUpScript: []string{
 			"CREATE TABLE t_smallint (id INTEGER primary key, v1 SMALLINT);",
@@ -602,6 +737,22 @@ var typesTests = []ScriptTest{
 				Expected: []sql.Row{
 					{1, 42},
 					{2, 99},
+				},
+			},
+		},
+	},
+	{
+		Name: "Smallint array type",
+		SetUpScript: []string{
+			"CREATE TABLE t_smallint (id INTEGER primary key, v1 SMALLINT[]);",
+			"INSERT INTO t_smallint VALUES (1, ARRAY[42,NULL]), (2, ARRAY[99,126]);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT * FROM t_smallint ORDER BY id;",
+				Expected: []sql.Row{
+					{1, "{42,NULL}"},
+					{2, "{99,126}"},
 				},
 			},
 		},
@@ -770,6 +921,22 @@ var typesTests = []ScriptTest{
 				Expected: []sql.Row{
 					{1, "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"},
 					{2, "f47ac10b-58cc-4372-a567-0e02b2c3d479"},
+				},
+			},
+		},
+	},
+	{
+		Name: "Uuid array type",
+		SetUpScript: []string{
+			"CREATE TABLE t_uuid (id INTEGER primary key, v1 UUID[]);",
+			"INSERT INTO t_uuid VALUES (1, ARRAY['a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'::uuid, NULL]), (2, ARRAY[NULL, 'f47ac10b58cc4372a567-0e02b2c3d479'::uuid]);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT * FROM t_uuid ORDER BY id;",
+				Expected: []sql.Row{
+					{1, "{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11,NULL}"},
+					{2, "{NULL,f47ac10b-58cc-4372-a567-0e02b2c3d479}"},
 				},
 			},
 		},


### PR DESCRIPTION
This PR adds array types for all existing types. This is done by providing a wrapper that handles all of the array-functionality over the base type. In addition, this removes the mock array functionality that only worked to demonstrate the viability of `boolean[]`, replacing the functionality with fully working equivalents.