### PR TITLE
Added more types, reworked cast framework

### DIFF
--- a/postgres/messages/row_description.go
+++ b/postgres/messages/row_description.go
@@ -265,6 +265,8 @@ func VitessTypeToObjectID(typ query.Type) (int32, error) {
 		return OidVarchar, nil
 	case query.Type_TEXT:
 		return OidText, nil
+	case query.Type_BLOB:
+		return OidBytea, nil
 	case query.Type_JSON:
 		return OidJson, nil
 	case query.Type_TIMESTAMP, query.Type_DATETIME:
@@ -316,6 +318,8 @@ func VitessFieldToDataTypeSize(field *query.Field) (int16, error) {
 	case query.Type_VARCHAR:
 		return -1, nil
 	case query.Type_TEXT:
+		return -1, nil
+	case query.Type_BLOB:
 		return -1, nil
 	case query.Type_JSON:
 		return -1, nil
@@ -374,6 +378,8 @@ func VitessFieldToDataTypeModifier(field *query.Field) (int32, error) {
 		// PostgreSQL adds 4 to the length for an unknown reason
 		return int32(int64(field.ColumnLength)/sql.CharacterSetID(field.Charset).MaxLength()) + 4, nil
 	case query.Type_TEXT:
+		return -1, nil
+	case query.Type_BLOB:
 		return -1, nil
 	case query.Type_JSON:
 		return -1, nil

--- a/server/cast/bool.go
+++ b/server/cast/bool.go
@@ -1,0 +1,125 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cast
+
+import (
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func init() {
+	boolExplicit()
+	boolImplicit()
+}
+
+// boolExplicit registers all explicit casts. This comprises only the "From" types.
+func boolExplicit() {
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Bool,
+		ToType:   pgtypes.Bool,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Bool,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := "false"
+			if val.(bool) {
+				str = "true"
+			}
+			return handleCharExplicitCast(str, targetType)
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Bool,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			if val.(bool) {
+				return int32(1), nil
+			} else {
+				return int32(0), nil
+			}
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Bool,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			if val.(bool) {
+				return "true", nil
+			} else {
+				return "false", nil
+			}
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Bool,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := "false"
+			if val.(bool) {
+				str = "true"
+			}
+			return handleCharExplicitCast(str, targetType)
+		},
+	})
+}
+
+// boolImplicit registers all implicit casts. This comprises only the "From" types.
+func boolImplicit() {
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Bool,
+		ToType:   pgtypes.Bool,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Bool,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := "false"
+			if val.(bool) {
+				str = "true"
+			}
+			return handleCharImplicitCast(str, targetType)
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Bool,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			if val.(bool) {
+				return "true", nil
+			} else {
+				return "false", nil
+			}
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Bool,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := "false"
+			if val.(bool) {
+				str = "true"
+			}
+			return handleCharImplicitCast(str, targetType)
+		},
+	})
+}

--- a/server/cast/bytea.go
+++ b/server/cast/bytea.go
@@ -1,0 +1,97 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cast
+
+import (
+	"encoding/hex"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func init() {
+	// TODO: handle the different output formats?
+	byteaExplicit()
+	byteaImplicit()
+}
+
+// byteaExplicit registers all explicit casts. This comprises only the "From" types.
+func byteaExplicit() {
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Bytea,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := `\x` + hex.EncodeToString(val.([]byte))
+			return handleCharExplicitCast(str, targetType)
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Bytea,
+		ToType:   pgtypes.Bytea,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Bytea,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return `\x` + hex.EncodeToString(val.([]byte)), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Bytea,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := `\x` + hex.EncodeToString(val.([]byte))
+			return handleCharExplicitCast(str, targetType)
+		},
+	})
+}
+
+// byteaImplicit registers all implicit casts. This comprises only the "From" types.
+func byteaImplicit() {
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Bytea,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := `\x` + hex.EncodeToString(val.([]byte))
+			return handleCharImplicitCast(str, targetType)
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Bytea,
+		ToType:   pgtypes.Bytea,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Bytea,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return `\x` + hex.EncodeToString(val.([]byte)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Bytea,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := `\x` + hex.EncodeToString(val.([]byte))
+			return handleCharImplicitCast(str, targetType)
+		},
+	})
+}

--- a/server/cast/char.go
+++ b/server/cast/char.go
@@ -1,0 +1,300 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cast
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/dolthub/doltgresql/postgres/parser/uuid"
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func init() {
+	charExplicit()
+	charImplicit()
+}
+
+// charExplicit registers all explicit casts. This comprises only the "From" types.
+func charExplicit() {
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Bool,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			switch strings.TrimSpace(strings.ToLower(val.(string))) {
+			case "true", "y", "ye", "yes", "on", "1", "t":
+				return true, nil
+			case "false", "n", "no", "off", "0", "f":
+				return false, nil
+			default:
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val)
+			}
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharExplicitCast(val.(string), targetType)
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Bytea,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			if strings.HasPrefix(val.(string), `\x`) {
+				return hex.DecodeString(val.(string)[2:])
+			} else {
+				return []byte(val.(string)), nil
+			}
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseFloat(strings.TrimSpace(val.(string)), 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return float32(out), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseFloat(strings.TrimSpace(val.(string)), 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return out, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			if out > 32767 || out < -32768 {
+				return nil, fmt.Errorf("value %q is out of range for type %s", val.(string), targetType.String())
+			}
+			return int16(out), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			if out > 2147483647 || out < -2147483648 {
+				return nil, fmt.Errorf("value %q is out of range for type %s", val.(string), targetType.String())
+			}
+			return int32(out), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return out, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			d, err := decimal.NewFromString(strings.TrimSpace(val.(string)))
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return d, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Uuid,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			u, err := uuid.FromString(strings.TrimSpace(val.(string)))
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return u, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharExplicitCast(val.(string), targetType)
+		},
+	})
+}
+
+// charImplicit registers all implicit casts. This comprises only the "From" types.
+func charImplicit() {
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Bool,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			switch strings.TrimSpace(strings.ToLower(val.(string))) {
+			case "true", "y", "ye", "yes", "on", "1", "t":
+				return true, nil
+			case "false", "n", "no", "off", "0", "f":
+				return false, nil
+			default:
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val)
+			}
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharImplicitCast(val.(string), targetType)
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Bytea,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			if strings.HasPrefix(val.(string), `\x`) {
+				return hex.DecodeString(val.(string)[2:])
+			} else {
+				return []byte(val.(string)), nil
+			}
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseFloat(strings.TrimSpace(val.(string)), 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return float32(out), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseFloat(strings.TrimSpace(val.(string)), 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return out, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			if out > 32767 || out < -32768 {
+				return nil, fmt.Errorf("value %q is out of range for type %s", val.(string), targetType.String())
+			}
+			return int16(out), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			if out > 2147483647 || out < -2147483648 {
+				return nil, fmt.Errorf("value %q is out of range for type %s", val.(string), targetType.String())
+			}
+			return int32(out), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return out, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			d, err := decimal.NewFromString(strings.TrimSpace(val.(string)))
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return d, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.Uuid,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			u, err := uuid.FromString(strings.TrimSpace(val.(string)))
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return u, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.BpChar,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharImplicitCast(val.(string), targetType)
+		},
+	})
+}

--- a/server/cast/float32.go
+++ b/server/cast/float32.go
@@ -1,0 +1,194 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cast
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func init() {
+	float32Explicit()
+	float32Implicit()
+}
+
+// float32Explicit registers all explicit casts. This comprises only the "From" types.
+func float32Explicit() {
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatFloat(float64(val.(float32)), 'g', -1, 32)
+			return handleCharExplicitCast(str, targetType)
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return float64(val.(float32)), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, valInterface any, targetType pgtypes.DoltgresType) (any, error) {
+			val := float32(math.RoundToEven(float64(valInterface.(float32))))
+			if val > 32767 || val < -32768 {
+				return nil, fmt.Errorf("smallint out of range")
+			}
+			return int16(val), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, valInterface any, targetType pgtypes.DoltgresType) (any, error) {
+			val := float32(math.RoundToEven(float64(valInterface.(float32))))
+			if val > 2147483647 || val < -2147483648 {
+				return nil, fmt.Errorf("integer out of range")
+			}
+			return int32(val), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, valInterface any, targetType pgtypes.DoltgresType) (any, error) {
+			val := float32(math.RoundToEven(float64(valInterface.(float32))))
+			if val > 9223372036854775807 || val < -9223372036854775808 {
+				return nil, fmt.Errorf("bigint out of range")
+			}
+			return int64(val), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return decimal.NewFromFloat(float64(val.(float32))), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return strconv.FormatFloat(float64(val.(float32)), 'g', -1, 32), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatFloat(float64(val.(float32)), 'g', -1, 32)
+			return handleCharExplicitCast(str, targetType)
+		},
+	})
+}
+
+// float32Implicit registers all implicit casts. This comprises only the "From" types.
+func float32Implicit() {
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatFloat(float64(val.(float32)), 'g', -1, 32)
+			return handleCharImplicitCast(str, targetType)
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return float64(val.(float32)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, valInterface any, targetType pgtypes.DoltgresType) (any, error) {
+			val := float32(math.RoundToEven(float64(valInterface.(float32))))
+			if val > 32767 || val < -32768 {
+				return nil, fmt.Errorf("smallint out of range")
+			}
+			return int16(val), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, valInterface any, targetType pgtypes.DoltgresType) (any, error) {
+			val := float32(math.RoundToEven(float64(valInterface.(float32))))
+			if val > 2147483647 || val < -2147483648 {
+				return nil, fmt.Errorf("integer out of range")
+			}
+			return int32(val), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, valInterface any, targetType pgtypes.DoltgresType) (any, error) {
+			val := float32(math.RoundToEven(float64(valInterface.(float32))))
+			if val > 9223372036854775807 || val < -9223372036854775808 {
+				return nil, fmt.Errorf("bigint out of range")
+			}
+			return int64(val), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return decimal.NewFromFloat(float64(val.(float32))), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return strconv.FormatFloat(float64(val.(float32)), 'g', -1, 32), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float32,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatFloat(float64(val.(float32)), 'g', -1, 32)
+			return handleCharImplicitCast(str, targetType)
+		},
+	})
+}

--- a/server/cast/float64.go
+++ b/server/cast/float64.go
@@ -1,0 +1,194 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cast
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func init() {
+	float64Explicit()
+	float64Implicit()
+}
+
+// float64Explicit registers all explicit casts. This comprises only the "From" types.
+func float64Explicit() {
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatFloat(val.(float64), 'g', -1, 64)
+			return handleCharExplicitCast(str, targetType)
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return float32(val.(float64)), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, valInterface any, targetType pgtypes.DoltgresType) (any, error) {
+			val := math.RoundToEven(valInterface.(float64))
+			if val > 32767 || val < -32768 {
+				return nil, fmt.Errorf("smallint out of range")
+			}
+			return int16(val), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, valInterface any, targetType pgtypes.DoltgresType) (any, error) {
+			val := math.RoundToEven(valInterface.(float64))
+			if val > 2147483647 || val < -2147483648 {
+				return nil, fmt.Errorf("integer out of range")
+			}
+			return int32(val), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, valInterface any, targetType pgtypes.DoltgresType) (any, error) {
+			val := math.RoundToEven(valInterface.(float64))
+			if val > 9223372036854775807 || val < -9223372036854775808 {
+				return nil, fmt.Errorf("bigint out of range")
+			}
+			return int64(val), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return decimal.NewFromFloat(val.(float64)), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return strconv.FormatFloat(val.(float64), 'g', -1, 64), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatFloat(val.(float64), 'g', -1, 64)
+			return handleCharExplicitCast(str, targetType)
+		},
+	})
+}
+
+// float64Implicit registers all implicit casts. This comprises only the "From" types.
+func float64Implicit() {
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatFloat(val.(float64), 'g', -1, 64)
+			return handleCharImplicitCast(str, targetType)
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return float32(val.(float64)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, valInterface any, targetType pgtypes.DoltgresType) (any, error) {
+			val := math.RoundToEven(valInterface.(float64))
+			if val > 32767 || val < -32768 {
+				return nil, fmt.Errorf("smallint out of range")
+			}
+			return int16(val), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, valInterface any, targetType pgtypes.DoltgresType) (any, error) {
+			val := math.RoundToEven(valInterface.(float64))
+			if val > 2147483647 || val < -2147483648 {
+				return nil, fmt.Errorf("integer out of range")
+			}
+			return int32(val), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, valInterface any, targetType pgtypes.DoltgresType) (any, error) {
+			val := math.RoundToEven(valInterface.(float64))
+			if val > 9223372036854775807 || val < -9223372036854775808 {
+				return nil, fmt.Errorf("bigint out of range")
+			}
+			return int64(val), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return decimal.NewFromFloat(val.(float64)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return strconv.FormatFloat(val.(float64), 'g', -1, 64), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Float64,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatFloat(val.(float64), 'g', -1, 64)
+			return handleCharImplicitCast(str, targetType)
+		},
+	})
+}

--- a/server/cast/int16.go
+++ b/server/cast/int16.go
@@ -1,0 +1,168 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cast
+
+import (
+	"strconv"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func init() {
+	int16Explicit()
+	int16Implicit()
+}
+
+// int16Explicit registers all explicit casts. This comprises only the "From" types.
+func int16Explicit() {
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatInt(int64(val.(int16)), 10)
+			return handleCharExplicitCast(str, targetType)
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return float32(val.(int16)), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return float64(val.(int16)), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return int32(val.(int16)), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return int64(val.(int16)), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return decimal.NewFromInt(int64(val.(int16))), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return strconv.FormatInt(int64(val.(int16)), 10), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatInt(int64(val.(int16)), 10)
+			return handleCharExplicitCast(str, targetType)
+		},
+	})
+}
+
+// int16Implicit registers all implicit casts. This comprises only the "From" types.
+func int16Implicit() {
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatInt(int64(val.(int16)), 10)
+			return handleCharImplicitCast(str, targetType)
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return float32(val.(int16)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return float64(val.(int16)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return int32(val.(int16)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return int64(val.(int16)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return decimal.NewFromInt(int64(val.(int16))), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return strconv.FormatInt(int64(val.(int16)), 10), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatInt(int64(val.(int16)), 10)
+			return handleCharImplicitCast(str, targetType)
+		},
+	})
+}

--- a/server/cast/int32.go
+++ b/server/cast/int32.go
@@ -1,0 +1,175 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cast
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func init() {
+	int32Explicit()
+	int32Implicit()
+}
+
+// int32Explicit registers all explicit casts. This comprises only the "From" types.
+func int32Explicit() {
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatInt(int64(val.(int32)), 10)
+			return handleCharExplicitCast(str, targetType)
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return float32(val.(int32)), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return float64(val.(int32)), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			if val.(int32) > 32767 || val.(int32) < -32768 {
+				return nil, fmt.Errorf("smallint out of range")
+			}
+			return int16(val.(int32)), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return int64(val.(int32)), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return decimal.NewFromInt(int64(val.(int32))), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return strconv.FormatInt(int64(val.(int32)), 10), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatInt(int64(val.(int32)), 10)
+			return handleCharExplicitCast(str, targetType)
+		},
+	})
+}
+
+// int32Implicit registers all implicit casts. This comprises only the "From" types.
+func int32Implicit() {
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatInt(int64(val.(int32)), 10)
+			return handleCharImplicitCast(str, targetType)
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return float32(val.(int32)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return float64(val.(int32)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			if val.(int32) > 32767 || val.(int32) < -32768 {
+				return nil, fmt.Errorf("smallint out of range")
+			}
+			return int16(val.(int32)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return int64(val.(int32)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return decimal.NewFromInt(int64(val.(int32))), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return strconv.FormatInt(int64(val.(int32)), 10), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatInt(int64(val.(int32)), 10)
+			return handleCharImplicitCast(str, targetType)
+		},
+	})
+}

--- a/server/cast/int64.go
+++ b/server/cast/int64.go
@@ -1,0 +1,181 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cast
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func init() {
+	int64Explicit()
+	int64Implicit()
+}
+
+// int64Explicit registers all explicit casts. This comprises only the "From" types.
+func int64Explicit() {
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatInt(val.(int64), 10)
+			return handleCharExplicitCast(str, targetType)
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return float32(val.(int64)), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return float64(val.(int64)), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			if val.(int64) > 32767 || val.(int64) < -32768 {
+				return nil, fmt.Errorf("smallint out of range")
+			}
+			return int16(val.(int64)), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			if val.(int64) > 2147483647 || val.(int64) < -2147483648 {
+				return nil, fmt.Errorf("integer out of range")
+			}
+			return int32(val.(int64)), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return decimal.NewFromInt(val.(int64)), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return strconv.FormatInt(val.(int64), 10), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatInt(val.(int64), 10)
+			return handleCharExplicitCast(str, targetType)
+		},
+	})
+}
+
+// int64Implicit registers all implicit casts. This comprises only the "From" types.
+func int64Implicit() {
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatInt(val.(int64), 10)
+			return handleCharImplicitCast(str, targetType)
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return float32(val.(int64)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return float64(val.(int64)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			if val.(int64) > 32767 || val.(int64) < -32768 {
+				return nil, fmt.Errorf("smallint out of range")
+			}
+			return int16(val.(int64)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			if val.(int64) > 2147483647 || val.(int64) < -2147483648 {
+				return nil, fmt.Errorf("integer out of range")
+			}
+			return int32(val.(int64)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return decimal.NewFromInt(val.(int64)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return strconv.FormatInt(val.(int64), 10), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			str := strconv.FormatInt(val.(int64), 10)
+			return handleCharImplicitCast(str, targetType)
+		},
+	})
+}

--- a/server/cast/numeric.go
+++ b/server/cast/numeric.go
@@ -1,0 +1,192 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cast
+
+import (
+	"fmt"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func init() {
+	numericExplicit()
+	numericImplicit()
+}
+
+// numericExplicit registers all explicit casts. This comprises only the "From" types.
+func numericExplicit() {
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharExplicitCast(val.(decimal.Decimal).String(), targetType)
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			f, _ := val.(decimal.Decimal).Float64()
+			return float32(f), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			f, _ := val.(decimal.Decimal).Float64()
+			return f, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			d := val.(decimal.Decimal)
+			if d.LessThan(pgtypes.NumericValueMinInt16) || d.GreaterThan(pgtypes.NumericValueMaxInt16) {
+				return nil, fmt.Errorf("smallint out of range")
+			}
+			return int16(d.IntPart()), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			d := val.(decimal.Decimal)
+			if d.LessThan(pgtypes.NumericValueMinInt32) || d.GreaterThan(pgtypes.NumericValueMaxInt32) {
+				return nil, fmt.Errorf("integer out of range")
+			}
+			return int32(d.IntPart()), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			d := val.(decimal.Decimal)
+			if d.LessThan(pgtypes.NumericValueMinInt64) || d.GreaterThan(pgtypes.NumericValueMaxInt64) {
+				return nil, fmt.Errorf("bigint out of range")
+			}
+			return int64(d.IntPart()), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val.(decimal.Decimal).String(), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharExplicitCast(val.(decimal.Decimal).String(), targetType)
+		},
+	})
+}
+
+// numericImplicit registers all implicit casts. This comprises only the "From" types.
+func numericImplicit() {
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharImplicitCast(val.(decimal.Decimal).String(), targetType)
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			f, _ := val.(decimal.Decimal).Float64()
+			return float32(f), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			f, _ := val.(decimal.Decimal).Float64()
+			return f, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			d := val.(decimal.Decimal)
+			if d.LessThan(pgtypes.NumericValueMinInt16) || d.GreaterThan(pgtypes.NumericValueMaxInt16) {
+				return nil, fmt.Errorf("smallint out of range")
+			}
+			return int16(d.IntPart()), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			d := val.(decimal.Decimal)
+			if d.LessThan(pgtypes.NumericValueMinInt32) || d.GreaterThan(pgtypes.NumericValueMaxInt32) {
+				return nil, fmt.Errorf("integer out of range")
+			}
+			return int32(d.IntPart()), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			d := val.(decimal.Decimal)
+			if d.LessThan(pgtypes.NumericValueMinInt64) || d.GreaterThan(pgtypes.NumericValueMaxInt64) {
+				return nil, fmt.Errorf("bigint out of range")
+			}
+			return int64(d.IntPart()), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val.(decimal.Decimal).String(), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Numeric,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharImplicitCast(val.(decimal.Decimal).String(), targetType)
+		},
+	})
+}

--- a/server/cast/text.go
+++ b/server/cast/text.go
@@ -1,0 +1,300 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cast
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/dolthub/doltgresql/postgres/parser/uuid"
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func init() {
+	textExplicit()
+	textImplicit()
+}
+
+// textExplicit registers all explicit casts. This comprises only the "From" types.
+func textExplicit() {
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Bool,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			switch strings.TrimSpace(strings.ToLower(val.(string))) {
+			case "true", "y", "ye", "yes", "on", "1", "t":
+				return true, nil
+			case "false", "n", "no", "off", "0", "f":
+				return false, nil
+			default:
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val)
+			}
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharExplicitCast(val.(string), targetType)
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Bytea,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			if strings.HasPrefix(val.(string), `\x`) {
+				return hex.DecodeString(val.(string)[2:])
+			} else {
+				return []byte(val.(string)), nil
+			}
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseFloat(strings.TrimSpace(val.(string)), 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return float32(out), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseFloat(strings.TrimSpace(val.(string)), 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return out, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			if out > 32767 || out < -32768 {
+				return nil, fmt.Errorf("value %q is out of range for type %s", val.(string), targetType.String())
+			}
+			return int16(out), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			if out > 2147483647 || out < -2147483648 {
+				return nil, fmt.Errorf("value %q is out of range for type %s", val.(string), targetType.String())
+			}
+			return int32(out), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return out, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			d, err := decimal.NewFromString(strings.TrimSpace(val.(string)))
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return d, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Uuid,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			u, err := uuid.FromString(strings.TrimSpace(val.(string)))
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return u, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharExplicitCast(val.(string), targetType)
+		},
+	})
+}
+
+// textImplicit registers all implicit casts. This comprises only the "From" types.
+func textImplicit() {
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Bool,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			switch strings.TrimSpace(strings.ToLower(val.(string))) {
+			case "true", "y", "ye", "yes", "on", "1", "t":
+				return true, nil
+			case "false", "n", "no", "off", "0", "f":
+				return false, nil
+			default:
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val)
+			}
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharImplicitCast(val.(string), targetType)
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Bytea,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			if strings.HasPrefix(val.(string), `\x`) {
+				return hex.DecodeString(val.(string)[2:])
+			} else {
+				return []byte(val.(string)), nil
+			}
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseFloat(strings.TrimSpace(val.(string)), 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return float32(out), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseFloat(strings.TrimSpace(val.(string)), 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return out, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			if out > 32767 || out < -32768 {
+				return nil, fmt.Errorf("value %q is out of range for type %s", val.(string), targetType.String())
+			}
+			return int16(out), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			if out > 2147483647 || out < -2147483648 {
+				return nil, fmt.Errorf("value %q is out of range for type %s", val.(string), targetType.String())
+			}
+			return int32(out), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return out, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			d, err := decimal.NewFromString(strings.TrimSpace(val.(string)))
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return d, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.Uuid,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			u, err := uuid.FromString(strings.TrimSpace(val.(string)))
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return u, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Text,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharImplicitCast(val.(string), targetType)
+		},
+	})
+}

--- a/server/cast/utils.go
+++ b/server/cast/utils.go
@@ -1,0 +1,89 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cast
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// handleCharExplicitCast handles explicit casts to Char and VarChar types. Returns an error if other types are passed in.
+func handleCharExplicitCast(str string, targetType pgtypes.DoltgresType) (string, error) {
+	switch targetType := targetType.(type) {
+	case pgtypes.CharType:
+		if targetType.IsUnbounded() {
+			return str, nil
+		}
+		str, runeCount := truncateString(str, targetType.Length)
+		if runeCount < targetType.Length {
+			return str + strings.Repeat(" ", int(targetType.Length-runeCount)), nil
+		}
+		return str, nil
+	case pgtypes.VarCharType:
+		if targetType.IsUnbounded() {
+			return str, nil
+		}
+		str, _ = truncateString(str, targetType.Length)
+		return str, nil
+	default:
+		return "", fmt.Errorf("explicit cast called to handle non-char type")
+	}
+}
+
+// handleCharImplicitCast handles implicit casts to Char and VarChar types. Returns an error if other types are passed in.
+func handleCharImplicitCast(str string, targetType pgtypes.DoltgresType) (string, error) {
+	switch targetType := targetType.(type) {
+	case pgtypes.CharType:
+		if targetType.IsUnbounded() {
+			return str, nil
+		} else {
+			runeLength := uint32(utf8.RuneCountInString(str))
+			if runeLength > targetType.Length {
+				return "", fmt.Errorf("value too long for type %s", targetType.String())
+			} else if runeLength < targetType.Length {
+				return str + strings.Repeat(" ", int(targetType.Length-runeLength)), nil
+			} else {
+				return str, nil
+			}
+		}
+	case pgtypes.VarCharType:
+		if !targetType.IsUnbounded() && uint32(utf8.RuneCountInString(str)) > targetType.Length {
+			return "", fmt.Errorf("value too long for type %s", targetType.String())
+		} else {
+			return str, nil
+		}
+	default:
+		return "", fmt.Errorf("implicit cast called to handle non-char type")
+	}
+}
+
+// truncateString returns a string that has been truncated to the given length. Uses the rune count rather than the
+// byte count. Returns the input string if it's smaller than the length. Also returns the rune count of the string.
+func truncateString(val string, runeLimit uint32) (string, uint32) {
+	runeLength := uint32(utf8.RuneCountInString(val))
+	if runeLength > runeLimit {
+		// TODO: figure out if there's a faster way to truncate based on rune count
+		startString := val
+		for i := uint32(0); i < runeLimit; i++ {
+			_, size := utf8.DecodeRuneInString(val)
+			val = val[size:]
+		}
+		return startString[:len(startString)-len(val)], runeLimit
+	}
+	return val, runeLength
+}

--- a/server/cast/uuid.go
+++ b/server/cast/uuid.go
@@ -1,0 +1,91 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cast
+
+import (
+	"github.com/dolthub/doltgresql/postgres/parser/uuid"
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func init() {
+	uuidExplicit()
+	uuidImplicit()
+}
+
+// uuidExplicit registers all explicit casts. This comprises only the "From" types.
+func uuidExplicit() {
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Uuid,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharExplicitCast(val.(uuid.UUID).String(), targetType)
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Uuid,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val.(uuid.UUID).String(), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Uuid,
+		ToType:   pgtypes.Uuid,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Uuid,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharExplicitCast(val.(uuid.UUID).String(), targetType)
+		},
+	})
+}
+
+// uuidImplicit registers all implicit casts. This comprises only the "From" types.
+func uuidImplicit() {
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Uuid,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharImplicitCast(val.(uuid.UUID).String(), targetType)
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Uuid,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val.(uuid.UUID).String(), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Uuid,
+		ToType:   pgtypes.Uuid,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Uuid,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharImplicitCast(val.(uuid.UUID).String(), targetType)
+		},
+	})
+}

--- a/server/cast/varchar.go
+++ b/server/cast/varchar.go
@@ -1,0 +1,300 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cast
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/dolthub/doltgresql/postgres/parser/uuid"
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func init() {
+	varcharExplicit()
+	varcharImplicit()
+}
+
+// varcharExplicit registers all explicit casts. This comprises only the "From" types.
+func varcharExplicit() {
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Bool,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			switch strings.TrimSpace(strings.ToLower(val.(string))) {
+			case "true", "y", "ye", "yes", "on", "1", "t":
+				return true, nil
+			case "false", "n", "no", "off", "0", "f":
+				return false, nil
+			default:
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val)
+			}
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharExplicitCast(val.(string), targetType)
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Bytea,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			if strings.HasPrefix(val.(string), `\x`) {
+				return hex.DecodeString(val.(string)[2:])
+			} else {
+				return []byte(val.(string)), nil
+			}
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseFloat(strings.TrimSpace(val.(string)), 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return float32(out), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseFloat(strings.TrimSpace(val.(string)), 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return out, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			if out > 32767 || out < -32768 {
+				return nil, fmt.Errorf("value %q is out of range for type %s", val.(string), targetType.String())
+			}
+			return int16(out), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			if out > 2147483647 || out < -2147483648 {
+				return nil, fmt.Errorf("value %q is out of range for type %s", val.(string), targetType.String())
+			}
+			return int32(out), nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return out, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			d, err := decimal.NewFromString(strings.TrimSpace(val.(string)))
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return d, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Uuid,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			u, err := uuid.FromString(strings.TrimSpace(val.(string)))
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return u, nil
+		},
+	})
+	framework.MustAddExplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharExplicitCast(val.(string), targetType)
+		},
+	})
+}
+
+// varcharImplicit registers all implicit casts. This comprises only the "From" types.
+func varcharImplicit() {
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Bool,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			switch strings.TrimSpace(strings.ToLower(val.(string))) {
+			case "true", "y", "ye", "yes", "on", "1", "t":
+				return true, nil
+			case "false", "n", "no", "off", "0", "f":
+				return false, nil
+			default:
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val)
+			}
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.BpChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharImplicitCast(val.(string), targetType)
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Bytea,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			if strings.HasPrefix(val.(string), `\x`) {
+				return hex.DecodeString(val.(string)[2:])
+			} else {
+				return []byte(val.(string)), nil
+			}
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Float32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseFloat(strings.TrimSpace(val.(string)), 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return float32(out), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Float64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseFloat(strings.TrimSpace(val.(string)), 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return out, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Int16,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			if out > 32767 || out < -32768 {
+				return nil, fmt.Errorf("value %q is out of range for type %s", val.(string), targetType.String())
+			}
+			return int16(out), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Int32,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			if out > 2147483647 || out < -2147483648 {
+				return nil, fmt.Errorf("value %q is out of range for type %s", val.(string), targetType.String())
+			}
+			return int32(out), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Int64,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return out, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Numeric,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			d, err := decimal.NewFromString(strings.TrimSpace(val.(string)))
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return d, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Text,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return val, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.Uuid,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			u, err := uuid.FromString(strings.TrimSpace(val.(string)))
+			if err != nil {
+				return nil, fmt.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+			}
+			return u, nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.VarChar,
+		ToType:   pgtypes.VarChar,
+		Function: func(ctx framework.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return handleCharImplicitCast(val.(string), targetType)
+		},
+	})
+}

--- a/server/expression/cast.go
+++ b/server/expression/cast.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dolthub/vitess/go/vt/proto/query"
 	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
 
+	_ "github.com/dolthub/doltgresql/server/cast"
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
@@ -122,15 +123,9 @@ func (c *Cast) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 			}
 		case query.Type_DATE, query.Type_DATETIME, query.Type_TIMESTAMP:
 			return nil, fmt.Errorf("need to add DoltgresType equivalents to DATETIME")
-		case query.Type_CHAR, query.Type_VARCHAR:
-			fromType = pgtypes.VarChar
-			val, _, err = pgtypes.VarChar.Convert(val)
-			if err != nil {
-				return nil, err
-			}
-		case query.Type_TEXT:
-			fromType = pgtypes.VarChar
-			val, _, err = pgtypes.VarChar.Convert(val)
+		case query.Type_CHAR, query.Type_VARCHAR, query.Type_TEXT:
+			fromType = pgtypes.Text
+			val, _, err = pgtypes.Text.Convert(val)
 			if err != nil {
 				return nil, err
 			}
@@ -152,11 +147,11 @@ func (c *Cast) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 			return nil, fmt.Errorf("encountered a GMS type that cannot be handled")
 		}
 	}
-	castFunction := framework.GetCast(fromType.BaseID(), c.castToType.BaseID())
+	castFunction := framework.GetExplicitCast(fromType.BaseID(), c.castToType.BaseID())
 	if castFunction == nil {
 		return nil, fmt.Errorf("cast from `%s` to `%s` does not exist", fromType.String(), c.castToType.String())
 	}
-	return castFunction(framework.Context{Context: ctx}, val)
+	return castFunction(framework.Context{Context: ctx}, val, c.castToType)
 }
 
 // IsNullable implements the sql.Expression interface.

--- a/server/expression/literal.go
+++ b/server/expression/literal.go
@@ -79,11 +79,11 @@ func NewIntegerLiteral(integerValue string) (*Literal, error) {
 	}
 }
 
-// NewStringLiteral returns a new *Literal containing a VARCHAR value.
+// NewStringLiteral returns a new *Literal containing a TEXT value.
 func NewStringLiteral(stringValue string) (*Literal, error) {
 	return &Literal{
 		value: stringValue,
-		typ:   pgtypes.VarChar,
+		typ:   pgtypes.Text,
 	}, nil
 }
 
@@ -125,19 +125,19 @@ func (l *Literal) String() string {
 // equivalent functionality should be built into Doltgres (recommend the second approach).
 func (l *Literal) ToVitessLiteral() *vitess.SQLVal {
 	switch l.typ.BaseID() {
-	case pgtypes.Bool.BaseID():
+	case pgtypes.DoltgresTypeBaseID_Bool:
 		if l.value.(bool) {
 			return vitess.NewIntVal([]byte("1"))
 		} else {
 			return vitess.NewIntVal([]byte("0"))
 		}
-	case pgtypes.Int32.BaseID():
+	case pgtypes.DoltgresTypeBaseID_Int32:
 		return vitess.NewIntVal([]byte(strconv.FormatInt(int64(l.value.(int32)), 10)))
-	case pgtypes.Int64.BaseID():
+	case pgtypes.DoltgresTypeBaseID_Int64:
 		return vitess.NewIntVal([]byte(strconv.FormatInt(l.value.(int64), 10)))
-	case pgtypes.Numeric.BaseID():
+	case pgtypes.DoltgresTypeBaseID_Numeric:
 		return vitess.NewFloatVal([]byte(l.value.(decimal.Decimal).String()))
-	case pgtypes.VarChar.BaseID():
+	case pgtypes.DoltgresTypeBaseID_Text:
 		return vitess.NewStrVal([]byte(l.value.(string)))
 	default:
 		panic("unhandled type in temporary literal conversion: " + l.typ.String())

--- a/server/functions/framework/cast.go
+++ b/server/functions/framework/cast.go
@@ -16,20 +16,16 @@ package framework
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 	"sync"
 
-	"github.com/shopspring/decimal"
-
-	"github.com/dolthub/doltgresql/postgres/parser/uuid"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
 // TODO: Right now, all casts are global. We should decide how to handle this in the presence of branches, sessions, etc.
 
 // TypeCastFunction is a function that takes a value of a particular kind of type, and returns it as another kind of type.
-type TypeCastFunction func(ctx Context, val any) (any, error)
+// The targetType given should match the "To" type used to obtain the cast.
+type TypeCastFunction func(ctx Context, val any, targetType pgtypes.DoltgresType) (any, error)
 
 // TypeCast is used to cast from one type to another.
 type TypeCast struct {
@@ -38,60 +34,109 @@ type TypeCast struct {
 	Function TypeCastFunction
 }
 
-// typeCastMutex is used to lock the type cast map and array when writing.
-var typeCastMutex = &sync.RWMutex{}
+// explicitTypeCastMutex is used to lock the explicit type cast map and array when writing.
+var explicitTypeCastMutex = &sync.RWMutex{}
 
-// typeCastsMap is a map that maps: from -> to -> function.
-var typeCastsMap = map[pgtypes.DoltgresTypeBaseID]map[pgtypes.DoltgresTypeBaseID]TypeCastFunction{}
+// explicitTypeCastsMap is a map that maps: from -> to -> function.
+var explicitTypeCastsMap = map[pgtypes.DoltgresTypeBaseID]map[pgtypes.DoltgresTypeBaseID]TypeCastFunction{}
 
-// typeCastsArray is a slice that holds all registered casts from the given type.
-var typeCastsArray = map[pgtypes.DoltgresTypeBaseID][]pgtypes.DoltgresType{}
+// explicitTypeCastsArray is a slice that holds all registered explicit casts from the given type.
+var explicitTypeCastsArray = map[pgtypes.DoltgresTypeBaseID][]pgtypes.DoltgresType{}
 
-// AddTypeCast registers the given type cast.
-func AddTypeCast(cast TypeCast) error {
-	typeCastMutex.Lock()
-	defer typeCastMutex.Unlock()
+// implicitTypeCastMutex is used to lock the implicit type cast map and array when writing.
+var implicitTypeCastMutex = &sync.RWMutex{}
 
-	toMap, ok := typeCastsMap[cast.FromType.BaseID()]
+// implicitTypeCastsMap is a map that maps: from -> to -> function.
+var implicitTypeCastsMap = map[pgtypes.DoltgresTypeBaseID]map[pgtypes.DoltgresTypeBaseID]TypeCastFunction{}
+
+// implicitTypeCastsArray is a slice that holds all registered implicit casts from the given type.
+var implicitTypeCastsArray = map[pgtypes.DoltgresTypeBaseID][]pgtypes.DoltgresType{}
+
+// AddExplicitTypeCast registers the given explicit type cast.
+func AddExplicitTypeCast(cast TypeCast) error {
+	return addTypeCast(explicitTypeCastMutex, explicitTypeCastsMap, explicitTypeCastsArray, cast)
+}
+
+// AddImplicitTypeCast registers the given implicit type cast.
+func AddImplicitTypeCast(cast TypeCast) error {
+	return addTypeCast(implicitTypeCastMutex, implicitTypeCastsMap, implicitTypeCastsArray, cast)
+}
+
+// MustAddExplicitTypeCast registers the given explicit type cast. Panics if an error occurs.
+func MustAddExplicitTypeCast(cast TypeCast) {
+	if err := AddExplicitTypeCast(cast); err != nil {
+		panic(err)
+	}
+}
+
+// MustAddImplicitTypeCast registers the given implicit type cast. Panics if an error occurs.
+func MustAddImplicitTypeCast(cast TypeCast) {
+	if err := AddImplicitTypeCast(cast); err != nil {
+		panic(err)
+	}
+}
+
+// GetPotentialExplicitCasts returns all registered explicit type casts from the given type.
+func GetPotentialExplicitCasts(fromType pgtypes.DoltgresTypeBaseID) []pgtypes.DoltgresType {
+	return getPotentialCasts(explicitTypeCastMutex, explicitTypeCastsArray, fromType)
+}
+
+// GetPotentialImplicitCasts returns all registered implicit type casts from the given type.
+func GetPotentialImplicitCasts(fromType pgtypes.DoltgresTypeBaseID) []pgtypes.DoltgresType {
+	return getPotentialCasts(implicitTypeCastMutex, implicitTypeCastsArray, fromType)
+}
+
+// GetExplicitCast returns the explicit type cast function that will cast the "from" type to the "to" type. Returns nil
+// if such a cast is not valid.
+func GetExplicitCast(fromType pgtypes.DoltgresTypeBaseID, toType pgtypes.DoltgresTypeBaseID) TypeCastFunction {
+	return getCast(explicitTypeCastMutex, explicitTypeCastsMap, fromType, toType)
+}
+
+// GetImplicitCast returns the implicit type cast function that will cast the "from" type to the "to" type. Returns nil
+// if such a cast is not valid.
+func GetImplicitCast(fromType pgtypes.DoltgresTypeBaseID, toType pgtypes.DoltgresTypeBaseID) TypeCastFunction {
+	return getCast(implicitTypeCastMutex, implicitTypeCastsMap, fromType, toType)
+}
+
+// addTypeCast registers the given type cast.
+func addTypeCast(mutex *sync.RWMutex,
+	castMap map[pgtypes.DoltgresTypeBaseID]map[pgtypes.DoltgresTypeBaseID]TypeCastFunction,
+	castArray map[pgtypes.DoltgresTypeBaseID][]pgtypes.DoltgresType, cast TypeCast) error {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	toMap, ok := castMap[cast.FromType.BaseID()]
 	if !ok {
 		toMap = map[pgtypes.DoltgresTypeBaseID]TypeCastFunction{}
-		typeCastsMap[cast.FromType.BaseID()] = toMap
-		typeCastsArray[cast.FromType.BaseID()] = nil
+		castMap[cast.FromType.BaseID()] = toMap
+		castArray[cast.FromType.BaseID()] = nil
 	}
 	if _, ok := toMap[cast.ToType.BaseID()]; ok {
 		// TODO: return the actual Postgres error
 		return fmt.Errorf("cast from `%s` to `%s` already exists", cast.FromType.String(), cast.ToType.String())
 	}
 	toMap[cast.ToType.BaseID()] = cast.Function
-	typeCastsArray[cast.FromType.BaseID()] = append(typeCastsArray[cast.FromType.BaseID()], cast.ToType)
+	castArray[cast.FromType.BaseID()] = append(castArray[cast.FromType.BaseID()], cast.ToType)
 	return nil
 }
 
-// MustAddTypeCast registers the given type cast. Panics if an error occurs.
-func MustAddTypeCast(cast TypeCast) {
-	if err := AddTypeCast(cast); err != nil {
-		panic(err)
-	}
+// getPotentialCasts returns all registered type casts from the given type.
+func getPotentialCasts(mutex *sync.RWMutex, castArray map[pgtypes.DoltgresTypeBaseID][]pgtypes.DoltgresType, fromType pgtypes.DoltgresTypeBaseID) []pgtypes.DoltgresType {
+	mutex.RLock()
+	defer mutex.RUnlock()
+
+	return castArray[fromType]
 }
 
-// GetPotentialCasts returns all registered type casts from the given type.
-func GetPotentialCasts(fromType pgtypes.DoltgresTypeBaseID) []pgtypes.DoltgresType {
-	typeCastMutex.RLock()
-	defer typeCastMutex.RUnlock()
-
-	return typeCastsArray[fromType]
-}
-
-// GetCast returns the type cast function that will cast the "from" type to the "to" type. Returns nil if such a cast is
+// getCast returns the type cast function that will cast the "from" type to the "to" type. Returns nil if such a cast is
 // not valid.
-func GetCast(fromType pgtypes.DoltgresTypeBaseID, toType pgtypes.DoltgresTypeBaseID) TypeCastFunction {
-	typeCastMutex.RLock()
-	defer typeCastMutex.RUnlock()
+func getCast(mutex *sync.RWMutex,
+	castMap map[pgtypes.DoltgresTypeBaseID]map[pgtypes.DoltgresTypeBaseID]TypeCastFunction,
+	fromType pgtypes.DoltgresTypeBaseID, toType pgtypes.DoltgresTypeBaseID) TypeCastFunction {
+	mutex.RLock()
+	defer mutex.RUnlock()
 
-	if fromType == toType {
-		return identityCast
-	}
-	if toMap, ok := typeCastsMap[fromType]; ok {
+	if toMap, ok := castMap[fromType]; ok {
 		if f, ok := toMap[toType]; ok {
 			return f
 		}
@@ -100,10 +145,10 @@ func GetCast(fromType pgtypes.DoltgresTypeBaseID, toType pgtypes.DoltgresTypeBas
 	// As long as the base types are convertable, the array variants are also convertable.
 	if fromArrayType, ok := pgtypes.IsBaseIDArrayType(fromType); ok {
 		if toArrayType, ok := pgtypes.IsBaseIDArrayType(toType); ok {
-			if toMap, ok := typeCastsMap[fromArrayType.BaseType().BaseID()]; ok {
+			if toMap, ok := castMap[fromArrayType.BaseType().BaseID()]; ok {
 				if f, ok := toMap[toArrayType.BaseType().BaseID()]; ok {
 					// We use a closure that can unwrap the slice, since conversion functions expect a singular non-nil value
-					return func(ctx Context, vals any) (any, error) {
+					return func(ctx Context, vals any, targetType pgtypes.DoltgresType) (any, error) {
 						var err error
 						oldVals := vals.([]any)
 						newVals := make([]any, len(oldVals))
@@ -111,7 +156,7 @@ func GetCast(fromType pgtypes.DoltgresTypeBaseID, toType pgtypes.DoltgresTypeBas
 							if oldVal == nil {
 								continue
 							}
-							newVals[i], err = f(ctx, oldVal)
+							newVals[i], err = f(ctx, oldVal, targetType.(pgtypes.DoltgresArrayType).BaseType())
 							if err != nil {
 								return nil, err
 							}
@@ -123,378 +168,4 @@ func GetCast(fromType pgtypes.DoltgresTypeBaseID, toType pgtypes.DoltgresTypeBas
 		}
 	}
 	return nil
-}
-
-// GetIdentityCast returns the identity cast function.
-func GetIdentityCast() TypeCastFunction {
-	return identityCast
-}
-
-func init() {
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Float32,
-		ToType:   pgtypes.Float64,
-		Function: func(ctx Context, val any) (any, error) {
-			return float64(val.(float32)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Float32,
-		ToType:   pgtypes.Int16,
-		Function: func(ctx Context, val any) (any, error) {
-			if val.(float32) > 32767 || val.(float32) < -32768 {
-				return nil, fmt.Errorf("smallint out of range")
-			}
-			return int16(val.(float32)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Float32,
-		ToType:   pgtypes.Int32,
-		Function: func(ctx Context, val any) (any, error) {
-			if val.(float32) > 2147483647 || val.(float32) < -2147483648 {
-				return nil, fmt.Errorf("integer out of range")
-			}
-			return int32(val.(float32)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Float32,
-		ToType:   pgtypes.Int64,
-		Function: func(ctx Context, val any) (any, error) {
-			if val.(float32) > 9223372036854775807 || val.(float32) < -9223372036854775808 {
-				return nil, fmt.Errorf("bigint out of range")
-			}
-			return int64(val.(float32)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Float32,
-		ToType:   pgtypes.Numeric,
-		Function: func(ctx Context, val any) (any, error) {
-			return decimal.NewFromFloat(float64(val.(float32))), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Float32,
-		ToType:   pgtypes.VarChar,
-		Function: func(ctx Context, val any) (any, error) {
-			return strconv.FormatFloat(float64(val.(float32)), 'g', -1, 32), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Float64,
-		ToType:   pgtypes.Float32,
-		Function: func(ctx Context, val any) (any, error) {
-			return float32(val.(float64)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Float64,
-		ToType:   pgtypes.Int16,
-		Function: func(ctx Context, val any) (any, error) {
-			if val.(float64) > 32767 || val.(float64) < -32768 {
-				return nil, fmt.Errorf("smallint out of range")
-			}
-			return int16(val.(float64)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Float64,
-		ToType:   pgtypes.Int32,
-		Function: func(ctx Context, val any) (any, error) {
-			if val.(float64) > 2147483647 || val.(float64) < -2147483648 {
-				return nil, fmt.Errorf("integer out of range")
-			}
-			return int32(val.(float64)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Float64,
-		ToType:   pgtypes.Int64,
-		Function: func(ctx Context, val any) (any, error) {
-			if val.(float64) > 9223372036854775807 || val.(float64) < -9223372036854775808 {
-				return nil, fmt.Errorf("bigint out of range")
-			}
-			return int64(val.(float64)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Float64,
-		ToType:   pgtypes.Numeric,
-		Function: func(ctx Context, val any) (any, error) {
-			return decimal.NewFromFloat(val.(float64)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Float64,
-		ToType:   pgtypes.VarChar,
-		Function: func(ctx Context, val any) (any, error) {
-			return strconv.FormatFloat(val.(float64), 'g', -1, 64), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int16,
-		ToType:   pgtypes.Float32,
-		Function: func(ctx Context, val any) (any, error) {
-			return float32(val.(int16)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int16,
-		ToType:   pgtypes.Float64,
-		Function: func(ctx Context, val any) (any, error) {
-			return float64(val.(int16)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int16,
-		ToType:   pgtypes.Int32,
-		Function: func(ctx Context, val any) (any, error) {
-			return int32(val.(int16)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int16,
-		ToType:   pgtypes.Int64,
-		Function: func(ctx Context, val any) (any, error) {
-			return int64(val.(int16)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int16,
-		ToType:   pgtypes.Numeric,
-		Function: func(ctx Context, val any) (any, error) {
-			return decimal.NewFromInt(int64(val.(int16))), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int16,
-		ToType:   pgtypes.VarChar,
-		Function: func(ctx Context, val any) (any, error) {
-			return strconv.FormatInt(int64(val.(int16)), 10), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int32,
-		ToType:   pgtypes.Float32,
-		Function: func(ctx Context, val any) (any, error) {
-			return float32(val.(int32)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int32,
-		ToType:   pgtypes.Float64,
-		Function: func(ctx Context, val any) (any, error) {
-			return float64(val.(int32)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int32,
-		ToType:   pgtypes.Int16,
-		Function: func(ctx Context, val any) (any, error) {
-			if val.(int32) > 32767 || val.(int32) < -32768 {
-				return nil, fmt.Errorf("smallint out of range")
-			}
-			return int16(val.(int32)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int32,
-		ToType:   pgtypes.Int64,
-		Function: func(ctx Context, val any) (any, error) {
-			return int64(val.(int32)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int32,
-		ToType:   pgtypes.Numeric,
-		Function: func(ctx Context, val any) (any, error) {
-			return decimal.NewFromInt(int64(val.(int32))), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int32,
-		ToType:   pgtypes.VarChar,
-		Function: func(ctx Context, val any) (any, error) {
-			return strconv.FormatInt(int64(val.(int32)), 10), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int64,
-		ToType:   pgtypes.Float32,
-		Function: func(ctx Context, val any) (any, error) {
-			return float32(val.(int64)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int64,
-		ToType:   pgtypes.Float64,
-		Function: func(ctx Context, val any) (any, error) {
-			return float64(val.(int64)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int64,
-		ToType:   pgtypes.Int16,
-		Function: func(ctx Context, val any) (any, error) {
-			if val.(int64) > 32767 || val.(int64) < -32768 {
-				return nil, fmt.Errorf("smallint out of range")
-			}
-			return int16(val.(int64)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int64,
-		ToType:   pgtypes.Int32,
-		Function: func(ctx Context, val any) (any, error) {
-			if val.(int64) > 2147483647 || val.(int64) < -2147483648 {
-				return nil, fmt.Errorf("integer out of range")
-			}
-			return int32(val.(int64)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int64,
-		ToType:   pgtypes.Numeric,
-		Function: func(ctx Context, val any) (any, error) {
-			return decimal.NewFromInt(val.(int64)), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Int64,
-		ToType:   pgtypes.VarChar,
-		Function: func(ctx Context, val any) (any, error) {
-			return strconv.FormatInt(val.(int64), 10), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Numeric,
-		ToType:   pgtypes.Float32,
-		Function: func(ctx Context, val any) (any, error) {
-			f, _ := val.(decimal.Decimal).Float64()
-			return float32(f), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Numeric,
-		ToType:   pgtypes.Float64,
-		Function: func(ctx Context, val any) (any, error) {
-			f, _ := val.(decimal.Decimal).Float64()
-			return f, nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Numeric,
-		ToType:   pgtypes.Int16,
-		Function: func(ctx Context, val any) (any, error) {
-			d := val.(decimal.Decimal)
-			if d.LessThan(pgtypes.NumericValueMinInt16) || d.GreaterThan(pgtypes.NumericValueMaxInt16) {
-				return nil, fmt.Errorf("smallint out of range")
-			}
-			return int16(d.IntPart()), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Numeric,
-		ToType:   pgtypes.Int32,
-		Function: func(ctx Context, val any) (any, error) {
-			d := val.(decimal.Decimal)
-			if d.LessThan(pgtypes.NumericValueMinInt32) || d.GreaterThan(pgtypes.NumericValueMaxInt32) {
-				return nil, fmt.Errorf("integer out of range")
-			}
-			return int32(d.IntPart()), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Numeric,
-		ToType:   pgtypes.Int64,
-		Function: func(ctx Context, val any) (any, error) {
-			d := val.(decimal.Decimal)
-			if d.LessThan(pgtypes.NumericValueMinInt64) || d.GreaterThan(pgtypes.NumericValueMaxInt64) {
-				return nil, fmt.Errorf("bigint out of range")
-			}
-			return int64(d.IntPart()), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.Numeric,
-		ToType:   pgtypes.VarChar,
-		Function: func(ctx Context, val any) (any, error) {
-			return val.(decimal.Decimal).String(), nil
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.VarChar,
-		ToType:   pgtypes.Bool,
-		Function: func(ctx Context, val any) (any, error) {
-			lowerVal := strings.TrimSpace(strings.ToLower(val.(string)))
-			if lowerVal == "true" || lowerVal == "yes" || lowerVal == "on" || lowerVal == "1" {
-				return true, nil
-			} else if lowerVal == "false" || lowerVal == "no" || lowerVal == "off" || lowerVal == "0" {
-				return false, nil
-			} else {
-				return nil, fmt.Errorf("invalid string value for boolean: %q", val)
-			}
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.VarChar,
-		ToType:   pgtypes.Float32,
-		Function: func(ctx Context, val any) (any, error) {
-			out, err := strconv.ParseFloat(val.(string), 32)
-			return float32(out), err
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.VarChar,
-		ToType:   pgtypes.Float64,
-		Function: func(ctx Context, val any) (any, error) {
-			out, err := strconv.ParseFloat(val.(string), 64)
-			return out, err
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.VarChar,
-		ToType:   pgtypes.Int16,
-		Function: func(ctx Context, val any) (any, error) {
-			out, err := strconv.ParseInt(val.(string), 10, 16)
-			return int16(out), err
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.VarChar,
-		ToType:   pgtypes.Int32,
-		Function: func(ctx Context, val any) (any, error) {
-			out, err := strconv.ParseInt(val.(string), 10, 32)
-			return int32(out), err
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.VarChar,
-		ToType:   pgtypes.Int64,
-		Function: func(ctx Context, val any) (any, error) {
-			out, err := strconv.ParseInt(val.(string), 10, 64)
-			return out, err
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.VarChar,
-		ToType:   pgtypes.Numeric,
-		Function: func(ctx Context, val any) (any, error) {
-			return decimal.NewFromString(val.(string))
-		},
-	})
-	MustAddTypeCast(TypeCast{
-		FromType: pgtypes.VarChar,
-		ToType:   pgtypes.Uuid,
-		Function: func(ctx Context, val any) (any, error) {
-			return uuid.FromString(val.(string))
-		},
-	})
-}
-
-// identityCast simply returns the input.
-func identityCast(ctx Context, val any) (any, error) {
-	return val, nil
 }

--- a/server/functions/framework/compiled_function.go
+++ b/server/functions/framework/compiled_function.go
@@ -85,18 +85,15 @@ func (c *CompiledFunction) OverloadString(types []pgtypes.DoltgresType) string {
 // Type implements the interface sql.Expression.
 func (c *CompiledFunction) Type() sql.Type {
 	parameters := c.possibleParameterTypes()
-	// resolveByType takes a slice of result types, so we need to create them here even though they're not used
-	resultTypes := make([]pgtypes.DoltgresType, len(parameters))
-	copy(resultTypes, parameters)
 	sources := make([]Source, len(parameters))
 	for i := range sources {
 		sources[i] = Source_Constant
 	}
-	if resolvedFunction := c.Functions.resolveByType(parameters, resultTypes, sources); resolvedFunction != nil {
+	if resolvedFunction := c.Functions.resolveByType(parameters, sources); resolvedFunction != nil {
 		return resolvedFunction.Function.GetReturn()
 	}
 	// We can't resolve to a function before evaluation in this case, so we'll return something arbitrary
-	return pgtypes.VarChar
+	return pgtypes.Unknown
 }
 
 // IsNullable implements the interface sql.Expression.
@@ -112,11 +109,7 @@ func (c *CompiledFunction) Eval(ctx *sql.Context, row sql.Row) (interface{}, err
 	if err != nil {
 		return nil, err
 	}
-	pgctx := Context{
-		Context:       ctx,
-		OriginalTypes: originalTypes,
-		Sources:       sources,
-	}
+	pgctx := Context{Context: ctx}
 	// Next we'll resolve the overload based on the parameters given.
 	overload, casts, err := c.Functions.Resolve(originalTypes, sources)
 	if err != nil {
@@ -132,9 +125,10 @@ func (c *CompiledFunction) Eval(ctx *sql.Context, row sql.Row) (interface{}, err
 		return nil, err
 	}
 	// Convert the parameter values into their correct types
+	resultTypes := overload.Function.GetParameters()
 	for i := range parameters {
 		if casts[i] != nil {
-			parameters[i], err = casts[i](pgctx, parameters[i])
+			parameters[i], err = casts[i](pgctx, parameters[i], resultTypes[i])
 			if err != nil {
 				return nil, err
 			}
@@ -203,10 +197,8 @@ func (c *CompiledFunction) evalParameters(ctx *sql.Context, row sql.Row) ([]any,
 				parameters[i], _, _ = pgtypes.Numeric.Convert(parameters[i])
 			case query.Type_DATE, query.Type_DATETIME, query.Type_TIMESTAMP:
 				return nil, fmt.Errorf("need to add DoltgresType equivalents to DATETIME")
-			case query.Type_CHAR, query.Type_VARCHAR:
-				parameters[i], _, _ = pgtypes.VarChar.Convert(parameters[i])
-			case query.Type_TEXT:
-				parameters[i], _, _ = pgtypes.VarChar.Convert(parameters[i])
+			case query.Type_CHAR, query.Type_VARCHAR, query.Type_TEXT:
+				parameters[i], _, _ = pgtypes.Text.Convert(parameters[i])
 			case query.Type_ENUM:
 				parameters[i], _, _ = pgtypes.Int16.Convert(parameters[i])
 			case query.Type_SET:
@@ -249,10 +241,8 @@ func (c *CompiledFunction) analyzeParameters() (originalTypes []pgtypes.Doltgres
 				originalTypes[i] = pgtypes.Numeric
 			case query.Type_DATE, query.Type_DATETIME, query.Type_TIMESTAMP:
 				return nil, nil, fmt.Errorf("need to add DoltgresType equivalents to DATETIME")
-			case query.Type_CHAR, query.Type_VARCHAR:
-				originalTypes[i] = pgtypes.VarChar
-			case query.Type_TEXT:
-				originalTypes[i] = pgtypes.VarChar
+			case query.Type_CHAR, query.Type_VARCHAR, query.Type_TEXT:
+				originalTypes[i] = pgtypes.Text
 			case query.Type_ENUM:
 				originalTypes[i] = pgtypes.Int16
 			case query.Type_SET:
@@ -314,9 +304,7 @@ func (c *CompiledFunction) possibleParameterTypes() []pgtypes.DoltgresType {
 				// TODO: need to add DoltgresType equivalents to DATETIME
 				possibleParamTypes[i] = pgtypes.Null
 			case query.Type_CHAR, query.Type_VARCHAR:
-				possibleParamTypes[i] = pgtypes.VarChar
-			case query.Type_TEXT:
-				possibleParamTypes[i] = pgtypes.VarChar
+				possibleParamTypes[i] = pgtypes.Text
 			case query.Type_ENUM:
 				possibleParamTypes[i] = pgtypes.Int16
 			case query.Type_SET:

--- a/server/functions/framework/functions.go
+++ b/server/functions/framework/functions.go
@@ -23,8 +23,6 @@ import (
 // Context is a context that PostgreSQL functions will use.
 type Context struct {
 	*sql.Context
-	OriginalTypes []pgtypes.DoltgresType
-	Sources       []Source
 }
 
 // FunctionInterface is an interface for PostgreSQL functions.

--- a/server/functions/framework/overload_cast.go
+++ b/server/functions/framework/overload_cast.go
@@ -22,77 +22,44 @@ type specialOverloadCast struct {
 	Expression pgtypes.DoltgresTypeBaseID
 }
 
-// specialOverloadCasts holds all valid automatic casts between a parameter and a given expression.
-var specialOverloadCasts = map[specialOverloadCast]struct{}{
-	{Parameter: pgtypes.Bool.BaseID(), Expression: pgtypes.VarChar.BaseID()}:    {},
-	{Parameter: pgtypes.Float32.BaseID(), Expression: pgtypes.Float32.BaseID()}: {},
-	{Parameter: pgtypes.Float32.BaseID(), Expression: pgtypes.Float64.BaseID()}: {},
-	{Parameter: pgtypes.Float32.BaseID(), Expression: pgtypes.Int16.BaseID()}:   {},
-	{Parameter: pgtypes.Float32.BaseID(), Expression: pgtypes.Int32.BaseID()}:   {},
-	{Parameter: pgtypes.Float32.BaseID(), Expression: pgtypes.Int64.BaseID()}:   {},
-	{Parameter: pgtypes.Float32.BaseID(), Expression: pgtypes.Numeric.BaseID()}: {},
-	{Parameter: pgtypes.Float32.BaseID(), Expression: pgtypes.VarChar.BaseID()}: {},
-	{Parameter: pgtypes.Float64.BaseID(), Expression: pgtypes.Float32.BaseID()}: {},
-	{Parameter: pgtypes.Float64.BaseID(), Expression: pgtypes.Float64.BaseID()}: {},
-	{Parameter: pgtypes.Float64.BaseID(), Expression: pgtypes.Int16.BaseID()}:   {},
-	{Parameter: pgtypes.Float64.BaseID(), Expression: pgtypes.Int32.BaseID()}:   {},
-	{Parameter: pgtypes.Float64.BaseID(), Expression: pgtypes.Int64.BaseID()}:   {},
-	{Parameter: pgtypes.Float64.BaseID(), Expression: pgtypes.Numeric.BaseID()}: {},
-	{Parameter: pgtypes.Float64.BaseID(), Expression: pgtypes.VarChar.BaseID()}: {},
-	{Parameter: pgtypes.Int16.BaseID(), Expression: pgtypes.Float32.BaseID()}:   {},
-	{Parameter: pgtypes.Int16.BaseID(), Expression: pgtypes.Float64.BaseID()}:   {},
-	{Parameter: pgtypes.Int16.BaseID(), Expression: pgtypes.Int16.BaseID()}:     {},
-	{Parameter: pgtypes.Int16.BaseID(), Expression: pgtypes.Int32.BaseID()}:     {},
-	{Parameter: pgtypes.Int16.BaseID(), Expression: pgtypes.Int64.BaseID()}:     {},
-	{Parameter: pgtypes.Int16.BaseID(), Expression: pgtypes.Numeric.BaseID()}:   {},
-	{Parameter: pgtypes.Int16.BaseID(), Expression: pgtypes.VarChar.BaseID()}:   {},
-	{Parameter: pgtypes.Int32.BaseID(), Expression: pgtypes.Float32.BaseID()}:   {},
-	{Parameter: pgtypes.Int32.BaseID(), Expression: pgtypes.Float64.BaseID()}:   {},
-	{Parameter: pgtypes.Int32.BaseID(), Expression: pgtypes.Int16.BaseID()}:     {},
-	{Parameter: pgtypes.Int32.BaseID(), Expression: pgtypes.Int32.BaseID()}:     {},
-	{Parameter: pgtypes.Int32.BaseID(), Expression: pgtypes.Int64.BaseID()}:     {},
-	{Parameter: pgtypes.Int32.BaseID(), Expression: pgtypes.Numeric.BaseID()}:   {},
-	{Parameter: pgtypes.Int32.BaseID(), Expression: pgtypes.VarChar.BaseID()}:   {},
-	{Parameter: pgtypes.Int64.BaseID(), Expression: pgtypes.Float32.BaseID()}:   {},
-	{Parameter: pgtypes.Int64.BaseID(), Expression: pgtypes.Float64.BaseID()}:   {},
-	{Parameter: pgtypes.Int64.BaseID(), Expression: pgtypes.Int16.BaseID()}:     {},
-	{Parameter: pgtypes.Int64.BaseID(), Expression: pgtypes.Int32.BaseID()}:     {},
-	{Parameter: pgtypes.Int64.BaseID(), Expression: pgtypes.Int64.BaseID()}:     {},
-	{Parameter: pgtypes.Int64.BaseID(), Expression: pgtypes.Numeric.BaseID()}:   {},
-	{Parameter: pgtypes.Int64.BaseID(), Expression: pgtypes.VarChar.BaseID()}:   {},
-	{Parameter: pgtypes.Numeric.BaseID(), Expression: pgtypes.Float32.BaseID()}: {},
-	{Parameter: pgtypes.Numeric.BaseID(), Expression: pgtypes.Float64.BaseID()}: {},
-	{Parameter: pgtypes.Numeric.BaseID(), Expression: pgtypes.Int16.BaseID()}:   {},
-	{Parameter: pgtypes.Numeric.BaseID(), Expression: pgtypes.Int32.BaseID()}:   {},
-	{Parameter: pgtypes.Numeric.BaseID(), Expression: pgtypes.Int64.BaseID()}:   {},
-	{Parameter: pgtypes.Numeric.BaseID(), Expression: pgtypes.Numeric.BaseID()}: {},
-	{Parameter: pgtypes.Numeric.BaseID(), Expression: pgtypes.VarChar.BaseID()}: {},
-	{Parameter: pgtypes.Uuid.BaseID(), Expression: pgtypes.VarChar.BaseID()}:    {},
+// numericUpcastsMap holds all valid automatic upcasts from an expression to the parameter.
+var numericUpcastsMap = map[specialOverloadCast]struct{}{
+	{Expression: pgtypes.DoltgresTypeBaseID_Float32, Parameter: pgtypes.DoltgresTypeBaseID_Float32}: {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Float32, Parameter: pgtypes.DoltgresTypeBaseID_Float64}: {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Float32, Parameter: pgtypes.DoltgresTypeBaseID_Numeric}: {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Float64, Parameter: pgtypes.DoltgresTypeBaseID_Float64}: {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Float64, Parameter: pgtypes.DoltgresTypeBaseID_Numeric}: {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Int16, Parameter: pgtypes.DoltgresTypeBaseID_Float32}:   {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Int16, Parameter: pgtypes.DoltgresTypeBaseID_Float64}:   {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Int16, Parameter: pgtypes.DoltgresTypeBaseID_Int16}:     {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Int16, Parameter: pgtypes.DoltgresTypeBaseID_Int32}:     {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Int16, Parameter: pgtypes.DoltgresTypeBaseID_Int64}:     {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Int16, Parameter: pgtypes.DoltgresTypeBaseID_Numeric}:   {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Int32, Parameter: pgtypes.DoltgresTypeBaseID_Float32}:   {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Int32, Parameter: pgtypes.DoltgresTypeBaseID_Float64}:   {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Int32, Parameter: pgtypes.DoltgresTypeBaseID_Int32}:     {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Int32, Parameter: pgtypes.DoltgresTypeBaseID_Int64}:     {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Int32, Parameter: pgtypes.DoltgresTypeBaseID_Numeric}:   {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Int64, Parameter: pgtypes.DoltgresTypeBaseID_Float32}:   {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Int64, Parameter: pgtypes.DoltgresTypeBaseID_Float64}:   {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Int64, Parameter: pgtypes.DoltgresTypeBaseID_Int64}:     {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Int64, Parameter: pgtypes.DoltgresTypeBaseID_Numeric}:   {},
+	{Expression: pgtypes.DoltgresTypeBaseID_Numeric, Parameter: pgtypes.DoltgresTypeBaseID_Numeric}: {},
 }
 
-// numericUpcasts holds all valid automatic upcasts from an expression to the parameter.
-var numericUpcasts = map[specialOverloadCast]struct{}{
-	{Parameter: pgtypes.Float32.BaseID(), Expression: pgtypes.Float32.BaseID()}: {},
-	{Parameter: pgtypes.Float32.BaseID(), Expression: pgtypes.Int16.BaseID()}:   {},
-	{Parameter: pgtypes.Float32.BaseID(), Expression: pgtypes.Int32.BaseID()}:   {},
-	{Parameter: pgtypes.Float32.BaseID(), Expression: pgtypes.Int64.BaseID()}:   {},
-	{Parameter: pgtypes.Float64.BaseID(), Expression: pgtypes.Float32.BaseID()}: {},
-	{Parameter: pgtypes.Float64.BaseID(), Expression: pgtypes.Float64.BaseID()}: {},
-	{Parameter: pgtypes.Float64.BaseID(), Expression: pgtypes.Int16.BaseID()}:   {},
-	{Parameter: pgtypes.Float64.BaseID(), Expression: pgtypes.Int32.BaseID()}:   {},
-	{Parameter: pgtypes.Float64.BaseID(), Expression: pgtypes.Int64.BaseID()}:   {},
-	{Parameter: pgtypes.Int16.BaseID(), Expression: pgtypes.Int16.BaseID()}:     {},
-	{Parameter: pgtypes.Int32.BaseID(), Expression: pgtypes.Int16.BaseID()}:     {},
-	{Parameter: pgtypes.Int32.BaseID(), Expression: pgtypes.Int32.BaseID()}:     {},
-	{Parameter: pgtypes.Int64.BaseID(), Expression: pgtypes.Int16.BaseID()}:     {},
-	{Parameter: pgtypes.Int64.BaseID(), Expression: pgtypes.Int32.BaseID()}:     {},
-	{Parameter: pgtypes.Int64.BaseID(), Expression: pgtypes.Int64.BaseID()}:     {},
-	{Parameter: pgtypes.Numeric.BaseID(), Expression: pgtypes.Float32.BaseID()}: {},
-	{Parameter: pgtypes.Numeric.BaseID(), Expression: pgtypes.Float64.BaseID()}: {},
-	{Parameter: pgtypes.Numeric.BaseID(), Expression: pgtypes.Int16.BaseID()}:   {},
-	{Parameter: pgtypes.Numeric.BaseID(), Expression: pgtypes.Int32.BaseID()}:   {},
-	{Parameter: pgtypes.Numeric.BaseID(), Expression: pgtypes.Int64.BaseID()}:   {},
-	{Parameter: pgtypes.Numeric.BaseID(), Expression: pgtypes.Numeric.BaseID()}: {},
+// implicitOverloadCasts uses the collection of implicit casts for overload resolution.
+func implicitOverloadCasts(param pgtypes.DoltgresTypeBaseID, expr pgtypes.DoltgresTypeBaseID) bool {
+	f := GetImplicitCast(expr, param)
+	return f != nil
+}
+
+// numericUpcasts uses the map of numeric upcasts for overload resolution.
+func numericUpcasts(param pgtypes.DoltgresTypeBaseID, expr pgtypes.DoltgresTypeBaseID) bool {
+	_, ok := numericUpcastsMap[specialOverloadCast{
+		Parameter:  param,
+		Expression: expr,
+	}]
+	return ok
 }
 
 // castPriorityForType returns the priority for the given type. The lower the value, the higher the priority. The
@@ -103,21 +70,25 @@ func castPriorityForType(t pgtypes.DoltgresTypeBaseID, sourceStringLiteral bool)
 		stringAdjustment = 1
 	}
 	switch t {
-	case pgtypes.Numeric.BaseID():
+	case pgtypes.DoltgresTypeBaseID_Numeric:
 		return 1 + (2 * stringAdjustment)
-	case pgtypes.Float64.BaseID():
+	case pgtypes.DoltgresTypeBaseID_Float64:
 		return 2 - stringAdjustment
-	case pgtypes.Float32.BaseID():
+	case pgtypes.DoltgresTypeBaseID_Float32:
 		return 3 - (2 * stringAdjustment)
-	case pgtypes.Int64.BaseID():
+	case pgtypes.DoltgresTypeBaseID_Int64:
 		return 4
-	case pgtypes.Int32.BaseID():
+	case pgtypes.DoltgresTypeBaseID_Int32:
 		return 5
-	case pgtypes.Int16.BaseID():
+	case pgtypes.DoltgresTypeBaseID_Int16:
 		return 6
-	case pgtypes.VarChar.BaseID():
+	case pgtypes.DoltgresTypeBaseID_Text:
 		return 7
-	default:
+	case pgtypes.DoltgresTypeBaseID_VarChar:
 		return 8
+	case pgtypes.DoltgresTypeBaseID_Char:
+		return 9
+	default:
+		return 10
 	}
 }

--- a/server/functions/lpad.go
+++ b/server/functions/lpad.go
@@ -31,11 +31,7 @@ var lpad_varchar_int32 = framework.Function2{
 	Return:     pgtypes.VarChar,
 	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32},
 	Callable: func(ctx framework.Context, val1 any, val2 any) (any, error) {
-		return lpad_varchar_int32_varchar.Callable(framework.Context{
-			Context:       ctx.Context,
-			OriginalTypes: append(ctx.OriginalTypes, pgtypes.VarChar),
-			Sources:       append(ctx.Sources, framework.Source_Constant),
-		}, val1, val2, " ")
+		return lpad_varchar_int32_varchar.Callable(ctx, val1, val2, " ")
 	},
 }
 

--- a/server/functions/ltrim.go
+++ b/server/functions/ltrim.go
@@ -31,11 +31,7 @@ var ltrim_varchar = framework.Function1{
 	Return:     pgtypes.VarChar,
 	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar},
 	Callable: func(ctx framework.Context, val1 any) (any, error) {
-		return ltrim_varchar_varchar.Callable(framework.Context{
-			Context:       ctx.Context,
-			OriginalTypes: append(ctx.OriginalTypes, pgtypes.VarChar),
-			Sources:       append(ctx.Sources, framework.Source_Constant),
-		}, val1, " ")
+		return ltrim_varchar_varchar.Callable(ctx, val1, " ")
 	},
 }
 

--- a/server/functions/rpad.go
+++ b/server/functions/rpad.go
@@ -31,11 +31,7 @@ var rpad_varchar_int32 = framework.Function2{
 	Return:     pgtypes.VarChar,
 	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32},
 	Callable: func(ctx framework.Context, val1 any, val2 any) (any, error) {
-		return rpad_varchar_int32_varchar.Callable(framework.Context{
-			Context:       ctx.Context,
-			OriginalTypes: append(ctx.OriginalTypes, pgtypes.VarChar),
-			Sources:       append(ctx.Sources, framework.Source_Constant),
-		}, val1, val2, " ")
+		return rpad_varchar_int32_varchar.Callable(ctx, val1, val2, " ")
 	},
 }
 

--- a/server/functions/rtrim.go
+++ b/server/functions/rtrim.go
@@ -31,11 +31,7 @@ var rtrim_varchar = framework.Function1{
 	Return:     pgtypes.VarChar,
 	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar},
 	Callable: func(ctx framework.Context, val1 any) (any, error) {
-		return rtrim_varchar_varchar.Callable(framework.Context{
-			Context:       ctx.Context,
-			OriginalTypes: append(ctx.OriginalTypes, pgtypes.VarChar),
-			Sources:       append(ctx.Sources, framework.Source_Constant),
-		}, val1, " ")
+		return rtrim_varchar_varchar.Callable(ctx, val1, " ")
 	},
 }
 

--- a/server/types/any_array.go
+++ b/server/types/any_array.go
@@ -76,6 +76,16 @@ func (aa AnyArrayType) FormatValue(val any) (string, error) {
 	return "", fmt.Errorf("%s cannot format values", aa.String())
 }
 
+// GetSerializationID implements the DoltgresType interface.
+func (aa AnyArrayType) GetSerializationID() SerializationID {
+	return SerializationID_Invalid
+}
+
+// IsUnbounded implements the DoltgresType interface.
+func (aa AnyArrayType) IsUnbounded() bool {
+	return true
+}
+
 // MaxSerializedWidth implements the DoltgresType interface.
 func (aa AnyArrayType) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
 	return types.ExtendedTypeSerializedWidth_Unbounded
@@ -99,11 +109,6 @@ func (aa AnyArrayType) Promote() sql.Type {
 // SerializedCompare implements the DoltgresType interface.
 func (aa AnyArrayType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	return 0, fmt.Errorf("%s cannot compare serialized values", aa.String())
-}
-
-// SerializeType implements the DoltgresType interface.
-func (aa AnyArrayType) SerializeType() ([]byte, error) {
-	return nil, fmt.Errorf("%s cannot be serialized", aa.String())
 }
 
 // SQL implements the DoltgresType interface.
@@ -136,6 +141,16 @@ func (aa AnyArrayType) Zero() any {
 	return []any{}
 }
 
+// SerializeType implements the DoltgresType interface.
+func (aa AnyArrayType) SerializeType() ([]byte, error) {
+	return nil, fmt.Errorf("%s cannot be serialized", aa.String())
+}
+
+// deserializeType implements the DoltgresType interface.
+func (aa AnyArrayType) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
+	return nil, fmt.Errorf("%s cannot be deserialized", aa.String())
+}
+
 // SerializeValue implements the DoltgresType interface.
 func (aa AnyArrayType) SerializeValue(val any) ([]byte, error) {
 	return nil, fmt.Errorf("%s cannot serialize values", aa.String())
@@ -144,9 +159,4 @@ func (aa AnyArrayType) SerializeValue(val any) ([]byte, error) {
 // DeserializeValue implements the DoltgresType interface.
 func (aa AnyArrayType) DeserializeValue(val []byte) (any, error) {
 	return nil, fmt.Errorf("%s cannot deserialize values", aa.String())
-}
-
-// withInnerDeserialization implements the DoltgresArrayType interface.
-func (aa AnyArrayType) withInnerDeserialization(innerSerializedType []byte) (types.ExtendedType, error) {
-	return nil, fmt.Errorf("%s cannot be deserialized", aa.String())
 }

--- a/server/types/base_ids.go
+++ b/server/types/base_ids.go
@@ -49,6 +49,27 @@ const (
 	DoltgresTypeBaseID_Unknown
 )
 
+const (
+	DoltgresTypeBaseID_Bool        = DoltgresTypeBaseID(SerializationID_Bool)
+	DoltgresTypeBaseID_Bytea       = DoltgresTypeBaseID(SerializationID_Bytea)
+	DoltgresTypeBaseID_Char        = DoltgresTypeBaseID(SerializationID_Char)
+	DoltgresTypeBaseID_Date        = DoltgresTypeBaseID(SerializationID_Date)
+	DoltgresTypeBaseID_Float32     = DoltgresTypeBaseID(SerializationID_Float32)
+	DoltgresTypeBaseID_Float64     = DoltgresTypeBaseID(SerializationID_Float64)
+	DoltgresTypeBaseID_Int16       = DoltgresTypeBaseID(SerializationID_Int16)
+	DoltgresTypeBaseID_Int32       = DoltgresTypeBaseID(SerializationID_Int32)
+	DoltgresTypeBaseID_Int64       = DoltgresTypeBaseID(SerializationID_Int64)
+	DoltgresTypeBaseID_Null        = DoltgresTypeBaseID(SerializationID_Null)
+	DoltgresTypeBaseID_Numeric     = DoltgresTypeBaseID(SerializationID_Numeric)
+	DoltgresTypeBaseID_Text        = DoltgresTypeBaseID(SerializationID_Text)
+	DoltgresTypeBaseID_Time        = DoltgresTypeBaseID(SerializationID_Time)
+	DoltgresTypeBaseID_Timestamp   = DoltgresTypeBaseID(SerializationID_Timestamp)
+	DoltgresTypeBaseID_TimestampTZ = DoltgresTypeBaseID(SerializationID_TimestampTZ)
+	DoltgresTypeBaseID_TimeTZ      = DoltgresTypeBaseID(SerializationID_TimeTZ)
+	DoltgresTypeBaseID_Uuid        = DoltgresTypeBaseID(SerializationID_Uuid)
+	DoltgresTypeBaseID_VarChar     = DoltgresTypeBaseID(SerializationID_VarChar)
+)
+
 // baseIDArrayTypes contains a map of all base IDs that represent array variants.
 var baseIDArrayTypes = map[DoltgresTypeBaseID]DoltgresArrayType{}
 

--- a/server/types/bool.go
+++ b/server/types/bool.go
@@ -39,7 +39,7 @@ var _ DoltgresType = BoolType{}
 
 // BaseID implements the DoltgresType interface.
 func (b BoolType) BaseID() DoltgresTypeBaseID {
-	return DoltgresTypeBaseID(SerializationID_Bool)
+	return DoltgresTypeBaseID_Bool
 }
 
 // CollationCoercibility implements the DoltgresType interface.
@@ -166,6 +166,16 @@ func (b BoolType) FormatValue(val any) (string, error) {
 	}
 }
 
+// GetSerializationID implements the DoltgresType interface.
+func (b BoolType) GetSerializationID() SerializationID {
+	return SerializationID_Bool
+}
+
+// IsUnbounded implements the DoltgresType interface.
+func (b BoolType) IsUnbounded() bool {
+	return false
+}
+
 // MaxSerializedWidth implements the DoltgresType interface.
 func (b BoolType) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
 	return types.ExtendedTypeSerializedWidth_64K
@@ -203,11 +213,6 @@ func (b BoolType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	} else {
 		return 1, nil
 	}
-}
-
-// SerializeType implements the DoltgresType interface.
-func (b BoolType) SerializeType() ([]byte, error) {
-	return SerializationID_Bool.ToByteSlice(), nil
 }
 
 // SQL implements the DoltgresType interface.
@@ -252,6 +257,21 @@ func (b BoolType) ValueType() reflect.Type {
 // Zero implements the DoltgresType interface.
 func (b BoolType) Zero() any {
 	return false
+}
+
+// SerializeType implements the DoltgresType interface.
+func (b BoolType) SerializeType() ([]byte, error) {
+	return SerializationID_Bool.ToByteSlice(0), nil
+}
+
+// deserializeType implements the DoltgresType interface.
+func (b BoolType) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
+	switch version {
+	case 0:
+		return Bool, nil
+	default:
+		return nil, fmt.Errorf("version %d is not yet supported for %s", version, b.String())
+	}
 }
 
 // SerializeValue implements the DoltgresType interface.

--- a/server/types/bytea_array.go
+++ b/server/types/bytea_array.go
@@ -1,0 +1,22 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"github.com/lib/pq/oid"
+)
+
+// ByteaArray is the array variant of Bytea.
+var ByteaArray = createArrayType(Bytea, SerializationID_ByteaArray, oid.T__bytea)

--- a/server/types/char_array.go
+++ b/server/types/char_array.go
@@ -1,0 +1,26 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "github.com/lib/pq/oid"
+
+// BpCharArray is the array variant of BpChar.
+var BpCharArray = createArrayTypeWithFuncs(BpChar, SerializationID_CharArray, oid.T__bpchar, arrayContainerFunctions{
+	SQL: stringArraySQL,
+})
+
+// CharArray is the array variant of BpChar. This is an alias of BpCharArray, since the documentation references "char"
+// more so than "bpchar" in PostgreSQL 15. They're the same type with different characteristics depending on the length.
+var CharArray = BpCharArray

--- a/server/types/date.go
+++ b/server/types/date.go
@@ -16,39 +16,37 @@ package types
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"reflect"
-	"strconv"
+	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/dolthub/vitess/go/vt/proto/query"
 	"github.com/lib/pq/oid"
-	"github.com/shopspring/decimal"
 )
 
-// Int16 is an int16.
-var Int16 = Int16Type{}
+// Date is the day, month, and year.
+var Date = DateType{}
 
-// Int16Type is the extended type implementation of the PostgreSQL smallint.
-type Int16Type struct{}
+// DateType is the extended type implementation of the PostgreSQL date.
+type DateType struct{}
 
-var _ DoltgresType = Int16Type{}
+var _ DoltgresType = DateType{}
 
 // BaseID implements the DoltgresType interface.
-func (b Int16Type) BaseID() DoltgresTypeBaseID {
-	return DoltgresTypeBaseID_Int16
+func (b DateType) BaseID() DoltgresTypeBaseID {
+	return DoltgresTypeBaseID_Date
 }
 
 // CollationCoercibility implements the DoltgresType interface.
-func (b Int16Type) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+func (b DateType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
 	return sql.Collation_binary, 5
 }
 
 // Compare implements the DoltgresType interface.
-func (b Int16Type) Compare(v1 any, v2 any) (int, error) {
+func (b DateType) Compare(v1 any, v2 any) (int, error) {
 	if v1 == nil && v2 == nil {
 		return 0, nil
 	} else if v1 != nil && v2 == nil {
@@ -66,74 +64,36 @@ func (b Int16Type) Compare(v1 any, v2 any) (int, error) {
 		return 0, err
 	}
 
-	ab := ac.(int16)
-	bb := bc.(int16)
-	if ab == bb {
-		return 0, nil
-	} else if ab < bb {
-		return -1, nil
-	} else {
-		return 1, nil
-	}
+	ab := ac.(time.Time)
+	bb := bc.(time.Time)
+	return ab.Compare(bb), nil
 }
 
 // Convert implements the DoltgresType interface.
-func (b Int16Type) Convert(val any) (any, sql.ConvertInRange, error) {
-	switch val := val.(type) {
-	case bool:
-		if val {
-			return int16(1), sql.InRange, nil
-		}
-		return int16(0), sql.InRange, nil
-	case int:
-		return int16(val), sql.InRange, nil
-	case uint:
-		return int16(val), sql.InRange, nil
-	case int8:
-		return int16(val), sql.InRange, nil
-	case uint8:
-		return int16(val), sql.InRange, nil
-	case int16:
-		return int16(val), sql.InRange, nil
-	case uint16:
-		return int16(val), sql.InRange, nil
-	case int32:
-		return int16(val), sql.InRange, nil
-	case uint32:
-		return int16(val), sql.InRange, nil
-	case int64:
-		return int16(val), sql.InRange, nil
-	case uint64:
-		return int16(val), sql.InRange, nil
-	case float32:
-		return int16(val), sql.InRange, nil
-	case float64:
-		return int16(val), sql.InRange, nil
-	case decimal.NullDecimal:
-		if !val.Valid {
-			return nil, sql.InRange, nil
-		}
-		return b.Convert(val.Decimal)
-	case decimal.Decimal:
-		v, _ := val.Float64()
-		return int16(v), sql.InRange, nil
-	case string:
-		i, err := strconv.ParseInt(val, 10, 64)
-		if err != nil {
-			return nil, sql.OutOfRange, err
-		}
-		return int16(i), sql.InRange, nil
-	case []byte:
-		return b.Convert(string(val))
-	case nil:
+func (b DateType) Convert(val any) (any, sql.ConvertInRange, error) {
+	if val == nil {
 		return nil, sql.InRange, nil
+	}
+
+	switch val := val.(type) {
+	case string:
+		if t, err := time.Parse("2006-01-02", val); err == nil {
+			return t.UTC(), sql.InRange, nil
+		} else if t, err = time.Parse("January 02, 2006", val); err == nil {
+			return t.UTC(), sql.InRange, nil
+		} else if t, err = time.Parse("2006-Jan-02", val); err == nil {
+			return t.UTC(), sql.InRange, nil
+		}
+		return nil, sql.OutOfRange, fmt.Errorf("invalid format for time")
+	case time.Time:
+		return val.UTC(), sql.InRange, nil
 	default:
-		return nil, sql.OutOfRange, fmt.Errorf("%s: unhandled type: %T", b.String(), val)
+		return nil, sql.OutOfRange, sql.ErrInvalidType.New(b)
 	}
 }
 
 // Equals implements the DoltgresType interface.
-func (b Int16Type) Equals(otherType sql.Type) bool {
+func (b DateType) Equals(otherType sql.Type) bool {
 	if otherExtendedType, ok := otherType.(types.ExtendedType); ok {
 		return bytes.Equal(MustSerializeType(b), MustSerializeType(otherExtendedType))
 	}
@@ -141,7 +101,7 @@ func (b Int16Type) Equals(otherType sql.Type) bool {
 }
 
 // FormatSerializedValue implements the DoltgresType interface.
-func (b Int16Type) FormatSerializedValue(val []byte) (string, error) {
+func (b DateType) FormatSerializedValue(val []byte) (string, error) {
 	deserialized, err := b.DeserializeValue(val)
 	if err != nil {
 		return "", err
@@ -150,7 +110,7 @@ func (b Int16Type) FormatSerializedValue(val []byte) (string, error) {
 }
 
 // FormatValue implements the DoltgresType interface.
-func (b Int16Type) FormatValue(val any) (string, error) {
+func (b DateType) FormatValue(val any) (string, error) {
 	if val == nil {
 		return "", nil
 	}
@@ -158,41 +118,41 @@ func (b Int16Type) FormatValue(val any) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strconv.FormatInt(int64(converted.(int16)), 10), nil
+	return converted.(time.Time).Format("2006-01-02"), nil
 }
 
 // GetSerializationID implements the DoltgresType interface.
-func (b Int16Type) GetSerializationID() SerializationID {
-	return SerializationID_Int16
+func (b DateType) GetSerializationID() SerializationID {
+	return SerializationID_Date
 }
 
 // IsUnbounded implements the DoltgresType interface.
-func (b Int16Type) IsUnbounded() bool {
+func (b DateType) IsUnbounded() bool {
 	return false
 }
 
 // MaxSerializedWidth implements the DoltgresType interface.
-func (b Int16Type) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
+func (b DateType) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
 	return types.ExtendedTypeSerializedWidth_64K
 }
 
 // MaxTextResponseByteLength implements the DoltgresType interface.
-func (b Int16Type) MaxTextResponseByteLength(ctx *sql.Context) uint32 {
-	return 2
+func (b DateType) MaxTextResponseByteLength(ctx *sql.Context) uint32 {
+	return 32
 }
 
 // OID implements the DoltgresType interface.
-func (b Int16Type) OID() uint32 {
-	return uint32(oid.T_int2)
+func (b DateType) OID() uint32 {
+	return uint32(oid.T_date)
 }
 
 // Promote implements the DoltgresType interface.
-func (b Int16Type) Promote() sql.Type {
-	return b
+func (b DateType) Promote() sql.Type {
+	return Date
 }
 
 // SerializedCompare implements the DoltgresType interface.
-func (b Int16Type) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
+func (b DateType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	if len(v1) == 0 && len(v2) == 0 {
 		return 0, nil
 	} else if len(v1) > 0 && len(v2) == 0 {
@@ -201,11 +161,12 @@ func (b Int16Type) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 		return -1, nil
 	}
 
+	// The marshalled time format is byte-comparable
 	return bytes.Compare(v1, v2), nil
 }
 
 // SQL implements the DoltgresType interface.
-func (b Int16Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
+func (b DateType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}
@@ -217,47 +178,47 @@ func (b Int16Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, er
 }
 
 // String implements the DoltgresType interface.
-func (b Int16Type) String() string {
-	return "smallint"
+func (b DateType) String() string {
+	return "date"
 }
 
 // ToArrayType implements the DoltgresType interface.
-func (b Int16Type) ToArrayType() DoltgresArrayType {
-	return Int16Array
+func (b DateType) ToArrayType() DoltgresArrayType {
+	return DateArray
 }
 
 // Type implements the DoltgresType interface.
-func (b Int16Type) Type() query.Type {
-	return sqltypes.Int16
+func (b DateType) Type() query.Type {
+	return sqltypes.Text
 }
 
 // ValueType implements the DoltgresType interface.
-func (b Int16Type) ValueType() reflect.Type {
-	return reflect.TypeOf(int16(0))
+func (b DateType) ValueType() reflect.Type {
+	return reflect.TypeOf(time.Time{})
 }
 
 // Zero implements the DoltgresType interface.
-func (b Int16Type) Zero() any {
-	return int16(0)
+func (b DateType) Zero() any {
+	return time.Time{}
 }
 
 // SerializeType implements the DoltgresType interface.
-func (b Int16Type) SerializeType() ([]byte, error) {
-	return SerializationID_Int16.ToByteSlice(0), nil
+func (b DateType) SerializeType() ([]byte, error) {
+	return SerializationID_Date.ToByteSlice(0), nil
 }
 
 // deserializeType implements the DoltgresType interface.
-func (b Int16Type) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
+func (b DateType) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
 	switch version {
 	case 0:
-		return Int16, nil
+		return Date, nil
 	default:
 		return nil, fmt.Errorf("version %d is not yet supported for %s", version, b.String())
 	}
 }
 
 // SerializeValue implements the DoltgresType interface.
-func (b Int16Type) SerializeValue(val any) ([]byte, error) {
+func (b DateType) SerializeValue(val any) ([]byte, error) {
 	if val == nil {
 		return nil, nil
 	}
@@ -265,15 +226,17 @@ func (b Int16Type) SerializeValue(val any) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	retVal := make([]byte, 2)
-	binary.BigEndian.PutUint16(retVal, uint16(converted.(int16))+(1<<15))
-	return retVal, nil
+	return converted.(time.Time).MarshalBinary()
 }
 
 // DeserializeValue implements the DoltgresType interface.
-func (b Int16Type) DeserializeValue(val []byte) (any, error) {
+func (b DateType) DeserializeValue(val []byte) (any, error) {
 	if len(val) == 0 {
 		return nil, nil
 	}
-	return int16(binary.BigEndian.Uint16(val) - (1 << 15)), nil
+	t := time.Time{}
+	if err := t.UnmarshalBinary(val); err != nil {
+		return nil, err
+	}
+	return t, nil
 }

--- a/server/types/date_array.go
+++ b/server/types/date_array.go
@@ -1,0 +1,20 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "github.com/lib/pq/oid"
+
+// DateArray is the array variant of Date.
+var DateArray = createArrayType(Date, SerializationID_DateArray, oid.T__date)

--- a/server/types/float32.go
+++ b/server/types/float32.go
@@ -41,7 +41,7 @@ var _ DoltgresType = Float32Type{}
 
 // BaseID implements the DoltgresType interface.
 func (b Float32Type) BaseID() DoltgresTypeBaseID {
-	return DoltgresTypeBaseID(SerializationID_Float32)
+	return DoltgresTypeBaseID_Float32
 }
 
 // CollationCoercibility implements the DoltgresType interface.
@@ -163,6 +163,16 @@ func (b Float32Type) FormatValue(val any) (string, error) {
 	return strconv.FormatFloat(float64(converted.(float32)), 'g', -1, 32), nil
 }
 
+// GetSerializationID implements the DoltgresType interface.
+func (b Float32Type) GetSerializationID() SerializationID {
+	return SerializationID_Float32
+}
+
+// IsUnbounded implements the DoltgresType interface.
+func (b Float32Type) IsUnbounded() bool {
+	return false
+}
+
 // MaxSerializedWidth implements the DoltgresType interface.
 func (b Float32Type) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
 	return types.ExtendedTypeSerializedWidth_64K
@@ -180,7 +190,7 @@ func (b Float32Type) OID() uint32 {
 
 // Promote implements the DoltgresType interface.
 func (b Float32Type) Promote() sql.Type {
-	return Float64
+	return b
 }
 
 // SerializedCompare implements the DoltgresType interface.
@@ -194,11 +204,6 @@ func (b Float32Type) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	}
 
 	return bytes.Compare(v1, v2), nil
-}
-
-// SerializeType implements the DoltgresType interface.
-func (b Float32Type) SerializeType() ([]byte, error) {
-	return SerializationID_Float32.ToByteSlice(), nil
 }
 
 // SQL implements the DoltgresType interface.
@@ -236,6 +241,21 @@ func (b Float32Type) ValueType() reflect.Type {
 // Zero implements the DoltgresType interface.
 func (b Float32Type) Zero() any {
 	return float32(0)
+}
+
+// SerializeType implements the DoltgresType interface.
+func (b Float32Type) SerializeType() ([]byte, error) {
+	return SerializationID_Float32.ToByteSlice(0), nil
+}
+
+// deserializeType implements the DoltgresType interface.
+func (b Float32Type) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
+	switch version {
+	case 0:
+		return Float32, nil
+	default:
+		return nil, fmt.Errorf("version %d is not yet supported for %s", version, b.String())
+	}
 }
 
 // SerializeValue implements the DoltgresType interface.

--- a/server/types/float64.go
+++ b/server/types/float64.go
@@ -40,7 +40,7 @@ var _ DoltgresType = Float64Type{}
 
 // BaseID implements the DoltgresType interface.
 func (b Float64Type) BaseID() DoltgresTypeBaseID {
-	return DoltgresTypeBaseID(SerializationID_Float64)
+	return DoltgresTypeBaseID_Float64
 }
 
 // CollationCoercibility implements the DoltgresType interface.
@@ -162,6 +162,16 @@ func (b Float64Type) FormatValue(val any) (string, error) {
 	return strconv.FormatFloat(converted.(float64), 'g', -1, 64), nil
 }
 
+// GetSerializationID implements the DoltgresType interface.
+func (b Float64Type) GetSerializationID() SerializationID {
+	return SerializationID_Float64
+}
+
+// IsUnbounded implements the DoltgresType interface.
+func (b Float64Type) IsUnbounded() bool {
+	return false
+}
+
 // MaxSerializedWidth implements the DoltgresType interface.
 func (b Float64Type) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
 	return types.ExtendedTypeSerializedWidth_64K
@@ -193,11 +203,6 @@ func (b Float64Type) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	}
 
 	return bytes.Compare(v1, v2), nil
-}
-
-// SerializeType implements the DoltgresType interface.
-func (b Float64Type) SerializeType() ([]byte, error) {
-	return SerializationID_Float64.ToByteSlice(), nil
 }
 
 // SQL implements the DoltgresType interface.
@@ -235,6 +240,21 @@ func (b Float64Type) ValueType() reflect.Type {
 // Zero implements the DoltgresType interface.
 func (b Float64Type) Zero() any {
 	return float64(0)
+}
+
+// SerializeType implements the DoltgresType interface.
+func (b Float64Type) SerializeType() ([]byte, error) {
+	return SerializationID_Float64.ToByteSlice(0), nil
+}
+
+// deserializeType implements the DoltgresType interface.
+func (b Float64Type) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
+	switch version {
+	case 0:
+		return Float64, nil
+	default:
+		return nil, fmt.Errorf("version %d is not yet supported for %s", version, b.String())
+	}
 }
 
 // SerializeValue implements the DoltgresType interface.

--- a/server/types/int32.go
+++ b/server/types/int32.go
@@ -39,7 +39,7 @@ var _ DoltgresType = Int32Type{}
 
 // BaseID implements the DoltgresType interface.
 func (b Int32Type) BaseID() DoltgresTypeBaseID {
-	return DoltgresTypeBaseID(SerializationID_Int32)
+	return DoltgresTypeBaseID_Int32
 }
 
 // CollationCoercibility implements the DoltgresType interface.
@@ -160,6 +160,16 @@ func (b Int32Type) FormatValue(val any) (string, error) {
 	return strconv.FormatInt(int64(converted.(int32)), 10), nil
 }
 
+// GetSerializationID implements the DoltgresType interface.
+func (b Int32Type) GetSerializationID() SerializationID {
+	return SerializationID_Int32
+}
+
+// IsUnbounded implements the DoltgresType interface.
+func (b Int32Type) IsUnbounded() bool {
+	return false
+}
+
 // MaxSerializedWidth implements the DoltgresType interface.
 func (b Int32Type) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
 	return types.ExtendedTypeSerializedWidth_64K
@@ -177,7 +187,7 @@ func (b Int32Type) OID() uint32 {
 
 // Promote implements the DoltgresType interface.
 func (b Int32Type) Promote() sql.Type {
-	return Int64
+	return b
 }
 
 // SerializedCompare implements the DoltgresType interface.
@@ -191,11 +201,6 @@ func (b Int32Type) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	}
 
 	return bytes.Compare(v1, v2), nil
-}
-
-// SerializeType implements the DoltgresType interface.
-func (b Int32Type) SerializeType() ([]byte, error) {
-	return SerializationID_Int32.ToByteSlice(), nil
 }
 
 // SQL implements the DoltgresType interface.
@@ -233,6 +238,21 @@ func (b Int32Type) ValueType() reflect.Type {
 // Zero implements the DoltgresType interface.
 func (b Int32Type) Zero() any {
 	return int32(0)
+}
+
+// SerializeType implements the DoltgresType interface.
+func (b Int32Type) SerializeType() ([]byte, error) {
+	return SerializationID_Int32.ToByteSlice(0), nil
+}
+
+// deserializeType implements the DoltgresType interface.
+func (b Int32Type) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
+	switch version {
+	case 0:
+		return Int32, nil
+	default:
+		return nil, fmt.Errorf("version %d is not yet supported for %s", version, b.String())
+	}
 }
 
 // SerializeValue implements the DoltgresType interface.

--- a/server/types/int64.go
+++ b/server/types/int64.go
@@ -39,7 +39,7 @@ var _ DoltgresType = Int64Type{}
 
 // BaseID implements the DoltgresType interface.
 func (b Int64Type) BaseID() DoltgresTypeBaseID {
-	return DoltgresTypeBaseID(SerializationID_Int64)
+	return DoltgresTypeBaseID_Int64
 }
 
 // CollationCoercibility implements the DoltgresType interface.
@@ -160,6 +160,16 @@ func (b Int64Type) FormatValue(val any) (string, error) {
 	return strconv.FormatInt(converted.(int64), 10), nil
 }
 
+// GetSerializationID implements the DoltgresType interface.
+func (b Int64Type) GetSerializationID() SerializationID {
+	return SerializationID_Int64
+}
+
+// IsUnbounded implements the DoltgresType interface.
+func (b Int64Type) IsUnbounded() bool {
+	return false
+}
+
 // MaxSerializedWidth implements the DoltgresType interface.
 func (b Int64Type) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
 	return types.ExtendedTypeSerializedWidth_64K
@@ -191,11 +201,6 @@ func (b Int64Type) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	}
 
 	return bytes.Compare(v1, v2), nil
-}
-
-// SerializeType implements the DoltgresType interface.
-func (b Int64Type) SerializeType() ([]byte, error) {
-	return SerializationID_Int64.ToByteSlice(), nil
 }
 
 // SQL implements the DoltgresType interface.
@@ -233,6 +238,21 @@ func (b Int64Type) ValueType() reflect.Type {
 // Zero implements the DoltgresType interface.
 func (b Int64Type) Zero() any {
 	return int64(0)
+}
+
+// SerializeType implements the DoltgresType interface.
+func (b Int64Type) SerializeType() ([]byte, error) {
+	return SerializationID_Int64.ToByteSlice(0), nil
+}
+
+// deserializeType implements the DoltgresType interface.
+func (b Int64Type) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
+	switch version {
+	case 0:
+		return Int64, nil
+	default:
+		return nil, fmt.Errorf("version %d is not yet supported for %s", version, b.String())
+	}
 }
 
 // SerializeValue implements the DoltgresType interface.

--- a/server/types/interface.go
+++ b/server/types/interface.go
@@ -21,6 +21,11 @@ type DoltgresType interface {
 	types.ExtendedType
 	// BaseID returns the DoltgresTypeBaseID for this type.
 	BaseID() DoltgresTypeBaseID
+	// GetSerializationID returns the SerializationID for this type.
+	GetSerializationID() SerializationID
+	// IsUnbounded returns whether the type is unbounded. Unbounded types do not enforce a length, precision, etc. on
+	// values. All values are still bound by the field size limit, but that differs from any type-enforced limits.
+	IsUnbounded() bool
 	// OID returns an OID that we are associating with this type. OIDs are not unique, and are not guaranteed to be the
 	// same between versions of Postgres. However, they've so far appeared relatively stable, and many libraries rely on
 	// them for type identification, so we return them here. These should not be used for any sort of identification on
@@ -30,6 +35,10 @@ type DoltgresType interface {
 	// SerializeType returns a byte slice representing the serialized form of the type. All serialized types MUST start
 	// with their SerializationID. Deserialization is done through the DeserializeType function.
 	SerializeType() ([]byte, error)
+	// deserializeType returns a new type based on the given version and metadata. The metadata is all data after the
+	// serialization header. This is called from within the types package. To deserialize types normally, use
+	// DeserializeType, which will call this as needed.
+	deserializeType(version uint16, metadata []byte) (DoltgresType, error)
 	// ToArrayType converts the calling DoltgresType into its corresponding array type. When called on a
 	// DoltgresArrayType, then it simply returns itself, as a multidimensional or nested array is equivalent to a
 	// standard array.
@@ -41,41 +50,45 @@ type DoltgresArrayType interface {
 	DoltgresType
 	// BaseType is the inner type of the array. This will always be a non-array type.
 	BaseType() DoltgresType
-	// withInnerDeserialization handles deserialization of the inner type. This is an internal function.
-	withInnerDeserialization(innerSerializedType []byte) (types.ExtendedType, error)
-}
-
-// FromBaseID returns a DoltgresType that matches the Base ID. This type will usually be the most permissive version of
-// the type, along with any default values.
-func FromBaseID(baseID DoltgresTypeBaseID) DoltgresType {
-	t, ok := typesFromBaseID[baseID]
-	if !ok {
-		panic("unknown Doltgres base id")
-	}
-	return t
 }
 
 // typesFromBaseID contains a map from a DoltgresTypeBaseID to its originating type.
 var typesFromBaseID = map[DoltgresTypeBaseID]DoltgresType{
-	AnyArray.BaseID():     AnyArray,
-	Bool.BaseID():         Bool,
-	BoolArray.BaseID():    BoolArray,
-	Float32.BaseID():      Float32,
-	Float32Array.BaseID(): Float32Array,
-	Float64.BaseID():      Float64,
-	Float64Array.BaseID(): Float64Array,
-	Int16.BaseID():        Int16,
-	Int16Array.BaseID():   Int16Array,
-	Int32.BaseID():        Int32,
-	Int32Array.BaseID():   Int32Array,
-	Int64.BaseID():        Int64,
-	Int64Array.BaseID():   Int64Array,
-	Null.BaseID():         Null,
-	Numeric.BaseID():      Numeric,
-	NumericArray.BaseID(): NumericArray,
-	Uuid.BaseID():         Uuid,
-	UuidArray.BaseID():    UuidArray,
-	Unknown.BaseID():      Unknown,
-	VarChar.BaseID():      VarChar,
-	VarCharArray.BaseID(): VarCharArray,
+	AnyArray.BaseID():         AnyArray,
+	BpChar.BaseID():           BpChar,
+	BpCharArray.BaseID():      BpCharArray,
+	Bool.BaseID():             Bool,
+	BoolArray.BaseID():        BoolArray,
+	Bytea.BaseID():            Bytea,
+	ByteaArray.BaseID():       ByteaArray,
+	Date.BaseID():             Date,
+	DateArray.BaseID():        DateArray,
+	Float32.BaseID():          Float32,
+	Float32Array.BaseID():     Float32Array,
+	Float64.BaseID():          Float64,
+	Float64Array.BaseID():     Float64Array,
+	Int16.BaseID():            Int16,
+	Int16Array.BaseID():       Int16Array,
+	Int32.BaseID():            Int32,
+	Int32Array.BaseID():       Int32Array,
+	Int64.BaseID():            Int64,
+	Int64Array.BaseID():       Int64Array,
+	Null.BaseID():             Null,
+	Numeric.BaseID():          Numeric,
+	NumericArray.BaseID():     NumericArray,
+	Text.BaseID():             Text,
+	TextArray.BaseID():        TextArray,
+	Time.BaseID():             Time,
+	TimeArray.BaseID():        TimeArray,
+	Timestamp.BaseID():        Timestamp,
+	TimestampArray.BaseID():   TimestampArray,
+	TimestampTZ.BaseID():      TimestampTZ,
+	TimestampTZArray.BaseID(): TimestampTZArray,
+	TimeTZ.BaseID():           TimeTZ,
+	TimeTZArray.BaseID():      TimeTZArray,
+	Uuid.BaseID():             Uuid,
+	UuidArray.BaseID():        UuidArray,
+	Unknown.BaseID():          Unknown,
+	VarChar.BaseID():          VarChar,
+	VarCharArray.BaseID():     VarCharArray,
 }

--- a/server/types/null.go
+++ b/server/types/null.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -34,7 +35,7 @@ var _ DoltgresType = NullType{}
 
 // BaseID implements the DoltgresType interface.
 func (b NullType) BaseID() DoltgresTypeBaseID {
-	return DoltgresTypeBaseID(SerializationID_Null)
+	return DoltgresTypeBaseID_Null
 }
 
 // CollationCoercibility implements the DoltgresType interface.
@@ -79,6 +80,16 @@ func (b NullType) FormatValue(val any) (string, error) {
 	return "NULL", nil
 }
 
+// GetSerializationID implements the DoltgresType interface.
+func (b NullType) GetSerializationID() SerializationID {
+	return SerializationID_Null
+}
+
+// IsUnbounded implements the DoltgresType interface.
+func (b NullType) IsUnbounded() bool {
+	return false
+}
+
 // MaxSerializedWidth implements the DoltgresType interface.
 func (b NullType) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
 	return types.ExtendedTypeSerializedWidth_64K
@@ -102,11 +113,6 @@ func (b NullType) Promote() sql.Type {
 // SerializedCompare implements the DoltgresType interface.
 func (b NullType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	return 0, nil
-}
-
-// SerializeType implements the DoltgresType interface.
-func (b NullType) SerializeType() ([]byte, error) {
-	return SerializationID_Null.ToByteSlice(), nil
 }
 
 // SQL implements the DoltgresType interface.
@@ -137,6 +143,21 @@ func (b NullType) ValueType() reflect.Type {
 // Zero implements the DoltgresType interface.
 func (b NullType) Zero() any {
 	return nil
+}
+
+// SerializeType implements the DoltgresType interface.
+func (b NullType) SerializeType() ([]byte, error) {
+	return SerializationID_Null.ToByteSlice(0), nil
+}
+
+// deserializeType implements the DoltgresType interface.
+func (b NullType) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
+	switch version {
+	case 0:
+		return Null, nil
+	default:
+		return nil, fmt.Errorf("version %d is not yet supported for %s", version, b.String())
+	}
 }
 
 // SerializeValue implements the DoltgresType interface.

--- a/server/types/text_array.go
+++ b/server/types/text_array.go
@@ -1,0 +1,22 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "github.com/lib/pq/oid"
+
+// TextArray is the array variant of Text.
+var TextArray = createArrayTypeWithFuncs(Text, SerializationID_TextArray, oid.T__text, arrayContainerFunctions{
+	SQL: stringArraySQL,
+})

--- a/server/types/time.go
+++ b/server/types/time.go
@@ -16,39 +16,40 @@ package types
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"reflect"
-	"strconv"
+	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/dolthub/vitess/go/vt/proto/query"
 	"github.com/lib/pq/oid"
-	"github.com/shopspring/decimal"
 )
 
-// Int16 is an int16.
-var Int16 = Int16Type{}
+// Time is the time without a time zone. Precision is unbounded.
+var Time = TimeType{-1}
 
-// Int16Type is the extended type implementation of the PostgreSQL smallint.
-type Int16Type struct{}
+// TimeType is the extended type implementation of the PostgreSQL time without time zone.
+type TimeType struct {
+	// TODO: implement precision
+	Precision int8
+}
 
-var _ DoltgresType = Int16Type{}
+var _ DoltgresType = TimeType{}
 
 // BaseID implements the DoltgresType interface.
-func (b Int16Type) BaseID() DoltgresTypeBaseID {
-	return DoltgresTypeBaseID_Int16
+func (b TimeType) BaseID() DoltgresTypeBaseID {
+	return DoltgresTypeBaseID_Time
 }
 
 // CollationCoercibility implements the DoltgresType interface.
-func (b Int16Type) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+func (b TimeType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
 	return sql.Collation_binary, 5
 }
 
 // Compare implements the DoltgresType interface.
-func (b Int16Type) Compare(v1 any, v2 any) (int, error) {
+func (b TimeType) Compare(v1 any, v2 any) (int, error) {
 	if v1 == nil && v2 == nil {
 		return 0, nil
 	} else if v1 != nil && v2 == nil {
@@ -66,74 +67,34 @@ func (b Int16Type) Compare(v1 any, v2 any) (int, error) {
 		return 0, err
 	}
 
-	ab := ac.(int16)
-	bb := bc.(int16)
-	if ab == bb {
-		return 0, nil
-	} else if ab < bb {
-		return -1, nil
-	} else {
-		return 1, nil
-	}
+	ab := ac.(time.Time)
+	bb := bc.(time.Time)
+	return ab.Compare(bb), nil
 }
 
 // Convert implements the DoltgresType interface.
-func (b Int16Type) Convert(val any) (any, sql.ConvertInRange, error) {
-	switch val := val.(type) {
-	case bool:
-		if val {
-			return int16(1), sql.InRange, nil
-		}
-		return int16(0), sql.InRange, nil
-	case int:
-		return int16(val), sql.InRange, nil
-	case uint:
-		return int16(val), sql.InRange, nil
-	case int8:
-		return int16(val), sql.InRange, nil
-	case uint8:
-		return int16(val), sql.InRange, nil
-	case int16:
-		return int16(val), sql.InRange, nil
-	case uint16:
-		return int16(val), sql.InRange, nil
-	case int32:
-		return int16(val), sql.InRange, nil
-	case uint32:
-		return int16(val), sql.InRange, nil
-	case int64:
-		return int16(val), sql.InRange, nil
-	case uint64:
-		return int16(val), sql.InRange, nil
-	case float32:
-		return int16(val), sql.InRange, nil
-	case float64:
-		return int16(val), sql.InRange, nil
-	case decimal.NullDecimal:
-		if !val.Valid {
-			return nil, sql.InRange, nil
-		}
-		return b.Convert(val.Decimal)
-	case decimal.Decimal:
-		v, _ := val.Float64()
-		return int16(v), sql.InRange, nil
-	case string:
-		i, err := strconv.ParseInt(val, 10, 64)
-		if err != nil {
-			return nil, sql.OutOfRange, err
-		}
-		return int16(i), sql.InRange, nil
-	case []byte:
-		return b.Convert(string(val))
-	case nil:
+func (b TimeType) Convert(val any) (any, sql.ConvertInRange, error) {
+	if val == nil {
 		return nil, sql.InRange, nil
+	}
+
+	switch val := val.(type) {
+	case string:
+		if t, err := time.Parse("15:04:05", val); err == nil {
+			return t.UTC(), sql.InRange, nil
+		} else if t, err = time.Parse("15:04:05.000", val); err == nil {
+			return t.UTC(), sql.InRange, nil
+		}
+		return nil, sql.OutOfRange, fmt.Errorf("invalid format for time")
+	case time.Time:
+		return val.UTC(), sql.InRange, nil
 	default:
-		return nil, sql.OutOfRange, fmt.Errorf("%s: unhandled type: %T", b.String(), val)
+		return nil, sql.OutOfRange, sql.ErrInvalidType.New(b)
 	}
 }
 
 // Equals implements the DoltgresType interface.
-func (b Int16Type) Equals(otherType sql.Type) bool {
+func (b TimeType) Equals(otherType sql.Type) bool {
 	if otherExtendedType, ok := otherType.(types.ExtendedType); ok {
 		return bytes.Equal(MustSerializeType(b), MustSerializeType(otherExtendedType))
 	}
@@ -141,7 +102,7 @@ func (b Int16Type) Equals(otherType sql.Type) bool {
 }
 
 // FormatSerializedValue implements the DoltgresType interface.
-func (b Int16Type) FormatSerializedValue(val []byte) (string, error) {
+func (b TimeType) FormatSerializedValue(val []byte) (string, error) {
 	deserialized, err := b.DeserializeValue(val)
 	if err != nil {
 		return "", err
@@ -150,7 +111,7 @@ func (b Int16Type) FormatSerializedValue(val []byte) (string, error) {
 }
 
 // FormatValue implements the DoltgresType interface.
-func (b Int16Type) FormatValue(val any) (string, error) {
+func (b TimeType) FormatValue(val any) (string, error) {
 	if val == nil {
 		return "", nil
 	}
@@ -158,41 +119,46 @@ func (b Int16Type) FormatValue(val any) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strconv.FormatInt(int64(converted.(int16)), 10), nil
+	t := converted.(time.Time)
+	if t.Nanosecond() != 0 {
+		return t.Format("15:04:05.999999999"), nil
+	} else {
+		return t.Format("15:04:05"), nil
+	}
 }
 
 // GetSerializationID implements the DoltgresType interface.
-func (b Int16Type) GetSerializationID() SerializationID {
-	return SerializationID_Int16
+func (b TimeType) GetSerializationID() SerializationID {
+	return SerializationID_Time
 }
 
 // IsUnbounded implements the DoltgresType interface.
-func (b Int16Type) IsUnbounded() bool {
+func (b TimeType) IsUnbounded() bool {
 	return false
 }
 
 // MaxSerializedWidth implements the DoltgresType interface.
-func (b Int16Type) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
+func (b TimeType) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
 	return types.ExtendedTypeSerializedWidth_64K
 }
 
 // MaxTextResponseByteLength implements the DoltgresType interface.
-func (b Int16Type) MaxTextResponseByteLength(ctx *sql.Context) uint32 {
-	return 2
+func (b TimeType) MaxTextResponseByteLength(ctx *sql.Context) uint32 {
+	return 32
 }
 
 // OID implements the DoltgresType interface.
-func (b Int16Type) OID() uint32 {
-	return uint32(oid.T_int2)
+func (b TimeType) OID() uint32 {
+	return uint32(oid.T_time)
 }
 
 // Promote implements the DoltgresType interface.
-func (b Int16Type) Promote() sql.Type {
-	return b
+func (b TimeType) Promote() sql.Type {
+	return Time
 }
 
 // SerializedCompare implements the DoltgresType interface.
-func (b Int16Type) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
+func (b TimeType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	if len(v1) == 0 && len(v2) == 0 {
 		return 0, nil
 	} else if len(v1) > 0 && len(v2) == 0 {
@@ -201,11 +167,12 @@ func (b Int16Type) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 		return -1, nil
 	}
 
+	// The marshalled time format is byte-comparable
 	return bytes.Compare(v1, v2), nil
 }
 
 // SQL implements the DoltgresType interface.
-func (b Int16Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
+func (b TimeType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}
@@ -217,47 +184,55 @@ func (b Int16Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, er
 }
 
 // String implements the DoltgresType interface.
-func (b Int16Type) String() string {
-	return "smallint"
+func (b TimeType) String() string {
+	if b.Precision == -1 {
+		return "time"
+	}
+	return fmt.Sprintf("time(%d)", b.Precision)
 }
 
 // ToArrayType implements the DoltgresType interface.
-func (b Int16Type) ToArrayType() DoltgresArrayType {
-	return Int16Array
+func (b TimeType) ToArrayType() DoltgresArrayType {
+	return createArrayType(b, SerializationID_TimeArray, oid.T__time)
 }
 
 // Type implements the DoltgresType interface.
-func (b Int16Type) Type() query.Type {
-	return sqltypes.Int16
+func (b TimeType) Type() query.Type {
+	return sqltypes.Text
 }
 
 // ValueType implements the DoltgresType interface.
-func (b Int16Type) ValueType() reflect.Type {
-	return reflect.TypeOf(int16(0))
+func (b TimeType) ValueType() reflect.Type {
+	return reflect.TypeOf(time.Time{})
 }
 
 // Zero implements the DoltgresType interface.
-func (b Int16Type) Zero() any {
-	return int16(0)
+func (b TimeType) Zero() any {
+	return time.Time{}
 }
 
 // SerializeType implements the DoltgresType interface.
-func (b Int16Type) SerializeType() ([]byte, error) {
-	return SerializationID_Int16.ToByteSlice(0), nil
+func (b TimeType) SerializeType() ([]byte, error) {
+	t := make([]byte, serializationIDHeaderSize+1)
+	copy(t, SerializationID_Time.ToByteSlice(0))
+	t[serializationIDHeaderSize] = byte(b.Precision)
+	return t, nil
 }
 
 // deserializeType implements the DoltgresType interface.
-func (b Int16Type) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
+func (b TimeType) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
 	switch version {
 	case 0:
-		return Int16, nil
+		return TimeType{
+			Precision: int8(metadata[0]),
+		}, nil
 	default:
 		return nil, fmt.Errorf("version %d is not yet supported for %s", version, b.String())
 	}
 }
 
 // SerializeValue implements the DoltgresType interface.
-func (b Int16Type) SerializeValue(val any) ([]byte, error) {
+func (b TimeType) SerializeValue(val any) ([]byte, error) {
 	if val == nil {
 		return nil, nil
 	}
@@ -265,15 +240,17 @@ func (b Int16Type) SerializeValue(val any) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	retVal := make([]byte, 2)
-	binary.BigEndian.PutUint16(retVal, uint16(converted.(int16))+(1<<15))
-	return retVal, nil
+	return converted.(time.Time).MarshalBinary()
 }
 
 // DeserializeValue implements the DoltgresType interface.
-func (b Int16Type) DeserializeValue(val []byte) (any, error) {
+func (b TimeType) DeserializeValue(val []byte) (any, error) {
 	if len(val) == 0 {
 		return nil, nil
 	}
-	return int16(binary.BigEndian.Uint16(val) - (1 << 15)), nil
+	t := time.Time{}
+	if err := t.UnmarshalBinary(val); err != nil {
+		return nil, err
+	}
+	return t, nil
 }

--- a/server/types/time_array.go
+++ b/server/types/time_array.go
@@ -1,0 +1,20 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "github.com/lib/pq/oid"
+
+// TimeArray is the array variant of Time.
+var TimeArray = createArrayType(Time, SerializationID_TimeArray, oid.T__time)

--- a/server/types/timestamp.go
+++ b/server/types/timestamp.go
@@ -16,39 +16,40 @@ package types
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"reflect"
-	"strconv"
+	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/dolthub/vitess/go/vt/proto/query"
 	"github.com/lib/pq/oid"
-	"github.com/shopspring/decimal"
 )
 
-// Int16 is an int16.
-var Int16 = Int16Type{}
+// Timestamp is the timestamp without a time zone. Precision is unbounded.
+var Timestamp = TimestampType{-1}
 
-// Int16Type is the extended type implementation of the PostgreSQL smallint.
-type Int16Type struct{}
+// TimestampType is the extended type implementation of the PostgreSQL timestamp without time zone.
+type TimestampType struct {
+	// TODO: implement precision
+	Precision int8
+}
 
-var _ DoltgresType = Int16Type{}
+var _ DoltgresType = TimestampType{}
 
 // BaseID implements the DoltgresType interface.
-func (b Int16Type) BaseID() DoltgresTypeBaseID {
-	return DoltgresTypeBaseID_Int16
+func (b TimestampType) BaseID() DoltgresTypeBaseID {
+	return DoltgresTypeBaseID_Timestamp
 }
 
 // CollationCoercibility implements the DoltgresType interface.
-func (b Int16Type) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+func (b TimestampType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
 	return sql.Collation_binary, 5
 }
 
 // Compare implements the DoltgresType interface.
-func (b Int16Type) Compare(v1 any, v2 any) (int, error) {
+func (b TimestampType) Compare(v1 any, v2 any) (int, error) {
 	if v1 == nil && v2 == nil {
 		return 0, nil
 	} else if v1 != nil && v2 == nil {
@@ -66,74 +67,34 @@ func (b Int16Type) Compare(v1 any, v2 any) (int, error) {
 		return 0, err
 	}
 
-	ab := ac.(int16)
-	bb := bc.(int16)
-	if ab == bb {
-		return 0, nil
-	} else if ab < bb {
-		return -1, nil
-	} else {
-		return 1, nil
-	}
+	ab := ac.(time.Time)
+	bb := bc.(time.Time)
+	return ab.Compare(bb), nil
 }
 
 // Convert implements the DoltgresType interface.
-func (b Int16Type) Convert(val any) (any, sql.ConvertInRange, error) {
-	switch val := val.(type) {
-	case bool:
-		if val {
-			return int16(1), sql.InRange, nil
-		}
-		return int16(0), sql.InRange, nil
-	case int:
-		return int16(val), sql.InRange, nil
-	case uint:
-		return int16(val), sql.InRange, nil
-	case int8:
-		return int16(val), sql.InRange, nil
-	case uint8:
-		return int16(val), sql.InRange, nil
-	case int16:
-		return int16(val), sql.InRange, nil
-	case uint16:
-		return int16(val), sql.InRange, nil
-	case int32:
-		return int16(val), sql.InRange, nil
-	case uint32:
-		return int16(val), sql.InRange, nil
-	case int64:
-		return int16(val), sql.InRange, nil
-	case uint64:
-		return int16(val), sql.InRange, nil
-	case float32:
-		return int16(val), sql.InRange, nil
-	case float64:
-		return int16(val), sql.InRange, nil
-	case decimal.NullDecimal:
-		if !val.Valid {
-			return nil, sql.InRange, nil
-		}
-		return b.Convert(val.Decimal)
-	case decimal.Decimal:
-		v, _ := val.Float64()
-		return int16(v), sql.InRange, nil
-	case string:
-		i, err := strconv.ParseInt(val, 10, 64)
-		if err != nil {
-			return nil, sql.OutOfRange, err
-		}
-		return int16(i), sql.InRange, nil
-	case []byte:
-		return b.Convert(string(val))
-	case nil:
+func (b TimestampType) Convert(val any) (any, sql.ConvertInRange, error) {
+	if val == nil {
 		return nil, sql.InRange, nil
+	}
+
+	switch val := val.(type) {
+	case string:
+		if t, err := time.Parse("2006-01-02 15:04:05", val); err == nil {
+			return t.UTC(), sql.InRange, nil
+		} else if t, err = time.Parse("January 01 15:04:05 2006", val); err == nil {
+			return t.UTC(), sql.InRange, nil
+		}
+		return nil, sql.OutOfRange, fmt.Errorf("invalid format for timestamp")
+	case time.Time:
+		return val.UTC(), sql.InRange, nil
 	default:
-		return nil, sql.OutOfRange, fmt.Errorf("%s: unhandled type: %T", b.String(), val)
+		return nil, sql.OutOfRange, sql.ErrInvalidType.New(b)
 	}
 }
 
 // Equals implements the DoltgresType interface.
-func (b Int16Type) Equals(otherType sql.Type) bool {
+func (b TimestampType) Equals(otherType sql.Type) bool {
 	if otherExtendedType, ok := otherType.(types.ExtendedType); ok {
 		return bytes.Equal(MustSerializeType(b), MustSerializeType(otherExtendedType))
 	}
@@ -141,7 +102,7 @@ func (b Int16Type) Equals(otherType sql.Type) bool {
 }
 
 // FormatSerializedValue implements the DoltgresType interface.
-func (b Int16Type) FormatSerializedValue(val []byte) (string, error) {
+func (b TimestampType) FormatSerializedValue(val []byte) (string, error) {
 	deserialized, err := b.DeserializeValue(val)
 	if err != nil {
 		return "", err
@@ -150,7 +111,7 @@ func (b Int16Type) FormatSerializedValue(val []byte) (string, error) {
 }
 
 // FormatValue implements the DoltgresType interface.
-func (b Int16Type) FormatValue(val any) (string, error) {
+func (b TimestampType) FormatValue(val any) (string, error) {
 	if val == nil {
 		return "", nil
 	}
@@ -158,41 +119,41 @@ func (b Int16Type) FormatValue(val any) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strconv.FormatInt(int64(converted.(int16)), 10), nil
+	return converted.(time.Time).Format("2006-01-02 15:04:05"), nil
 }
 
 // GetSerializationID implements the DoltgresType interface.
-func (b Int16Type) GetSerializationID() SerializationID {
-	return SerializationID_Int16
+func (b TimestampType) GetSerializationID() SerializationID {
+	return SerializationID_Timestamp
 }
 
 // IsUnbounded implements the DoltgresType interface.
-func (b Int16Type) IsUnbounded() bool {
+func (b TimestampType) IsUnbounded() bool {
 	return false
 }
 
 // MaxSerializedWidth implements the DoltgresType interface.
-func (b Int16Type) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
+func (b TimestampType) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
 	return types.ExtendedTypeSerializedWidth_64K
 }
 
 // MaxTextResponseByteLength implements the DoltgresType interface.
-func (b Int16Type) MaxTextResponseByteLength(ctx *sql.Context) uint32 {
-	return 2
+func (b TimestampType) MaxTextResponseByteLength(ctx *sql.Context) uint32 {
+	return 32
 }
 
 // OID implements the DoltgresType interface.
-func (b Int16Type) OID() uint32 {
-	return uint32(oid.T_int2)
+func (b TimestampType) OID() uint32 {
+	return uint32(oid.T_timestamp)
 }
 
 // Promote implements the DoltgresType interface.
-func (b Int16Type) Promote() sql.Type {
-	return b
+func (b TimestampType) Promote() sql.Type {
+	return Timestamp
 }
 
 // SerializedCompare implements the DoltgresType interface.
-func (b Int16Type) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
+func (b TimestampType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	if len(v1) == 0 && len(v2) == 0 {
 		return 0, nil
 	} else if len(v1) > 0 && len(v2) == 0 {
@@ -201,11 +162,12 @@ func (b Int16Type) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 		return -1, nil
 	}
 
+	// The marshalled time format is byte-comparable
 	return bytes.Compare(v1, v2), nil
 }
 
 // SQL implements the DoltgresType interface.
-func (b Int16Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
+func (b TimestampType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}
@@ -217,47 +179,55 @@ func (b Int16Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, er
 }
 
 // String implements the DoltgresType interface.
-func (b Int16Type) String() string {
-	return "smallint"
+func (b TimestampType) String() string {
+	if b.Precision == -1 {
+		return "timestamp"
+	}
+	return fmt.Sprintf("timestamp(%d)", b.Precision)
 }
 
 // ToArrayType implements the DoltgresType interface.
-func (b Int16Type) ToArrayType() DoltgresArrayType {
-	return Int16Array
+func (b TimestampType) ToArrayType() DoltgresArrayType {
+	return createArrayType(b, SerializationID_TimestampArray, oid.T__timestamp)
 }
 
 // Type implements the DoltgresType interface.
-func (b Int16Type) Type() query.Type {
-	return sqltypes.Int16
+func (b TimestampType) Type() query.Type {
+	return sqltypes.Text
 }
 
 // ValueType implements the DoltgresType interface.
-func (b Int16Type) ValueType() reflect.Type {
-	return reflect.TypeOf(int16(0))
+func (b TimestampType) ValueType() reflect.Type {
+	return reflect.TypeOf(time.Time{})
 }
 
 // Zero implements the DoltgresType interface.
-func (b Int16Type) Zero() any {
-	return int16(0)
+func (b TimestampType) Zero() any {
+	return time.Time{}
 }
 
 // SerializeType implements the DoltgresType interface.
-func (b Int16Type) SerializeType() ([]byte, error) {
-	return SerializationID_Int16.ToByteSlice(0), nil
+func (b TimestampType) SerializeType() ([]byte, error) {
+	t := make([]byte, serializationIDHeaderSize+1)
+	copy(t, SerializationID_Timestamp.ToByteSlice(0))
+	t[serializationIDHeaderSize] = byte(b.Precision)
+	return t, nil
 }
 
 // deserializeType implements the DoltgresType interface.
-func (b Int16Type) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
+func (b TimestampType) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
 	switch version {
 	case 0:
-		return Int16, nil
+		return TimestampType{
+			Precision: int8(metadata[0]),
+		}, nil
 	default:
 		return nil, fmt.Errorf("version %d is not yet supported for %s", version, b.String())
 	}
 }
 
 // SerializeValue implements the DoltgresType interface.
-func (b Int16Type) SerializeValue(val any) ([]byte, error) {
+func (b TimestampType) SerializeValue(val any) ([]byte, error) {
 	if val == nil {
 		return nil, nil
 	}
@@ -265,15 +235,17 @@ func (b Int16Type) SerializeValue(val any) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	retVal := make([]byte, 2)
-	binary.BigEndian.PutUint16(retVal, uint16(converted.(int16))+(1<<15))
-	return retVal, nil
+	return converted.(time.Time).MarshalBinary()
 }
 
 // DeserializeValue implements the DoltgresType interface.
-func (b Int16Type) DeserializeValue(val []byte) (any, error) {
+func (b TimestampType) DeserializeValue(val []byte) (any, error) {
 	if len(val) == 0 {
 		return nil, nil
 	}
-	return int16(binary.BigEndian.Uint16(val) - (1 << 15)), nil
+	t := time.Time{}
+	if err := t.UnmarshalBinary(val); err != nil {
+		return nil, err
+	}
+	return t, nil
 }

--- a/server/types/timestamp_array.go
+++ b/server/types/timestamp_array.go
@@ -1,0 +1,20 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "github.com/lib/pq/oid"
+
+// TimestampArray is the array variant of Timestamp.
+var TimestampArray = createArrayType(Timestamp, SerializationID_TimestampArray, oid.T__timestamp)

--- a/server/types/timestamptz.go
+++ b/server/types/timestamptz.go
@@ -1,0 +1,260 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/dolthub/vitess/go/sqltypes"
+	"github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/lib/pq/oid"
+)
+
+// TimestampTZ is the timestamp with a time zone. Precision is unbounded.
+var TimestampTZ = TimestampTZType{-1}
+
+// TimestampTZType is the extended type implementation of the PostgreSQL timestamp with time zone.
+type TimestampTZType struct {
+	// TODO: implement precision
+	Precision int8
+}
+
+var _ DoltgresType = TimestampTZType{}
+
+// BaseID implements the DoltgresType interface.
+func (b TimestampTZType) BaseID() DoltgresTypeBaseID {
+	return DoltgresTypeBaseID_TimestampTZ
+}
+
+// CollationCoercibility implements the DoltgresType interface.
+func (b TimestampTZType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
+// Compare implements the DoltgresType interface.
+func (b TimestampTZType) Compare(v1 any, v2 any) (int, error) {
+	if v1 == nil && v2 == nil {
+		return 0, nil
+	} else if v1 != nil && v2 == nil {
+		return 1, nil
+	} else if v1 == nil && v2 != nil {
+		return -1, nil
+	}
+
+	ac, _, err := b.Convert(v1)
+	if err != nil {
+		return 0, err
+	}
+	bc, _, err := b.Convert(v2)
+	if err != nil {
+		return 0, err
+	}
+
+	ab := ac.(time.Time)
+	bb := bc.(time.Time)
+	return ab.Compare(bb), nil
+}
+
+// Convert implements the DoltgresType interface.
+func (b TimestampTZType) Convert(val any) (any, sql.ConvertInRange, error) {
+	if val == nil {
+		return nil, sql.InRange, nil
+	}
+
+	switch val := val.(type) {
+	case string:
+		if t, err := time.Parse("2006-01-02 15:04:05-0700", val); err == nil {
+			return t, sql.InRange, nil
+		} else if t, err = time.Parse("2006-01-02 15:04:05-07:00", val); err == nil {
+			return t, sql.InRange, nil
+		} else if t, err = time.Parse("2006-01-02 15:04:05-07", val); err == nil {
+			return t, sql.InRange, nil
+		} else if t, err = time.Parse("January 01 15:04:05 2006 -0700", val); err == nil {
+			return t, sql.InRange, nil
+		} else if t, err = time.Parse("January 01 15:04:05 2006 -07:00", val); err == nil {
+			return t, sql.InRange, nil
+		} else if t, err = time.Parse("January 01 15:04:05 2006 -07", val); err == nil {
+			return t, sql.InRange, nil
+		}
+		return nil, sql.OutOfRange, fmt.Errorf("invalid format for timestamptz")
+	case time.Time:
+		return val, sql.InRange, nil
+	default:
+		return nil, sql.OutOfRange, sql.ErrInvalidType.New(b)
+	}
+}
+
+// Equals implements the DoltgresType interface.
+func (b TimestampTZType) Equals(otherType sql.Type) bool {
+	if otherExtendedType, ok := otherType.(types.ExtendedType); ok {
+		return bytes.Equal(MustSerializeType(b), MustSerializeType(otherExtendedType))
+	}
+	return false
+}
+
+// FormatSerializedValue implements the DoltgresType interface.
+func (b TimestampTZType) FormatSerializedValue(val []byte) (string, error) {
+	deserialized, err := b.DeserializeValue(val)
+	if err != nil {
+		return "", err
+	}
+	return b.FormatValue(deserialized)
+}
+
+// FormatValue implements the DoltgresType interface.
+func (b TimestampTZType) FormatValue(val any) (string, error) {
+	if val == nil {
+		return "", nil
+	}
+	converted, _, err := b.Convert(val)
+	if err != nil {
+		return "", err
+	}
+	// TODO: this always displays the time with an offset relevant to the server location
+	return converted.(time.Time).Format("2006-01-02 15:04:05-07"), nil
+}
+
+// GetSerializationID implements the DoltgresType interface.
+func (b TimestampTZType) GetSerializationID() SerializationID {
+	return SerializationID_TimestampTZ
+}
+
+// IsUnbounded implements the DoltgresType interface.
+func (b TimestampTZType) IsUnbounded() bool {
+	return false
+}
+
+// MaxSerializedWidth implements the DoltgresType interface.
+func (b TimestampTZType) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
+	return types.ExtendedTypeSerializedWidth_64K
+}
+
+// MaxTextResponseByteLength implements the DoltgresType interface.
+func (b TimestampTZType) MaxTextResponseByteLength(ctx *sql.Context) uint32 {
+	return 40
+}
+
+// OID implements the DoltgresType interface.
+func (b TimestampTZType) OID() uint32 {
+	return uint32(oid.T_timestamptz)
+}
+
+// Promote implements the DoltgresType interface.
+func (b TimestampTZType) Promote() sql.Type {
+	return TimestampTZ
+}
+
+// SerializedCompare implements the DoltgresType interface.
+func (b TimestampTZType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
+	if len(v1) == 0 && len(v2) == 0 {
+		return 0, nil
+	} else if len(v1) > 0 && len(v2) == 0 {
+		return 1, nil
+	} else if len(v1) == 0 && len(v2) > 0 {
+		return -1, nil
+	}
+
+	// The marshalled time format is byte-comparable
+	return bytes.Compare(v1, v2), nil
+}
+
+// SQL implements the DoltgresType interface.
+func (b TimestampTZType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
+	if v == nil {
+		return sqltypes.NULL, nil
+	}
+	value, err := b.FormatValue(v)
+	if err != nil {
+		return sqltypes.Value{}, err
+	}
+	return sqltypes.MakeTrusted(sqltypes.Text, types.AppendAndSliceBytes(dest, []byte(value))), nil
+}
+
+// String implements the DoltgresType interface.
+func (b TimestampTZType) String() string {
+	if b.Precision == -1 {
+		return "timestamptz"
+	}
+	return fmt.Sprintf("timestamptz(%d)", b.Precision)
+}
+
+// ToArrayType implements the DoltgresType interface.
+func (b TimestampTZType) ToArrayType() DoltgresArrayType {
+	return createArrayType(b, SerializationID_TimestampTZArray, oid.T__timestamptz)
+}
+
+// Type implements the DoltgresType interface.
+func (b TimestampTZType) Type() query.Type {
+	return sqltypes.Text
+}
+
+// ValueType implements the DoltgresType interface.
+func (b TimestampTZType) ValueType() reflect.Type {
+	return reflect.TypeOf(time.Time{})
+}
+
+// Zero implements the DoltgresType interface.
+func (b TimestampTZType) Zero() any {
+	return time.Time{}
+}
+
+// SerializeType implements the DoltgresType interface.
+func (b TimestampTZType) SerializeType() ([]byte, error) {
+	t := make([]byte, serializationIDHeaderSize+1)
+	copy(t, SerializationID_TimestampTZ.ToByteSlice(0))
+	t[serializationIDHeaderSize] = byte(b.Precision)
+	return t, nil
+}
+
+// deserializeType implements the DoltgresType interface.
+func (b TimestampTZType) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
+	switch version {
+	case 0:
+		return TimestampTZType{
+			Precision: int8(metadata[0]),
+		}, nil
+	default:
+		return nil, fmt.Errorf("version %d is not yet supported for %s", version, b.String())
+	}
+}
+
+// SerializeValue implements the DoltgresType interface.
+func (b TimestampTZType) SerializeValue(val any) ([]byte, error) {
+	if val == nil {
+		return nil, nil
+	}
+	converted, _, err := b.Convert(val)
+	if err != nil {
+		return nil, err
+	}
+	return converted.(time.Time).MarshalBinary()
+}
+
+// DeserializeValue implements the DoltgresType interface.
+func (b TimestampTZType) DeserializeValue(val []byte) (any, error) {
+	if len(val) == 0 {
+		return nil, nil
+	}
+	t := time.Time{}
+	if err := t.UnmarshalBinary(val); err != nil {
+		return nil, err
+	}
+	return t, nil
+}

--- a/server/types/timestamptz_array.go
+++ b/server/types/timestamptz_array.go
@@ -1,0 +1,20 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "github.com/lib/pq/oid"
+
+// TimestampTZArray is the array variant of TimestampTZ.
+var TimestampTZArray = createArrayType(TimestampTZ, SerializationID_TimestampTZArray, oid.T__timestamptz)

--- a/server/types/timetz_array.go
+++ b/server/types/timetz_array.go
@@ -1,0 +1,20 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "github.com/lib/pq/oid"
+
+// TimeTZArray is the array variant of TimeTZ.
+var TimeTZArray = createArrayType(TimeTZ, SerializationID_TimeTZArray, oid.T__timetz)

--- a/server/types/unknown.go
+++ b/server/types/unknown.go
@@ -76,6 +76,16 @@ func (u UnknownType) FormatValue(val any) (string, error) {
 	return "", fmt.Errorf("%s cannot format values", u.String())
 }
 
+// GetSerializationID implements the DoltgresType interface.
+func (u UnknownType) GetSerializationID() SerializationID {
+	return SerializationID_Invalid
+}
+
+// IsUnbounded implements the DoltgresType interface.
+func (u UnknownType) IsUnbounded() bool {
+	return false
+}
+
 // MaxSerializedWidth implements the DoltgresType interface.
 func (u UnknownType) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
 	return types.ExtendedTypeSerializedWidth_Unbounded
@@ -99,11 +109,6 @@ func (u UnknownType) Promote() sql.Type {
 // SerializedCompare implements the DoltgresType interface.
 func (u UnknownType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	return 0, fmt.Errorf("%s cannot compare serialized values", u.String())
-}
-
-// SerializeType implements the DoltgresType interface.
-func (u UnknownType) SerializeType() ([]byte, error) {
-	return nil, fmt.Errorf("%s cannot be serialized", u.String())
 }
 
 // SQL implements the DoltgresType interface.
@@ -136,6 +141,16 @@ func (u UnknownType) Zero() any {
 	return any(nil)
 }
 
+// SerializeType implements the DoltgresType interface.
+func (u UnknownType) SerializeType() ([]byte, error) {
+	return nil, fmt.Errorf("%s cannot be serialized", u.String())
+}
+
+// deserializeType implements the DoltgresType interface.
+func (u UnknownType) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
+	return nil, fmt.Errorf("%s cannot be deserialized", u.String())
+}
+
 // SerializeValue implements the DoltgresType interface.
 func (u UnknownType) SerializeValue(val any) ([]byte, error) {
 	return nil, fmt.Errorf("%s cannot serialize values", u.String())
@@ -144,9 +159,4 @@ func (u UnknownType) SerializeValue(val any) ([]byte, error) {
 // DeserializeValue implements the DoltgresType interface.
 func (u UnknownType) DeserializeValue(val []byte) (any, error) {
 	return nil, fmt.Errorf("%s cannot deserialize values", u.String())
-}
-
-// withInnerDeserialization implements the DoltgresArrayType interface.
-func (u UnknownType) withInnerDeserialization(innerSerializedType []byte) (types.ExtendedType, error) {
-	return nil, fmt.Errorf("%s cannot be deserialized", u.String())
 }

--- a/server/types/uuid.go
+++ b/server/types/uuid.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -37,7 +38,7 @@ var _ DoltgresType = UuidType{}
 
 // BaseID implements the DoltgresType interface.
 func (b UuidType) BaseID() DoltgresTypeBaseID {
-	return DoltgresTypeBaseID(SerializationID_Uuid)
+	return DoltgresTypeBaseID_Uuid
 }
 
 // CollationCoercibility implements the DoltgresType interface.
@@ -118,6 +119,16 @@ func (b UuidType) FormatValue(val any) (string, error) {
 	return converted.(uuid.UUID).String(), nil
 }
 
+// GetSerializationID implements the DoltgresType interface.
+func (b UuidType) GetSerializationID() SerializationID {
+	return SerializationID_Uuid
+}
+
+// IsUnbounded implements the DoltgresType interface.
+func (b UuidType) IsUnbounded() bool {
+	return false
+}
+
 // MaxSerializedWidth implements the DoltgresType interface.
 func (b UuidType) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
 	return types.ExtendedTypeSerializedWidth_64K
@@ -149,11 +160,6 @@ func (b UuidType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	}
 
 	return bytes.Compare(v1, v2), nil
-}
-
-// SerializeType implements the DoltgresType interface.
-func (b UuidType) SerializeType() ([]byte, error) {
-	return SerializationID_Uuid.ToByteSlice(), nil
 }
 
 // SQL implements the DoltgresType interface.
@@ -191,6 +197,21 @@ func (b UuidType) ValueType() reflect.Type {
 // Zero implements the DoltgresType interface.
 func (b UuidType) Zero() any {
 	return uuid.UUID{}
+}
+
+// SerializeType implements the DoltgresType interface.
+func (b UuidType) SerializeType() ([]byte, error) {
+	return SerializationID_Uuid.ToByteSlice(0), nil
+}
+
+// deserializeType implements the DoltgresType interface.
+func (b UuidType) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
+	switch version {
+	case 0:
+		return Uuid, nil
+	default:
+		return nil, fmt.Errorf("version %d is not yet supported for %s", version, b.String())
+	}
 }
 
 // SerializeValue implements the DoltgresType interface.

--- a/server/types/varchar_array.go
+++ b/server/types/varchar_array.go
@@ -26,11 +26,11 @@ import (
 
 // VarCharArray is the array variant of VarChar.
 var VarCharArray = createArrayTypeWithFuncs(VarChar, SerializationID_VarCharArray, oid.T__varchar, arrayContainerFunctions{
-	SQL: varCharArraySQL,
+	SQL: stringArraySQL,
 })
 
-// varCharArraySQL is the SQL implementation for VarCharArray.
-func varCharArraySQL(ctx *sql.Context, ac arrayContainer, dest []byte, valInterface any) (sqltypes.Value, error) {
+// stringArraySQL is the SQL implementation for all string array types.
+func stringArraySQL(ctx *sql.Context, ac arrayContainer, dest []byte, valInterface any) (sqltypes.Value, error) {
 	if valInterface == nil {
 		return sqltypes.NULL, nil
 	}

--- a/testing/go/types_test.go
+++ b/testing/go/types_test.go
@@ -223,10 +223,9 @@ var typesTests = []ScriptTest{
 	},
 	{
 		Name: "Bytea type",
-		Skip: true,
 		SetUpScript: []string{
 			"CREATE TABLE t_bytea (id INTEGER primary key, v1 BYTEA);",
-			"INSERT INTO t_bytea VALUES (1, E'\\\\xDEADBEEF'), (2, E'\\\\xC0FFEE');",
+			"INSERT INTO t_bytea VALUES (1, E'\\\\xDEADBEEF'), (2, '\\xC0FFEE');",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -242,7 +241,7 @@ var typesTests = []ScriptTest{
 		Name: "Character type",
 		SetUpScript: []string{
 			"CREATE TABLE t_character (id INTEGER primary key, v1 CHARACTER(5));",
-			"INSERT INTO t_character VALUES (1, 'abcde'), (2, 'vwxyz');",
+			"INSERT INTO t_character VALUES (1, 'abcde'), (2, 'vwxyz'), (3, 'ghi');",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -250,8 +249,8 @@ var typesTests = []ScriptTest{
 				Expected: []sql.Row{
 					{1, "abcde"},
 					{2, "vwxyz"},
+					{3, "ghi  "},
 				},
-				Skip: true, // getting spurious 'invalid length for "char": 5' error
 			},
 		},
 	},
@@ -369,7 +368,6 @@ var typesTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Skip:  true, // TODO: these are coming back as date time objects, not dates
 				Query: "SELECT * FROM t_date ORDER BY id;",
 				Expected: []sql.Row{
 					{1, "2023-01-01"},
@@ -809,7 +807,6 @@ var typesTests = []ScriptTest{
 	},
 	{
 		Name: "Time without time zone type",
-		Skip: true,
 		SetUpScript: []string{
 			"CREATE TABLE t_time_without_zone (id INTEGER primary key, v1 TIME);",
 			"INSERT INTO t_time_without_zone VALUES (1, '12:34:56'), (2, '23:45:01');",
@@ -824,7 +821,7 @@ var typesTests = []ScriptTest{
 			},
 		},
 	},
-	{
+	{ // TODO: timezone representation is reported via local time, need to account for that in testing?
 		Name: "Time with time zone type",
 		Skip: true,
 		SetUpScript: []string{
@@ -857,7 +854,7 @@ var typesTests = []ScriptTest{
 			},
 		},
 	},
-	{
+	{ // TODO: timezone representation is reported via local time, need to account for that in testing?
 		Name: "Timestamp with time zone type",
 		Skip: true,
 		SetUpScript: []string{
@@ -1057,7 +1054,7 @@ func TestSameTypes(t *testing.T) {
 				{
 					Query: "SELECT * FROM test ORDER BY 1;",
 					Expected: []sql.Row{
-						{"1986-08-02 17:04:22", "2023-09-03 00:00:00"},
+						{"1986-08-02 17:04:22", "2023-09-03"},
 					},
 				},
 			},


### PR DESCRIPTION
This adds several new types, and also reworks type serialization and casting, among a few other things. This is not nearly as tested as I'd want it to be, as I discovered that the implicit/explicit casting is fundamentally incompatible with how we use `sql.Type.Convert`, so that entire system needs to be "removed" for Doltgres (that is, it functionally should not do anything).

In addition, in an effort to be a little forward-thinking since I'm assuming we'll be breaking things a bit once the conversion system is removed, I added a form of type versions so that we can update types as we discover deficiencies. For example, let's say a type uses `-1` to mean "no limit", and then we later find out that `-1` is a valid value. We can make that distinction using type versions. In addition, this will break all existing databases due to the type serialization change, but I think it's fine as all currently known users should be able to rebuild the database since their replicas.