### PR TITLE
Added explicit initialization order to packages

### DIFF
--- a/server/cast/bool.go
+++ b/server/cast/bool.go
@@ -19,8 +19,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
-func init() {
+// initBool handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func initBool() {
 	boolExplicit()
 	boolImplicit()
 }

--- a/server/cast/bytea.go
+++ b/server/cast/bytea.go
@@ -21,8 +21,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
-func init() {
+// initBytea handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func initBytea() {
 	// TODO: handle the different output formats?
 	byteaExplicit()
 	byteaImplicit()

--- a/server/cast/char.go
+++ b/server/cast/char.go
@@ -27,8 +27,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
-func init() {
+// initChar handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func initChar() {
 	charExplicit()
 	charImplicit()
 }

--- a/server/cast/float32.go
+++ b/server/cast/float32.go
@@ -25,8 +25,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
-func init() {
+// initFloat32 handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func initFloat32() {
 	float32Explicit()
 	float32Implicit()
 }

--- a/server/cast/float64.go
+++ b/server/cast/float64.go
@@ -25,8 +25,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
-func init() {
+// initFloat64 handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func initFloat64() {
 	float64Explicit()
 	float64Implicit()
 }

--- a/server/cast/init.go
+++ b/server/cast/init.go
@@ -12,27 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package functions
+package cast
 
-import (
-	"math"
-
-	"github.com/dolthub/doltgresql/server/functions/framework"
-
-	pgtypes "github.com/dolthub/doltgresql/server/types"
-)
-
-// initPi registers the functions to the catalog.
-func initPi() {
-	framework.RegisterFunction(pi)
-}
-
-// pi represents the PostgreSQL function of the same name, taking the same parameters.
-var pi = framework.Function0{
-	Name:       "pi",
-	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{},
-	Callable: func(ctx framework.Context) (any, error) {
-		return float64(math.Pi), nil
-	},
+// Init initializes all casts in this package.
+func Init() {
+	initBool()
+	initBytea()
+	initChar()
+	initFloat32()
+	initFloat64()
+	initInt16()
+	initInt32()
+	initInt64()
+	initNumeric()
+	initText()
+	initUuid()
+	initVarChar()
 }

--- a/server/cast/int16.go
+++ b/server/cast/int16.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
-func init() {
+// initInt16 handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func initInt16() {
 	int16Explicit()
 	int16Implicit()
 }

--- a/server/cast/int32.go
+++ b/server/cast/int32.go
@@ -24,8 +24,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
-func init() {
+// initInt32 handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func initInt32() {
 	int32Explicit()
 	int32Implicit()
 }

--- a/server/cast/int64.go
+++ b/server/cast/int64.go
@@ -24,8 +24,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
-func init() {
+// initInt64 handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func initInt64() {
 	int64Explicit()
 	int64Implicit()
 }

--- a/server/cast/numeric.go
+++ b/server/cast/numeric.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
-func init() {
+// initNumeric handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func initNumeric() {
 	numericExplicit()
 	numericImplicit()
 }

--- a/server/cast/text.go
+++ b/server/cast/text.go
@@ -27,8 +27,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
-func init() {
+// initText handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func initText() {
 	textExplicit()
 	textImplicit()
 }

--- a/server/cast/uuid.go
+++ b/server/cast/uuid.go
@@ -20,8 +20,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
-func init() {
+// initUuid handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func initUuid() {
 	uuidExplicit()
 	uuidImplicit()
 }

--- a/server/cast/varchar.go
+++ b/server/cast/varchar.go
@@ -27,8 +27,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
-func init() {
+// initVarChar handles all explicit and implicit casts that are built-in. This comprises only the "From" types.
+func initVarChar() {
 	varcharExplicit()
 	varcharImplicit()
 }

--- a/server/config/parameters.go
+++ b/server/config/parameters.go
@@ -26,11 +26,11 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/variables"
 )
 
-// init initializes or appends to SystemVariables as it functions as a global variable.
+// Init initializes or appends to SystemVariables as it functions as a global variable.
 // Currently, we append all of postgres configuration parameters to sql.SystemVariables.
 // This means that all of mysql system variables and postgres config parameters will be stored together.
 // TODO: get rid of me, use an integration point to define new sysvars
-func init() {
+func Init() {
 	// There are two postgres parameters have the same name as mysql variables
 	// TODO: issue with this approach is that those parameters will override the mysql variables.
 	if sql.SystemVariables == nil {

--- a/server/expression/binary_operator.go
+++ b/server/expression/binary_operator.go
@@ -21,7 +21,6 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
 
-	_ "github.com/dolthub/doltgresql/server/functions/binary"
 	"github.com/dolthub/doltgresql/server/functions/framework"
 )
 

--- a/server/expression/cast.go
+++ b/server/expression/cast.go
@@ -21,7 +21,6 @@ import (
 	"github.com/dolthub/vitess/go/vt/proto/query"
 	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
 
-	_ "github.com/dolthub/doltgresql/server/cast"
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )

--- a/server/expression/unary_operator.go
+++ b/server/expression/unary_operator.go
@@ -21,7 +21,6 @@ import (
 	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
-	_ "github.com/dolthub/doltgresql/server/functions/unary"
 )
 
 // UnaryOperator represents a VALUE OPERATOR VALUE expression.

--- a/server/functions/abs.go
+++ b/server/functions/abs.go
@@ -22,8 +22,8 @@ import (
 	"github.com/dolthub/doltgresql/utils"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initAbs registers the functions to the catalog.
+func initAbs() {
 	framework.RegisterFunction(abs_int16)
 	framework.RegisterFunction(abs_int32)
 	framework.RegisterFunction(abs_int64)

--- a/server/functions/acos.go
+++ b/server/functions/acos.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initAcos registers the functions to the catalog.
+func initAcos() {
 	framework.RegisterFunction(acos_float64)
 }
 

--- a/server/functions/acosd.go
+++ b/server/functions/acosd.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initAcosd registers the functions to the catalog.
+func initAcosd() {
 	framework.RegisterFunction(acosd_float64)
 }
 

--- a/server/functions/acosh.go
+++ b/server/functions/acosh.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initAcosh registers the functions to the catalog.
+func initAcosh() {
 	framework.RegisterFunction(acosh_float64)
 }
 

--- a/server/functions/ascii.go
+++ b/server/functions/ascii.go
@@ -19,8 +19,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initAscii registers the functions to the catalog.
+func initAscii() {
 	framework.RegisterFunction(ascii_varchar)
 }
 

--- a/server/functions/asin.go
+++ b/server/functions/asin.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initAsin registers the functions to the catalog.
+func initAsin() {
 	framework.RegisterFunction(asin_float64)
 }
 

--- a/server/functions/asind.go
+++ b/server/functions/asind.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initAsind registers the functions to the catalog.
+func initAsind() {
 	framework.RegisterFunction(asind_float64)
 }
 

--- a/server/functions/asinh.go
+++ b/server/functions/asinh.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initAsinh registers the functions to the catalog.
+func initAsinh() {
 	framework.RegisterFunction(asinh_float64)
 }
 

--- a/server/functions/atan.go
+++ b/server/functions/atan.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initAtan registers the functions to the catalog.
+func initAtan() {
 	framework.RegisterFunction(atan_float64)
 }
 

--- a/server/functions/atan2.go
+++ b/server/functions/atan2.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initAtan2 registers the functions to the catalog.
+func initAtan2() {
 	framework.RegisterFunction(atan2_float64)
 }
 

--- a/server/functions/atan2d.go
+++ b/server/functions/atan2d.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initAtan2d registers the functions to the catalog.
+func initAtan2d() {
 	framework.RegisterFunction(atan2d_float64)
 }
 

--- a/server/functions/atand.go
+++ b/server/functions/atand.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initAtand registers the functions to the catalog.
+func initAtand() {
 	framework.RegisterFunction(atand_float64)
 }
 

--- a/server/functions/atanh.go
+++ b/server/functions/atanh.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initAtanh registers the functions to the catalog.
+func initAtanh() {
 	framework.RegisterFunction(atanh_float64)
 }
 

--- a/server/functions/binary/bit_and.go
+++ b/server/functions/binary/bit_and.go
@@ -22,8 +22,8 @@ import (
 // These functions can be gathered using the following query from a Postgres 15 instance:
 // SELECT * FROM pg_operator o WHERE o.oprname = '&' ORDER BY o.oprcode::varchar;
 
-// init registers the functions to the catalog.
-func init() {
+// InitBinaryBitAnd registers the functions to the catalog.
+func InitBinaryBitAnd() {
 	framework.RegisterBinaryFunction(framework.Operator_BinaryBitAnd, int2and)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryBitAnd, int4and)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryBitAnd, int8and)

--- a/server/functions/binary/bit_or.go
+++ b/server/functions/binary/bit_or.go
@@ -22,8 +22,8 @@ import (
 // These functions can be gathered using the following query from a Postgres 15 instance:
 // SELECT * FROM pg_operator o WHERE o.oprname = '|' ORDER BY o.oprcode::varchar;
 
-// init registers the functions to the catalog.
-func init() {
+// initBinaryBitOr registers the functions to the catalog.
+func initBinaryBitOr() {
 	framework.RegisterBinaryFunction(framework.Operator_BinaryBitOr, int2or)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryBitOr, int4or)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryBitOr, int8or)

--- a/server/functions/binary/bit_xor.go
+++ b/server/functions/binary/bit_xor.go
@@ -22,8 +22,8 @@ import (
 // These functions can be gathered using the following query from a Postgres 15 instance:
 // SELECT * FROM pg_operator o WHERE o.oprname = '#' ORDER BY o.oprcode::varchar;
 
-// init registers the functions to the catalog.
-func init() {
+// initBinaryBitXor registers the functions to the catalog.
+func initBinaryBitXor() {
 	framework.RegisterBinaryFunction(framework.Operator_BinaryBitXor, int2xor)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryBitXor, int4xor)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryBitXor, int8xor)

--- a/server/functions/binary/divide.go
+++ b/server/functions/binary/divide.go
@@ -26,8 +26,8 @@ import (
 // These functions can be gathered using the following query from a Postgres 15 instance:
 // SELECT * FROM pg_operator o WHERE o.oprname = '/' ORDER BY o.oprcode::varchar;
 
-// init registers the functions to the catalog.
-func init() {
+// initBinaryDivide registers the functions to the catalog.
+func initBinaryDivide() {
 	framework.RegisterBinaryFunction(framework.Operator_BinaryDivide, float4div)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryDivide, float48div)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryDivide, float8div)

--- a/server/functions/binary/init.go
+++ b/server/functions/binary/init.go
@@ -12,27 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package functions
+package binary
 
-import (
-	"math"
-
-	"github.com/dolthub/doltgresql/server/functions/framework"
-
-	pgtypes "github.com/dolthub/doltgresql/server/types"
-)
-
-// initPi registers the functions to the catalog.
-func initPi() {
-	framework.RegisterFunction(pi)
-}
-
-// pi represents the PostgreSQL function of the same name, taking the same parameters.
-var pi = framework.Function0{
-	Name:       "pi",
-	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{},
-	Callable: func(ctx framework.Context) (any, error) {
-		return float64(math.Pi), nil
-	},
+// Init initializes all binary operators in this package.
+func Init() {
+	InitBinaryBitAnd()
+	initBinaryBitOr()
+	initBinaryBitXor()
+	initBinaryDivide()
+	initBinaryMinus()
+	initBinaryMod()
+	initBinaryMultiply()
+	initBinaryPlus()
+	initBinaryShiftLeft()
+	initBinaryShiftRight()
 }

--- a/server/functions/binary/minus.go
+++ b/server/functions/binary/minus.go
@@ -27,8 +27,8 @@ import (
 // These functions can be gathered using the following query from a Postgres 15 instance:
 // SELECT * FROM pg_operator o WHERE o.oprname = '-' ORDER BY o.oprcode::varchar;
 
-// init registers the functions to the catalog.
-func init() {
+// initBinaryMinus registers the functions to the catalog.
+func initBinaryMinus() {
 	framework.RegisterBinaryFunction(framework.Operator_BinaryMinus, float4mi)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryMinus, float48mi)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryMinus, float8mi)

--- a/server/functions/binary/mod.go
+++ b/server/functions/binary/mod.go
@@ -26,8 +26,8 @@ import (
 // These functions can be gathered using the following query from a Postgres 15 instance:
 // SELECT * FROM pg_operator o WHERE o.oprname = '%' ORDER BY o.oprcode::varchar;
 
-// init registers the functions to the catalog.
-func init() {
+// initBinaryMod registers the functions to the catalog.
+func initBinaryMod() {
 	framework.RegisterBinaryFunction(framework.Operator_BinaryMod, int2mod)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryMod, int4mod)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryMod, int8mod)

--- a/server/functions/binary/multiply.go
+++ b/server/functions/binary/multiply.go
@@ -27,8 +27,8 @@ import (
 // These functions can be gathered using the following query from a Postgres 15 instance:
 // SELECT * FROM pg_operator o WHERE o.oprname = '*' ORDER BY o.oprcode::varchar;
 
-// init registers the functions to the catalog.
-func init() {
+// initBinaryMultiply registers the functions to the catalog.
+func initBinaryMultiply() {
 	framework.RegisterBinaryFunction(framework.Operator_BinaryMultiply, float4mul)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryMultiply, float48mul)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryMultiply, float8mul)

--- a/server/functions/binary/plus.go
+++ b/server/functions/binary/plus.go
@@ -27,8 +27,8 @@ import (
 // These functions can be gathered using the following query from a Postgres 15 instance:
 // SELECT * FROM pg_operator o WHERE o.oprname = '+' ORDER BY o.oprcode::varchar;
 
-// init registers the functions to the catalog.
-func init() {
+// initBinaryPlus registers the functions to the catalog.
+func initBinaryPlus() {
 	framework.RegisterBinaryFunction(framework.Operator_BinaryPlus, float4pl)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryPlus, float48pl)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryPlus, float8pl)

--- a/server/functions/binary/shift_left.go
+++ b/server/functions/binary/shift_left.go
@@ -22,8 +22,8 @@ import (
 // These functions can be gathered using the following query from a Postgres 15 instance:
 // SELECT * FROM pg_operator o WHERE o.oprname = '<<' ORDER BY o.oprcode::varchar;
 
-// init registers the functions to the catalog.
-func init() {
+// initBinaryShiftLeft registers the functions to the catalog.
+func initBinaryShiftLeft() {
 	framework.RegisterBinaryFunction(framework.Operator_BinaryShiftLeft, int2shl)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryShiftLeft, int4shl)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryShiftLeft, int8shl)

--- a/server/functions/binary/shift_right.go
+++ b/server/functions/binary/shift_right.go
@@ -22,8 +22,8 @@ import (
 // These functions can be gathered using the following query from a Postgres 15 instance:
 // SELECT * FROM pg_operator o WHERE o.oprname = '>>' ORDER BY o.oprcode::varchar;
 
-// init registers the functions to the catalog.
-func init() {
+// initBinaryShiftRight registers the functions to the catalog.
+func initBinaryShiftRight() {
 	framework.RegisterBinaryFunction(framework.Operator_BinaryShiftRight, int2shr)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryShiftRight, int4shr)
 	framework.RegisterBinaryFunction(framework.Operator_BinaryShiftRight, int8shr)

--- a/server/functions/bit_length.go
+++ b/server/functions/bit_length.go
@@ -19,8 +19,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initBitLength registers the functions to the catalog.
+func initBitLength() {
 	framework.RegisterFunction(bit_length_varchar)
 }
 

--- a/server/functions/btrim.go
+++ b/server/functions/btrim.go
@@ -19,8 +19,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initBtrim registers the functions to the catalog.
+func initBtrim() {
 	framework.RegisterFunction(btrim_varchar_varchar)
 }
 

--- a/server/functions/cbrt.go
+++ b/server/functions/cbrt.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initCbrt registers the functions to the catalog.
+func initCbrt() {
 	framework.RegisterFunction(cbrt_float64)
 }
 

--- a/server/functions/ceil.go
+++ b/server/functions/ceil.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initCeil registers the functions to the catalog.
+func initCeil() {
 	framework.RegisterFunction(ceil_float64)
 	framework.RegisterFunction(ceil_numeric)
 	// Register aliases

--- a/server/functions/char_length.go
+++ b/server/functions/char_length.go
@@ -19,8 +19,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initCharLength registers the functions to the catalog.
+func initCharLength() {
 	framework.RegisterFunction(char_length_varchar)
 	// Register alias
 	character_length_varchar := char_length_varchar

--- a/server/functions/chr.go
+++ b/server/functions/chr.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initChr registers the functions to the catalog.
+func initChr() {
 	framework.RegisterFunction(chr_int32)
 }
 

--- a/server/functions/cos.go
+++ b/server/functions/cos.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initCos registers the functions to the catalog.
+func initCos() {
 	framework.RegisterFunction(cos_float64)
 }
 

--- a/server/functions/cosd.go
+++ b/server/functions/cosd.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initCosd registers the functions to the catalog.
+func initCosd() {
 	framework.RegisterFunction(cosd_float64)
 }
 

--- a/server/functions/cosh.go
+++ b/server/functions/cosh.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initCosh registers the functions to the catalog.
+func initCosh() {
 	framework.RegisterFunction(cosh_float64)
 }
 

--- a/server/functions/cot.go
+++ b/server/functions/cot.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initCot registers the functions to the catalog.
+func initCot() {
 	framework.RegisterFunction(cot_float64)
 }
 

--- a/server/functions/cotd.go
+++ b/server/functions/cotd.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initCotd registers the functions to the catalog.
+func initCotd() {
 	framework.RegisterFunction(cotd_float64)
 }
 

--- a/server/functions/degrees.go
+++ b/server/functions/degrees.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initDegrees registers the functions to the catalog.
+func initDegrees() {
 	framework.RegisterFunction(degrees_float64)
 }
 

--- a/server/functions/div.go
+++ b/server/functions/div.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initDiv registers the functions to the catalog.
+func initDiv() {
 	framework.RegisterFunction(div_numeric)
 }
 

--- a/server/functions/exp.go
+++ b/server/functions/exp.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initExp registers the functions to the catalog.
+func initExp() {
 	framework.RegisterFunction(exp_float64)
 	framework.RegisterFunction(exp_numeric)
 }

--- a/server/functions/factorial.go
+++ b/server/functions/factorial.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initFactorial registers the functions to the catalog.
+func initFactorial() {
 	framework.RegisterFunction(factorial_int64)
 }
 

--- a/server/functions/floor.go
+++ b/server/functions/floor.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initFloor registers the functions to the catalog.
+func initFloor() {
 	framework.RegisterFunction(floor_float64)
 	framework.RegisterFunction(floor_numeric)
 }

--- a/server/functions/gcd.go
+++ b/server/functions/gcd.go
@@ -20,8 +20,8 @@ import (
 	"github.com/dolthub/doltgresql/utils"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initGcd registers the functions to the catalog.
+func initGcd() {
 	framework.RegisterFunction(gcd_int64_int64)
 }
 

--- a/server/functions/init.go
+++ b/server/functions/init.go
@@ -1,0 +1,91 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+// Init initializes all functions in this package.
+func Init() {
+	initAbs()
+	initAcos()
+	initAcosd()
+	initAcosh()
+	initAscii()
+	initAsin()
+	initAsind()
+	initAsinh()
+	initAtan()
+	initAtan2()
+	initAtan2d()
+	initAtand()
+	initAtanh()
+	initBitLength()
+	initBtrim()
+	initCbrt()
+	initCeil()
+	initCharLength()
+	initChr()
+	initCos()
+	initCosd()
+	initCosh()
+	initCot()
+	initCotd()
+	initDegrees()
+	initDiv()
+	initExp()
+	initFactorial()
+	initFloor()
+	initGcd()
+	initInitcap()
+	initLcm()
+	initLeft()
+	initLength()
+	initLn()
+	initLog()
+	initLog10()
+	initLower()
+	initLpad()
+	initLtrim()
+	initMd5()
+	initMinScale()
+	initMod()
+	initOctetLength()
+	initPi()
+	initPower()
+	initRadians()
+	initRandom()
+	initRepeat()
+	initReplace()
+	initReverse()
+	initRight()
+	initRound()
+	initRpad()
+	initRtrim()
+	initScale()
+	initSign()
+	initSin()
+	initSind()
+	initSinh()
+	initSplitPart()
+	initSqrt()
+	initStrpos()
+	initSubstr()
+	initTan()
+	initTand()
+	initTanh()
+	initToHex()
+	initTrimScale()
+	initTrunc()
+	initUpper()
+	initWidthBucket()
+}

--- a/server/functions/initcap.go
+++ b/server/functions/initcap.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initInitcap registers the functions to the catalog.
+func initInitcap() {
 	framework.RegisterFunction(initcap_varchar)
 }
 

--- a/server/functions/lcm.go
+++ b/server/functions/lcm.go
@@ -22,8 +22,8 @@ import (
 	"github.com/dolthub/doltgresql/utils"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initLcm registers the functions to the catalog.
+func initLcm() {
 	framework.RegisterFunction(lcm_int64_int64)
 }
 

--- a/server/functions/left.go
+++ b/server/functions/left.go
@@ -19,8 +19,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initLeft registers the functions to the catalog.
+func initLeft() {
 	framework.RegisterFunction(left_varchar_int32)
 }
 

--- a/server/functions/length.go
+++ b/server/functions/length.go
@@ -19,8 +19,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initLength registers the functions to the catalog.
+func initLength() {
 	framework.RegisterFunction(length_varchar)
 }
 

--- a/server/functions/ln.go
+++ b/server/functions/ln.go
@@ -24,8 +24,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initLn registers the functions to the catalog.
+func initLn() {
 	framework.RegisterFunction(ln_float64)
 	framework.RegisterFunction(ln_numeric)
 }

--- a/server/functions/log.go
+++ b/server/functions/log.go
@@ -24,8 +24,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initLog registers the functions to the catalog.
+func initLog() {
 	framework.RegisterFunction(log_float64)
 	framework.RegisterFunction(log_numeric)
 	framework.RegisterFunction(log_numeric_numeric)

--- a/server/functions/log10.go
+++ b/server/functions/log10.go
@@ -16,8 +16,8 @@ package functions
 
 import "github.com/dolthub/doltgresql/server/functions/framework"
 
-// init registers the functions to the catalog.
-func init() {
+// initLog10 registers the functions to the catalog.
+func initLog10() {
 	log10_float64 := log_float64
 	log10_numeric := log_numeric
 	log10_float64.Name = "log10"

--- a/server/functions/lower.go
+++ b/server/functions/lower.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initLower registers the functions to the catalog.
+func initLower() {
 	framework.RegisterFunction(lower_varchar)
 }
 

--- a/server/functions/lpad.go
+++ b/server/functions/lpad.go
@@ -19,8 +19,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initLpad registers the functions to the catalog.
+func initLpad() {
 	framework.RegisterFunction(lpad_varchar_int32)
 	framework.RegisterFunction(lpad_varchar_int32_varchar)
 }

--- a/server/functions/ltrim.go
+++ b/server/functions/ltrim.go
@@ -19,8 +19,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initLtrim registers the functions to the catalog.
+func initLtrim() {
 	framework.RegisterFunction(ltrim_varchar)
 	framework.RegisterFunction(ltrim_varchar_varchar)
 }

--- a/server/functions/md5.go
+++ b/server/functions/md5.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initMd5 registers the functions to the catalog.
+func initMd5() {
 	framework.RegisterFunction(md5_varchar)
 }
 

--- a/server/functions/min_scale.go
+++ b/server/functions/min_scale.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initMinScale registers the functions to the catalog.
+func initMinScale() {
 	framework.RegisterFunction(min_scale_numeric)
 }
 

--- a/server/functions/mod.go
+++ b/server/functions/mod.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initMod registers the functions to the catalog.
+func initMod() {
 	framework.RegisterFunction(mod_int16_int16)
 	framework.RegisterFunction(mod_int32_int32)
 	framework.RegisterFunction(mod_int64_int64)

--- a/server/functions/octet_length.go
+++ b/server/functions/octet_length.go
@@ -19,8 +19,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initOctetLength registers the functions to the catalog.
+func initOctetLength() {
 	framework.RegisterFunction(octet_length_varchar)
 }
 

--- a/server/functions/power.go
+++ b/server/functions/power.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initPower registers the functions to the catalog.
+func initPower() {
 	framework.RegisterFunction(power_float64_float64)
 	framework.RegisterFunction(power_numeric_numeric)
 }

--- a/server/functions/radians.go
+++ b/server/functions/radians.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initRadians registers the functions to the catalog.
+func initRadians() {
 	framework.RegisterFunction(radians_float64)
 }
 

--- a/server/functions/random.go
+++ b/server/functions/random.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initRandom registers the functions to the catalog.
+func initRandom() {
 	framework.RegisterFunction(random)
 }
 

--- a/server/functions/repeat.go
+++ b/server/functions/repeat.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initRepeat registers the functions to the catalog.
+func initRepeat() {
 	framework.RegisterFunction(repeat_varchar_int32)
 }
 

--- a/server/functions/replace.go
+++ b/server/functions/replace.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initReplace registers the functions to the catalog.
+func initReplace() {
 	framework.RegisterFunction(replace_varchar_varchar_varchar)
 }
 

--- a/server/functions/reverse.go
+++ b/server/functions/reverse.go
@@ -19,8 +19,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initReverse registers the functions to the catalog.
+func initReverse() {
 	framework.RegisterFunction(reverse_varchar)
 }
 

--- a/server/functions/right.go
+++ b/server/functions/right.go
@@ -19,8 +19,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initRight registers the functions to the catalog.
+func initRight() {
 	framework.RegisterFunction(right_varchar_int32)
 }
 

--- a/server/functions/round.go
+++ b/server/functions/round.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initRound registers the functions to the catalog.
+func initRound() {
 	framework.RegisterFunction(round_float64)
 	framework.RegisterFunction(round_numeric)
 	framework.RegisterFunction(round_numeric_int64)

--- a/server/functions/rpad.go
+++ b/server/functions/rpad.go
@@ -19,8 +19,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initRpad registers the functions to the catalog.
+func initRpad() {
 	framework.RegisterFunction(rpad_varchar_int32)
 	framework.RegisterFunction(rpad_varchar_int32_varchar)
 }

--- a/server/functions/rtrim.go
+++ b/server/functions/rtrim.go
@@ -19,8 +19,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initRtrim registers the functions to the catalog.
+func initRtrim() {
 	framework.RegisterFunction(rtrim_varchar)
 	framework.RegisterFunction(rtrim_varchar_varchar)
 }

--- a/server/functions/sign.go
+++ b/server/functions/sign.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initSign registers the functions to the catalog.
+func initSign() {
 	framework.RegisterFunction(sign_float64)
 	framework.RegisterFunction(sign_numeric)
 }

--- a/server/functions/sin.go
+++ b/server/functions/sin.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initSin registers the functions to the catalog.
+func initSin() {
 	framework.RegisterFunction(sin_float64)
 }
 

--- a/server/functions/sind.go
+++ b/server/functions/sind.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initSind registers the functions to the catalog.
+func initSind() {
 	framework.RegisterFunction(sind_float64)
 }
 

--- a/server/functions/sinh.go
+++ b/server/functions/sinh.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initSinh registers the functions to the catalog.
+func initSinh() {
 	framework.RegisterFunction(sinh_float64)
 }
 

--- a/server/functions/split_part.go
+++ b/server/functions/split_part.go
@@ -23,8 +23,8 @@ import (
 	"github.com/dolthub/doltgresql/utils"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initSplitPart registers the functions to the catalog.
+func initSplitPart() {
 	framework.RegisterFunction(split_part_varchar_varchar_int32)
 }
 

--- a/server/functions/sqrt.go
+++ b/server/functions/sqrt.go
@@ -24,8 +24,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catasqrt.
-func init() {
+// initSqrt registers the functions to the catasqrt.
+func initSqrt() {
 	framework.RegisterFunction(sqrt_float64)
 	framework.RegisterFunction(sqrt_numeric)
 }

--- a/server/functions/strpos.go
+++ b/server/functions/strpos.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initStrpos registers the functions to the catalog.
+func initStrpos() {
 	framework.RegisterFunction(strpos_varchar)
 }
 

--- a/server/functions/substr.go
+++ b/server/functions/substr.go
@@ -21,8 +21,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initSubstr registers the functions to the catalog.
+func initSubstr() {
 	framework.RegisterFunction(substr_varchar_int32)
 	framework.RegisterFunction(substr_varchar_int32_int32)
 }

--- a/server/functions/tan.go
+++ b/server/functions/tan.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initTan registers the functions to the catalog.
+func initTan() {
 	framework.RegisterFunction(tan_float64)
 }
 

--- a/server/functions/tand.go
+++ b/server/functions/tand.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initTand registers the functions to the catalog.
+func initTand() {
 	framework.RegisterFunction(tand_float64)
 }
 

--- a/server/functions/tanh.go
+++ b/server/functions/tanh.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initTanh registers the functions to the catalog.
+func initTanh() {
 	framework.RegisterFunction(tanh_float64)
 }
 

--- a/server/functions/to_hex.go
+++ b/server/functions/to_hex.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initToHex registers the functions to the catalog.
+func initToHex() {
 	framework.RegisterFunction(to_hex_int64)
 }
 

--- a/server/functions/trim_scale.go
+++ b/server/functions/trim_scale.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initTrimScale registers the functions to the catalog.
+func initTrimScale() {
 	framework.RegisterFunction(trim_scale_numeric)
 }
 

--- a/server/functions/trunc.go
+++ b/server/functions/trunc.go
@@ -23,8 +23,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initTrunc registers the functions to the catalog.
+func initTrunc() {
 	framework.RegisterFunction(trunc_float64)
 	framework.RegisterFunction(trunc_numeric)
 	framework.RegisterFunction(trunc_numeric_int64)

--- a/server/functions/unary/init.go
+++ b/server/functions/unary/init.go
@@ -12,27 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package functions
+package unary
 
-import (
-	"math"
-
-	"github.com/dolthub/doltgresql/server/functions/framework"
-
-	pgtypes "github.com/dolthub/doltgresql/server/types"
-)
-
-// initPi registers the functions to the catalog.
-func initPi() {
-	framework.RegisterFunction(pi)
-}
-
-// pi represents the PostgreSQL function of the same name, taking the same parameters.
-var pi = framework.Function0{
-	Name:       "pi",
-	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{},
-	Callable: func(ctx framework.Context) (any, error) {
-		return float64(math.Pi), nil
-	},
+// Init initializes all unary operators in this package.
+func Init() {
+	initUnaryMinus()
+	initUnaryPlus()
 }

--- a/server/functions/unary/minus.go
+++ b/server/functions/unary/minus.go
@@ -24,8 +24,8 @@ import (
 // These functions can be gathered using the following query from a Postgres 15 instance:
 // SELECT * FROM pg_operator o WHERE o.oprname = '-' AND o.oprleft = 0 ORDER BY o.oprcode::varchar;
 
-// init registers the functions to the catalog.
-func init() {
+// initUnaryMinus registers the functions to the catalog.
+func initUnaryMinus() {
 	framework.RegisterUnaryFunction(framework.Operator_UnaryMinus, float4um)
 	framework.RegisterUnaryFunction(framework.Operator_UnaryMinus, float8um)
 	framework.RegisterUnaryFunction(framework.Operator_UnaryMinus, int2um)

--- a/server/functions/unary/plus.go
+++ b/server/functions/unary/plus.go
@@ -22,8 +22,8 @@ import (
 // These functions can be gathered using the following query from a Postgres 15 instance:
 // SELECT * FROM pg_operator o WHERE o.oprname = '+' AND o.oprleft = 0 ORDER BY o.oprcode::varchar;
 
-// init registers the functions to the catalog.
-func init() {
+// initUnaryPlus registers the functions to the catalog.
+func initUnaryPlus() {
 	framework.RegisterUnaryFunction(framework.Operator_UnaryPlus, float4up)
 	framework.RegisterUnaryFunction(framework.Operator_UnaryPlus, float8up)
 	framework.RegisterUnaryFunction(framework.Operator_UnaryPlus, int2up)

--- a/server/functions/upper.go
+++ b/server/functions/upper.go
@@ -22,8 +22,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initUpper registers the functions to the catalog.
+func initUpper() {
 	framework.RegisterFunction(upper_varchar)
 }
 

--- a/server/functions/width_bucket.go
+++ b/server/functions/width_bucket.go
@@ -24,8 +24,8 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// init registers the functions to the catalog.
-func init() {
+// initWidthBucket registers the functions to the catalog.
+func initWidthBucket() {
 	framework.RegisterFunction(width_bucket_float64_float64_float64_int64)
 	framework.RegisterFunction(width_bucket_numeric_numeric_numeric_int64)
 }

--- a/server/initialization/initialization.go
+++ b/server/initialization/initialization.go
@@ -12,29 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package functions
+package initialization
 
 import (
-	"github.com/dolthub/doltgresql/server/functions/framework"
+	"sync"
 
+	"github.com/dolthub/doltgresql/server/cast"
+	"github.com/dolthub/doltgresql/server/config"
+	"github.com/dolthub/doltgresql/server/functions"
+	"github.com/dolthub/doltgresql/server/functions/binary"
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	"github.com/dolthub/doltgresql/server/functions/unary"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// initScale registers the functions to the catalog.
-func initScale() {
-	framework.RegisterFunction(scale_numeric)
-}
+var once = &sync.Once{}
 
-// scale_numeric represents the PostgreSQL function of the same name, taking the same parameters.
-var scale_numeric = framework.Function1{
-	Name:       "scale",
-	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric},
-	Callable: func(ctx framework.Context, val1 any) (any, error) {
-		res, err := min_scale_numeric.Callable(ctx, val1)
-		if res != nil {
-			return res.(int32), err
-		}
-		return nil, err
-	},
+// Initialize initializes each package across the project. This function should be used instead of an init() function.
+func Initialize() {
+	once.Do(func() {
+		config.Init()
+		pgtypes.InitBaseIDs()
+		binary.Init()
+		unary.Init()
+		functions.Init()
+		cast.Init()
+		framework.Initialize()
+	})
 }

--- a/server/listener.go
+++ b/server/listener.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/dolthub/go-mysql-server/server"
 	"github.com/dolthub/vitess/go/mysql"
-
-	_ "github.com/dolthub/doltgresql/server/functions"
 )
 
 var (

--- a/server/server.go
+++ b/server/server.go
@@ -36,8 +36,7 @@ import (
 	"github.com/dolthub/go-mysql-server/server"
 	"github.com/dolthub/go-mysql-server/sql"
 
-	_ "github.com/dolthub/doltgresql/server/config"
-	"github.com/dolthub/doltgresql/server/functions/framework"
+	"github.com/dolthub/doltgresql/server/initialization"
 	"github.com/dolthub/doltgresql/server/logrepl"
 )
 
@@ -126,7 +125,6 @@ func init() {
 	server.DefaultProtocolListenerFunc = NewListener
 	sqlserver.ExternalDisableUsers = true
 	dfunctions.VersionString = Version
-	framework.Initialize()
 }
 
 // RunOnDisk starts the server based on the given args, while also using the local disk as the backing store.
@@ -155,7 +153,7 @@ func RunInMemory(args []string) (*svcs.Controller, error) {
 // runServer starts the server based on the given args, using the provided file system as the backing store.
 // The returned WaitGroup may be used to wait for the server to close.
 func runServer(ctx context.Context, args []string, dEnv *env.DoltEnv) (*svcs.Controller, error) {
-	//doltgresconfig.InitConfigParameters()
+	initialization.Initialize()
 
 	sqlServerCmd := sqlserver.SqlServerCmd{}
 	if serverArgs, err := sqlServerCmd.ArgParser().Parse(append([]string{"sql-server"}, args...)); err == nil {

--- a/server/types/base_ids.go
+++ b/server/types/base_ids.go
@@ -73,8 +73,8 @@ const (
 // baseIDArrayTypes contains a map of all base IDs that represent array variants.
 var baseIDArrayTypes = map[DoltgresTypeBaseID]DoltgresArrayType{}
 
-// init reads the list of all types and creates a mapping of the base ID for each array variant.
-func init() {
+// InitBaseIDs reads the list of all types and creates a mapping of the base ID for each array variant.
+func InitBaseIDs() {
 	for _, t := range typesFromBaseID {
 		if dat, ok := t.(DoltgresArrayType); ok {
 			baseIDArrayTypes[t.BaseID()] = dat

--- a/testing/generation/function_coverage/main.go
+++ b/testing/generation/function_coverage/main.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/dolthub/go-mysql-server/sql"
 
-	_ "github.com/dolthub/doltgresql/server/functions"
 	"github.com/dolthub/doltgresql/server/functions/framework"
+	"github.com/dolthub/doltgresql/server/initialization"
 	"github.com/dolthub/doltgresql/testing/generation/utils"
 )
 
@@ -33,7 +33,7 @@ type Assertion struct {
 }
 
 func main() {
-	framework.Initialize()
+	initialization.Initialize()
 	rootFolder, err := utils.GetRootFolder()
 	if err != nil {
 		fmt.Printf("%s\n", err.Error())


### PR DESCRIPTION
This replaces all of the `init()` functions throughout the project with a package-level `Init()` function that is called from a new `initialization` package. This now gives an explicit ordering to the calls. The biggest disadvantage of this approach is that some packages cannot have package-level tests that can access package-private variables without potentially causing import cycles if they need to initialize another package. This was also a limitation with the previous `init()` approach as well, but the _vast majority_ of our tests are done from the `testing` subdirectories (in part due to this limitation), so we've not lost anything by changing to this approach.