### PR TITLE
build parser earlier in release process

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -34,6 +34,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN || secrets.REPO_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Build SQL Syntax
+        run: ./build.sh
+        working-directory: ./postgres/parser
+        shell: bash
       - name: Update Doltgres version command
         run: sed -i -e 's/	Version = ".*"/	Version = "'"$NEW_VERSION"'"/' "$FILE"
         env:
@@ -67,10 +71,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Build SQL Syntax
-        run: ./build.sh
-        working-directory: ./postgres/parser
-        shell: bash
       - name: Build Binaries
         id: build_binaries
         run: |


### PR DESCRIPTION
The parser needs to be built before `go run -mod=readonly ./utils/genminver_validation/ $FILE`