### PR TITLE
`EXECUTE` doesn't send RowDescription

### DIFF
--- a/postgres/messages/command_complete.go
+++ b/postgres/messages/command_complete.go
@@ -70,16 +70,6 @@ func (m CommandComplete) IsIUD() bool {
 	}
 }
 
-// ReturnsRow returns whether the query returns set or rows such as SELECT and FETCH statements.
-func (m CommandComplete) ReturnsRow() bool {
-	switch m.Tag {
-	case "SELECT", "SHOW", "FETCH":
-		return true
-	default:
-		return false
-	}
-}
-
 // Encode implements the interface connection.Message.
 func (m CommandComplete) Encode() (connection.MessageFormat, error) {
 	outputMessage := m.DefaultMessage().Copy()
@@ -118,4 +108,14 @@ func (m CommandComplete) Decode(s connection.MessageFormat) (connection.Message,
 // DefaultMessage implements the interface connection.Message.
 func (m CommandComplete) DefaultMessage() *connection.MessageFormat {
 	return &commandCompleteDefault
+}
+
+// ReturnsRow returns whether the query returns set of rows such as SELECT and FETCH statements.
+func ReturnsRow(tag string) bool {
+	switch tag {
+	case "SELECT", "SHOW", "FETCH":
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
This PR fixes issue connecting to doltgres server using Postgres JDBC driver.

In [Postgres docs](https://www.postgresql.org/docs/current/protocol-flow.html), it says, "`Execute` doesn't cause ReadyForQuery or RowDescription to be issued."

Also, queries that don't return set of rows send `NoData` in response to `Describe` message.