### PR TITLE
Added string literal to array interpretation

### DIFF
--- a/postgres/parser/parser/parse.go
+++ b/postgres/parser/parser/parse.go
@@ -418,9 +418,6 @@ func arrayOf(
 	// If the reference is a statically known type, then return an array type,
 	// rather than an array type reference.
 	if typ, ok := tree.GetStaticallyKnownType(ref); ok {
-		if err := types.CheckArrayElementType(typ); err != nil {
-			return nil, err
-		}
 		return types.MakeArray(typ), nil
 	}
 	return &tree.ArrayTypeReference{ElementType: ref}, nil

--- a/postgres/parser/types/types.go
+++ b/postgres/parser/types/types.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq/oid"
 
-	"github.com/dolthub/doltgresql/postgres/parser/errorutil/unimplemented"
 	"github.com/dolthub/doltgresql/postgres/parser/geo/geopb"
 	"github.com/dolthub/doltgresql/postgres/parser/lex"
 	"github.com/dolthub/doltgresql/postgres/parser/oidext"
@@ -2392,28 +2391,6 @@ func IsStringType(t *T) bool {
 	default:
 		return false
 	}
-}
-
-// IsValidArrayElementType returns true if the given type can be used as the
-// element type of an ArrayFamily-typed column. If the valid return is false,
-// the issue number should be included in the error report to inform the user.
-func IsValidArrayElementType(t *T) (valid bool, issueNum int) {
-	switch t.Family() {
-	case JsonFamily:
-		return false, 23468
-	default:
-		return true, 0
-	}
-}
-
-// CheckArrayElementType ensures that the given type can be used as the element
-// type of an ArrayFamily-typed column. If not, it returns an error.
-func CheckArrayElementType(t *T) error {
-	if ok, issueNum := IsValidArrayElementType(t); !ok {
-		return unimplemented.NewWithIssueDetailf(issueNum, t.String(),
-			"arrays of %s not allowed", t)
-	}
-	return nil
 }
 
 // IsDateTimeType returns true if the given type is a date or time-related type.

--- a/server/expression/explicit_cast.go
+++ b/server/expression/explicit_cast.go
@@ -90,7 +90,8 @@ func (c *ExplicitCast) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 		if arrayType, ok := c.castToType.BaseID().IsBaseIDArrayType(); ok {
 			baseID = arrayType.BaseType().BaseID()
 		}
-		if baseID.GetTypeCategory() != pgtypes.TypeCategory_StringTypes {
+		// A nil result will be returned if there's a critical error, which we should never ignore.
+		if baseID.GetTypeCategory() != pgtypes.TypeCategory_StringTypes || castResult == nil {
 			return nil, err
 		}
 	}

--- a/server/functions/framework/compiled_function.go
+++ b/server/functions/framework/compiled_function.go
@@ -184,6 +184,7 @@ func (c *CompiledFunction) WithChildren(children ...sql.Expression) (sql.Express
 		Parameters:   children,
 		Functions:    c.Functions,
 		AllOverloads: c.AllOverloads,
+		IsOperator:   c.IsOperator,
 	}, nil
 }
 
@@ -310,7 +311,7 @@ func (c *CompiledFunction) resolveFunction(parameters []pgtypes.DoltgresType, so
 }
 
 // resolveOperator resolves an operator according to the rules defined by Postgres.
-// https://www.postgresql.org/docs/16/typeconv-oper.html
+// https://www.postgresql.org/docs/15/typeconv-oper.html
 func (c *CompiledFunction) resolveOperator(parameters []pgtypes.DoltgresType, sources []Source) (*OverloadDeduction, []TypeCastFunction, error) {
 	// Binary operators treat string literals as the other type, so we'll account for that here to see if we can find an
 	// "exact" match.
@@ -327,8 +328,8 @@ func (c *CompiledFunction) resolveOperator(parameters []pgtypes.DoltgresType, so
 				casts[1] = stringLiteralCast
 				baseID = parameters[0].BaseID()
 			}
-			if _, ok := c.Functions.Parameter[baseID]; ok {
-				if exactMatch, ok := c.Functions.Parameter[baseID]; ok {
+			if exactMatch, ok := c.Functions.Parameter[baseID]; ok {
+				if exactMatch, ok = exactMatch.Parameter[baseID]; ok {
 					return exactMatch, casts, nil
 				}
 			}

--- a/server/types/bool_array.go
+++ b/server/types/bool_array.go
@@ -15,8 +15,40 @@
 package types
 
 import (
+	"bytes"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/lib/pq/oid"
 )
 
 // BoolArray is the array variant of Bool.
-var BoolArray = createArrayType(Bool, SerializationID_BoolArray, oid.T__bool)
+var BoolArray = createArrayTypeWithFuncs(Bool, SerializationID_BoolArray, oid.T__bool, arrayContainerFunctions{
+	SQL: func(ctx *sql.Context, ac arrayContainer, dest []byte, valInterface any) (sqltypes.Value, error) {
+		if valInterface == nil {
+			return sqltypes.NULL, nil
+		}
+		converted, _, err := ac.Convert(valInterface)
+		if err != nil {
+			return sqltypes.Value{}, err
+		}
+		vals := converted.([]any)
+		bb := bytes.Buffer{}
+		bb.WriteRune('{')
+		for i := range vals {
+			if i > 0 {
+				bb.WriteRune(',')
+			}
+			if vals[i] == nil {
+				bb.WriteString("NULL")
+			} else if vals[i].(bool) {
+				bb.WriteRune('t')
+			} else {
+				bb.WriteRune('f')
+			}
+		}
+		bb.WriteRune('}')
+		return sqltypes.MakeTrusted(sqltypes.Text, types.AppendAndSliceBytes(dest, bb.Bytes())), nil
+	},
+})

--- a/server/types/char.go
+++ b/server/types/char.go
@@ -228,13 +228,9 @@ func (b CharType) String() string {
 // ToArrayType implements the DoltgresType interface.
 func (b CharType) ToArrayType() DoltgresArrayType {
 	if b.Length == stringUnbounded {
-		return createArrayTypeWithFuncs(b, SerializationID_CharArray, oid.T__bpchar, arrayContainerFunctions{
-			SQL: stringArraySQL,
-		})
+		return createArrayType(b, SerializationID_CharArray, oid.T__bpchar)
 	} else {
-		return createArrayTypeWithFuncs(b, SerializationID_CharArray, oid.T__char, arrayContainerFunctions{
-			SQL: stringArraySQL,
-		})
+		return createArrayType(b, SerializationID_CharArray, oid.T__char)
 	}
 }
 

--- a/server/types/char_array.go
+++ b/server/types/char_array.go
@@ -17,9 +17,7 @@ package types
 import "github.com/lib/pq/oid"
 
 // BpCharArray is the array variant of BpChar.
-var BpCharArray = createArrayTypeWithFuncs(BpChar, SerializationID_CharArray, oid.T__bpchar, arrayContainerFunctions{
-	SQL: stringArraySQL,
-})
+var BpCharArray = createArrayType(BpChar, SerializationID_CharArray, oid.T__bpchar)
 
 // CharArray is the array variant of BpChar. This is an alias of BpCharArray, since the documentation references "char"
 // more so than "bpchar" in PostgreSQL 15. They're the same type with different characteristics depending on the length.

--- a/server/types/name_array.go
+++ b/server/types/name_array.go
@@ -17,6 +17,4 @@ package types
 import "github.com/lib/pq/oid"
 
 // NameArray is the array variant of Name.
-var NameArray = createArrayTypeWithFuncs(Name, SerializationID_NameArray, oid.T__name, arrayContainerFunctions{
-	SQL: stringArraySQL,
-})
+var NameArray = createArrayType(Name, SerializationID_NameArray, oid.T__name)

--- a/server/types/text_array.go
+++ b/server/types/text_array.go
@@ -17,6 +17,4 @@ package types
 import "github.com/lib/pq/oid"
 
 // TextArray is the array variant of Text.
-var TextArray = createArrayTypeWithFuncs(Text, SerializationID_TextArray, oid.T__text, arrayContainerFunctions{
-	SQL: stringArraySQL,
-})
+var TextArray = createArrayType(Text, SerializationID_TextArray, oid.T__text)

--- a/server/types/varchar.go
+++ b/server/types/varchar.go
@@ -231,9 +231,7 @@ func (b VarCharType) String() string {
 
 // ToArrayType implements the DoltgresType interface.
 func (b VarCharType) ToArrayType() DoltgresArrayType {
-	return createArrayTypeWithFuncs(b, SerializationID_VarCharArray, oid.T__varchar, arrayContainerFunctions{
-		SQL: stringArraySQL,
-	})
+	return createArrayType(b, SerializationID_VarCharArray, oid.T__varchar)
 }
 
 // Type implements the DoltgresType interface.

--- a/server/types/varchar_array.go
+++ b/server/types/varchar_array.go
@@ -15,63 +15,8 @@
 package types
 
 import (
-	"bytes"
-	"strings"
-
-	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/types"
-	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/lib/pq/oid"
 )
 
 // VarCharArray is the array variant of VarChar.
-var VarCharArray = createArrayTypeWithFuncs(VarChar, SerializationID_VarCharArray, oid.T__varchar, arrayContainerFunctions{
-	SQL: stringArraySQL,
-})
-
-// stringArraySQL is the SQL implementation for all string array types.
-func stringArraySQL(ctx *sql.Context, ac arrayContainer, dest []byte, valInterface any) (sqltypes.Value, error) {
-	if valInterface == nil {
-		return sqltypes.NULL, nil
-	}
-	converted, _, err := ac.Convert(valInterface)
-	if err != nil {
-		return sqltypes.Value{}, err
-	}
-	vals := converted.([]any)
-	if len(vals) == 0 {
-		return sqltypes.MakeTrusted(ac.Type(), types.AppendAndSliceBytes(dest, []byte{'{', '}'})), nil
-	}
-	bb := bytes.Buffer{}
-	bb.WriteRune('{')
-	for i := range vals {
-		if i > 0 {
-			bb.WriteRune(',')
-		}
-		if vals[i] == nil {
-			bb.WriteString("NULL")
-			continue
-		}
-		sqlStringQuote(&bb, vals[i].(string))
-	}
-	bb.WriteRune('}')
-	return sqltypes.MakeTrusted(sqltypes.Text, types.AppendAndSliceBytes(dest, bb.Bytes())), nil
-}
-
-// sqlStringQuote returns a string that has been quoted according to the rules defined by Postgres. Not all strings will
-// result in quoting, therefore this function takes care of all situations where a string does or does not need to be
-// quoted. Writes the result to the buffer.
-func sqlStringQuote(bb *bytes.Buffer, val string) {
-	containsDoubleQuote := strings.Contains(val, `"`)
-	if containsDoubleQuote {
-		val = strings.ReplaceAll(val, `"`, `\"`)
-	}
-	if containsDoubleQuote || strings.Contains(val, `,`) ||
-		strings.Contains(val, `{`) || strings.Contains(val, `}`) {
-		bb.WriteRune('"')
-		bb.WriteString(val)
-		bb.WriteRune('"')
-	} else {
-		bb.WriteString(val)
-	}
-}
+var VarCharArray = createArrayType(VarChar, SerializationID_VarCharArray, oid.T__varchar)

--- a/testing/go/operators_test.go
+++ b/testing/go/operators_test.go
@@ -993,8 +993,16 @@ func TestOperators(t *testing.T) {
 					Query:    `SELECT '{"a":1,"b":2}'::jsonb ->> 'b';`,
 					Expected: []sql.Row{{`2`}},
 				},
-				{ // ARRAY['a','b','1']
+				{
 					Query:    `SELECT '{"a": {"b": ["foo","bar"]}}'::json #> ARRAY['a','b','1']::text[];`,
+					Expected: []sql.Row{{`"bar"`}},
+				},
+				{
+					Query:    `SELECT '{"a": {"b": ["foo","bar"]}}'::json #> ARRAY['a','b','1'];`,
+					Expected: []sql.Row{{`"bar"`}},
+				},
+				{
+					Query:    `SELECT '{"a": {"b": ["foo","bar"]}}'::json #> '{a,b,1}';`,
 					Expected: []sql.Row{{`"bar"`}},
 				},
 				{
@@ -1002,11 +1010,35 @@ func TestOperators(t *testing.T) {
 					Expected: []sql.Row{{`"bar"`}},
 				},
 				{
+					Query:    `SELECT '{"a": {"b": ["foo","bar"]}}'::jsonb #> ARRAY['a','b','1'];`,
+					Expected: []sql.Row{{`"bar"`}},
+				},
+				{
+					Query:    `SELECT '{"a": {"b": ["foo","bar"]}}'::jsonb #> '{a,b,1}';`,
+					Expected: []sql.Row{{`"bar"`}},
+				},
+				{
 					Query:    `SELECT '{"a": {"b": ["foo","bar"]}}'::json #>> ARRAY['a','b','1']::text[];`,
 					Expected: []sql.Row{{`bar`}},
 				},
 				{
+					Query:    `SELECT '{"a": {"b": ["foo","bar"]}}'::json #>> ARRAY['a','b','1'];`,
+					Expected: []sql.Row{{`bar`}},
+				},
+				{
+					Query:    `SELECT '{"a": {"b": ["foo","bar"]}}'::json #>> '{a,b,1}';`,
+					Expected: []sql.Row{{`bar`}},
+				},
+				{
 					Query:    `SELECT '{"a": {"b": ["foo","bar"]}}'::jsonb #>> ARRAY['a','b','1']::text[];`,
+					Expected: []sql.Row{{`bar`}},
+				},
+				{
+					Query:    `SELECT '{"a": {"b": ["foo","bar"]}}'::jsonb #>> ARRAY['a','b','1'];`,
+					Expected: []sql.Row{{`bar`}},
+				},
+				{
+					Query:    `SELECT '{"a": {"b": ["foo","bar"]}}'::jsonb #>> '{a,b,1}';`,
 					Expected: []sql.Row{{`bar`}},
 				},
 				{
@@ -1032,11 +1064,23 @@ func TestOperators(t *testing.T) {
 					Expected: []sql.Row{{"t"}},
 				},
 				{
+					Query:    `SELECT '{"a":1, "b":2, "c":3}'::jsonb ?| ARRAY['b','d'];`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
 					Query:    `SELECT '["a", "b", "c"]'::jsonb ?& ARRAY['a','b']::text[];`,
 					Expected: []sql.Row{{"t"}},
 				},
 				{
+					Query:    `SELECT '["a", "b", "c"]'::jsonb ?& ARRAY['a','b'];`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
 					Query:    `SELECT '["a", "b", "c"]'::jsonb ?& ARRAY['d','b']::text[];`,
+					Expected: []sql.Row{{"f"}},
+				},
+				{
+					Query:    `SELECT '["a", "b", "c"]'::jsonb ?& ARRAY['d','b'];`,
 					Expected: []sql.Row{{"f"}},
 				},
 				{

--- a/testing/go/smoke_test.go
+++ b/testing/go/smoke_test.go
@@ -306,6 +306,159 @@ func TestSmokeTests(t *testing.T) {
 			},
 		},
 		{
+			Name: "Array casting",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `SELECT '{true,false,true}'::boolean[];`,
+					Expected: []sql.Row{
+						{`{t,f,t}`},
+					},
+				},
+				{
+					Query: `SELECT '{"\\x68656c6c6f", "\\x776f726c64", "\\x6578616d706c65"}'::bytea[]::text[];`,
+					Expected: []sql.Row{
+						{`{"\x68656c6c6f","\x776f726c64","\x6578616d706c65"}`},
+					},
+				},
+				{
+					Query: `SELECT '{"abcd", "efgh", "ijkl"}'::char(3)[];`,
+					Expected: []sql.Row{
+						{`{abc,efg,ijk}`},
+					},
+				},
+				{
+					Query: `SELECT '{"2020-02-03", "2020-04-05", "2020-06-06"}'::date[];`,
+					Expected: []sql.Row{
+						{`{2020-02-03,2020-04-05,2020-06-06}`},
+					},
+				},
+				{
+					Query: `SELECT '{1.25,2.5,3.75}'::float4[];`,
+					Expected: []sql.Row{
+						{`{1.25,2.5,3.75}`},
+					},
+				},
+				{
+					Query: `SELECT '{4.25,5.5,6.75}'::float8[];`,
+					Expected: []sql.Row{
+						{`{4.25,5.5,6.75}`},
+					},
+				},
+				{
+					Query: `SELECT '{1,2,3}'::int2[];`,
+					Expected: []sql.Row{
+						{`{1,2,3}`},
+					},
+				},
+				{
+					Query: `SELECT '{4,5,6}'::int4[];`,
+					Expected: []sql.Row{
+						{`{4,5,6}`},
+					},
+				},
+				{
+					Query: `SELECT '{7,8,9}'::int8[];`,
+					Expected: []sql.Row{
+						{`{7,8,9}`},
+					},
+				},
+				{
+					Query: `SELECT '{"{\"a\":\"val1\"}", "{\"b\":\"value2\"}", "{\"c\": \"object_value3\"}"}'::json[];`,
+					Expected: []sql.Row{
+						{`{"{\"a\":\"val1\"}","{\"b\":\"value2\"}","{\"c\": \"object_value3\"}"}`},
+					},
+				},
+				{
+					Query: `SELECT '{"{\"d\":\"val1\"}", "{\"e\":\"value2\"}", "{\"f\": \"object_value3\"}"}'::jsonb[];`,
+					Expected: []sql.Row{
+						{`{"{\"d\": \"val1\"}","{\"e\": \"value2\"}","{\"f\": \"object_value3\"}"}`},
+					},
+				},
+				{
+					Query: `SELECT '{"the", "legendary", "formula"}'::name[];`,
+					Expected: []sql.Row{
+						{`{the,legendary,formula}`},
+					},
+				},
+				{
+					Query: `SELECT '{10.01,20.02,30.03}'::numeric[];`,
+					Expected: []sql.Row{
+						{`{10.01,20.02,30.03}`},
+					},
+				},
+				{
+					Query: `SELECT '{1,10,100}'::oid[];`,
+					Expected: []sql.Row{
+						{`{1,10,100}`},
+					},
+				},
+				{
+					Query: `SELECT '{"this", "is", "some", "text"}'::text[], '{text,without,quotes}'::text[], '{null,NULL,"NULL","quoted"}'::text[];`,
+					Expected: []sql.Row{
+						{`{this,is,some,text}`, `{text,without,quotes}`, `{NULL,NULL,"NULL",quoted}`},
+					},
+				},
+				{
+					Query: `SELECT '{"12:12:13", "14:14:15", "16:16:17"}'::time[];`,
+					Expected: []sql.Row{
+						{`{12:12:13,14:14:15,16:16:17}`},
+					},
+				},
+				{
+					Query: `SELECT '{"2020-02-03 12:13:14", "2020-04-05 15:16:17", "2020-06-06 18:19:20"}'::timestamp[];`,
+					Expected: []sql.Row{
+						{`{"2020-02-03 12:13:14","2020-04-05 15:16:17","2020-06-06 18:19:20"}`},
+					},
+				},
+				{
+					Query: `SELECT '{"3920fd79-7b53-437c-b647-d450b58b4532", "a594c217-4c63-4669-96ec-40eed180b7cf", "4367b70d-8d8b-4969-a1aa-bf59536455fb"}'::uuid[];`,
+					Expected: []sql.Row{
+						{`{3920fd79-7b53-437c-b647-d450b58b4532,a594c217-4c63-4669-96ec-40eed180b7cf,4367b70d-8d8b-4969-a1aa-bf59536455fb}`},
+					},
+				},
+				{
+					Query: `SELECT '{"somewhere", "over", "the", "rainbow"}'::varchar(5)[];`,
+					Expected: []sql.Row{
+						{`{somew,over,the,rainb}`},
+					},
+				},
+				{
+					Query: `SELECT '{1,2,3}'::xid[];`,
+					Expected: []sql.Row{
+						{`{1,2,3}`},
+					},
+				},
+				{
+					Query:       `SELECT '{"abc""","def"}'::text[];`,
+					ExpectedErr: "malformed",
+				},
+				{
+					Query:       `SELECT '{a,b,c'::text[];`,
+					ExpectedErr: "malformed",
+				},
+				{
+					Query:       `SELECT 'a,b,c}'::text[];`,
+					ExpectedErr: "malformed",
+				},
+				{
+					Query:       `SELECT '{"a,b,c}'::text[];`,
+					ExpectedErr: "malformed",
+				},
+				{
+					Query:       `SELECT '{a",b,c}'::text[];`,
+					ExpectedErr: "malformed",
+				},
+				{
+					Query:       `SELECT '{a,b,"c}'::text[];`,
+					ExpectedErr: "malformed",
+				},
+				{
+					Query:       `SELECT '{a,b,c"}'::text[];`,
+					ExpectedErr: "malformed",
+				},
+			},
+		},
+		{
 			Name: "Empty statement",
 			Assertions: []ScriptTestAssertion{
 				{

--- a/testing/go/types_test.go
+++ b/testing/go/types_test.go
@@ -347,7 +347,7 @@ var typesTests = []ScriptTest{
 		Name: "Character varying array type, no length",
 		SetUpScript: []string{
 			"CREATE TABLE t_varchar (id INTEGER primary key, v1 CHARACTER VARYING[]);",
-			"INSERT INTO t_varchar VALUES (1, ARRAY['abcdefghij', NULL]), (2, ARRAY['ab''cdef', 'what', 'is,hi', 'wh\"at', '}', '{', '{}']);",
+			"INSERT INTO t_varchar VALUES (1, '{abcdefghij, NULL}'), (2, ARRAY['ab''cdef', 'what', 'is,hi', 'wh\"at', '}', '{', '{}']);",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -1923,7 +1923,6 @@ var typesTests = []ScriptTest{
 	},
 	{
 		Name: "Xid array type",
-		Skip: true, // TODO: need to implement array I/O input
 		SetUpScript: []string{
 			"CREATE TABLE t_xid (id INTEGER primary key, v1 XID[], v2 CHARACTER(100), v3 BOOLEAN);",
 			"INSERT INTO t_xid VALUES (2, '{123, 456, 789, 101}', '1234567890', true);",
@@ -1937,7 +1936,7 @@ var typesTests = []ScriptTest{
 			},
 			{
 				Query:       `INSERT INTO t_xid VALUES (2, ARRAY[123, 456, 789, 101], '1234567890', true);`,
-				ExpectedErr: "does not exist",
+				ExpectedErr: "is of type",
 			},
 		},
 	},


### PR DESCRIPTION
This adds functionality so that string literals such as `'{1,2,3}'` can be interpreted as arrays of _any_ type. This builds off of the https://github.com/dolthub/doltgresql/pull/333 PR, which enables this to "just work" for all contexts (includes casting, inserting into columns, automatic operator resolution, etc.). This also includes additional tests for a few bugs that weren't caught in the previous PR.