### PR TITLE
Reworked config

### DIFF
--- a/cmd/doltgres/main.go
+++ b/cmd/doltgres/main.go
@@ -173,21 +173,21 @@ func setupDataDir(params map[string]*string, cfg *servercfg.DoltgresConfig, fs f
 // 2. If the default config file config.yaml exists, attempts to load it, but doesn't return an error if it doesn't exist.
 // 3. If neither of the above are successful, returns the default config server config.
 func loadServerConfig(params map[string]*string, fs filesys.Filesys) (*servercfg.DoltgresConfig, error) {
-	configFilePath, cfgPathProvided := params[configParam]
+	configFilePath, configFilePathSpecified := paramVal(params, configParam)
 	
-	if cfgPathProvided {
-		cfgPathExists, isDir := fs.Exists(*configFilePath)
+	if configFilePathSpecified {
+		cfgPathExists, isDir := fs.Exists(configFilePath)
 		if !cfgPathExists {
-			return nil, fmt.Errorf("config file not found at %s", *configFilePath)
+			return nil, fmt.Errorf("config file not found at %s", configFilePath)
 		} else if isDir {
-			return nil, fmt.Errorf("cannot use directory %s for config file", *configFilePath)
+			return nil, fmt.Errorf("cannot use directory %s for config file", configFilePath)
 		}
 
-		return servercfg.ReadConfigFromYamlFile(fs, *configFilePath)
+		return servercfg.ReadConfigFromYamlFile(fs, configFilePath)
 	} else {
 		cfgPathExists, isDir := fs.Exists(defaultCfgFile)
 		if cfgPathExists && !isDir {
-			return servercfg.ReadConfigFromYamlFile(fs, *configFilePath)
+			return servercfg.ReadConfigFromYamlFile(fs, configFilePath)
 		}
 	}
 

--- a/cmd/doltgres/main.go
+++ b/cmd/doltgres/main.go
@@ -146,11 +146,12 @@ func setupDataDir(params map[string]*string, cfg *servercfg.DoltgresConfig, fs f
 	}
 
 	// determine the data dir to use, in order of preference: 1) explicit flag, 2) env var, 3) default
+	dataDirNotSpecifiedInCfg := cfg.DataDirStr == nil || *cfg.DataDirStr == servercfg.DefaultDataDir
 	if dataDirType == dataDirExplicitParam {
 		cfg.DataDirStr = &dataDir
-	} else if dataDirType == dataDirEnv && (cfg.DataDirStr == nil || *cfg.DataDirStr == servercfg.DefaultDataDir) {
+	} else if dataDirType == dataDirEnv && dataDirNotSpecifiedInCfg {
 		cfg.DataDirStr = &dataDir
-	} else {
+	} else if dataDirNotSpecifiedInCfg {
 		def := servercfg.DefaultDataDir
 		cfg.DataDirStr = &def
 	}
@@ -187,7 +188,7 @@ func loadServerConfig(params map[string]*string, fs filesys.Filesys) (*servercfg
 	} else {
 		cfgPathExists, isDir := fs.Exists(defaultCfgFile)
 		if cfgPathExists && !isDir {
-			return servercfg.ReadConfigFromYamlFile(fs, configFilePath)
+			return servercfg.ReadConfigFromYamlFile(fs, defaultCfgFile)
 		}
 	}
 

--- a/cmd/doltgres/main.go
+++ b/cmd/doltgres/main.go
@@ -55,12 +55,11 @@ const (
 	stdErrParam       = "stderr"
 	stdOutAndErrParam = "out-and-err"
 	configParam       = "config"
-	dataDirParam   = "data-dir"
-	defaultCfgFile = "config.yaml"
+	dataDirParam      = "data-dir"
+	defaultCfgFile    = "config.yaml"
 
 	versionFlag    = "version"
 	configHelpFlag = "config-help"
-
 
 	configHelpText = "Path to the config file.\n" +
 		"If not provided, ./config.yaml will be used if it exists."
@@ -164,7 +163,7 @@ func main() {
 	fs := filesys.LocalFS
 	// dEnv will be reloaded at server start to point to the data dir on the server config
 	dEnv := env.Load(ctx, env.GetCurrentUserHomeDir, fs, doltdb.LocalDirDoltDB, server.Version)
-	
+
 	cfg, loadedFromDisk, err := loadServerConfig(params, fs)
 	if err != nil {
 		handleErrAndExitCode(err)
@@ -174,9 +173,9 @@ func main() {
 	if err != nil {
 		handleErrAndExitCode(err)
 	}
-	
+
 	// TODO: override other aspects of cfg with command line params
-	
+
 	err = runServer(ctx, dEnv, cfg)
 	handleErrAndExitCode(err)
 }
@@ -216,7 +215,7 @@ func setupDataDir(params map[string]*string, cfg *servercfg.DoltgresConfig, cfgL
 	} else if !isDir {
 		return fmt.Errorf("cannot use file %s as doltgres data directory", dataDirPath)
 	}
-	
+
 	return nil
 }
 
@@ -224,11 +223,11 @@ func setupDataDir(params map[string]*string, cfg *servercfg.DoltgresConfig, cfgL
 // 1. If the --config flag is provided, loads the config from the file at the path provided, or returns an errors if it cannot.
 // 2. If the default config file config.yaml exists, attempts to load it, but doesn't return an error if it doesn't exist.
 // 3. If neither of the above are successful, returns the default config server config.
-// The second result param is a boolean indicating whether a file was loaded, since we vary later initialization 
+// The second result param is a boolean indicating whether a file was loaded, since we vary later initialization
 // behavior depending on whether we loaded a config file from disk.
 func loadServerConfig(params map[string]*string, fs filesys.Filesys) (*servercfg.DoltgresConfig, bool, error) {
 	configFilePath, configFilePathSpecified := paramVal(params, configParam)
-	
+
 	if configFilePathSpecified {
 		cfgPathExists, isDir := fs.Exists(configFilePath)
 		if !cfgPathExists {
@@ -251,6 +250,7 @@ func loadServerConfig(params map[string]*string, fs filesys.Filesys) (*servercfg
 }
 
 type dataDirType byte
+
 const (
 	dataDirExplicitParam dataDirType = iota
 	dataDirEnv
@@ -270,7 +270,7 @@ func getDataDirFromParams(params map[string]*string) (string, dataDirType, error
 		if err != nil {
 			return "", dataDirDefault, fmt.Errorf("failed to get current user's home directory: %w", err)
 		}
-		
+
 		dbDir := filepath.Join(homeDir, servercfg.DOLTGRES_DATA_DIR_DEFAULT)
 		return dbDir, dataDirDefault, nil
 	}

--- a/cmd/doltgres/main.go
+++ b/cmd/doltgres/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"github.com/dolthub/dolt/go/store/nbs"
 	"github.com/fatih/color"
+	"github.com/mitchellh/go-wordwrap"
 
 	"github.com/dolthub/doltgresql/server"
 	"github.com/dolthub/doltgresql/servercfg"
@@ -61,13 +62,12 @@ const (
 	configHelpFlag = "config-help"
 
 
-	configHelpText = "Path to the config file. If not provided, ./config.yaml\n" +
-		"will be used if it exists."
+	configHelpText = "Path to the config file.\n" +
+		"If not provided, ./config.yaml will be used if it exists."
 	dataDirHelpText = "Path to the directory where doltgres databases are stored.\n" +
-		"If not provided, the value in config.yaml will be used. If that's not provided\n" +
-		"either, the value of the DOLTGRES_DATA_DIR environment variable will be used\n" +
-		"if set. Otherwise $HOME/doltgres/databases will be used. The directory will be\n" +
-		"created if it doesn't exist."
+		"If not provided, the value in config.yaml will be used. If that's not provided either, the value of the " +
+		"DOLTGRES_DATA_DIR environment variable will be used if set. Otherwise $HOME/doltgres/databases will be used. " +
+		"The directory will be created if it doesn't exist."
 )
 
 func parseArgs() (flags map[string]*bool, params map[string]*string) {
@@ -81,7 +81,7 @@ func parseArgs() (flags map[string]*bool, params map[string]*string) {
 	params = make(map[string]*string)
 
 	params[configParam] = flag.String(configParam, "", configHelpText)
-	params[dataDirParam] = flag.String(dataDirParam, "", configHelpText)
+	params[dataDirParam] = flag.String(dataDirParam, "", dataDirHelpText)
 	params[chdirParam] = flag.String(chdirParam, "", "set the working directory for doltgres")
 	params[stdInParam] = flag.String(stdInParam, "", "file to use as stdin")
 	params[stdOutParam] = flag.String(stdOutParam, "", "file to use as stdout")
@@ -128,6 +128,8 @@ func PrintDefaults(fs *flag.FlagSet) {
 			// for both 4- and 8-space tab stops.
 			b.WriteString("\n    \t")
 		}
+		// wrap at 80 chars
+		usage = wordwrap.WrapString(usage, 76)
 		b.WriteString(strings.ReplaceAll(usage, "\n", "\n    \t"))
 
 		if f.DefValue != "false" && f.DefValue != "" {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/jackc/pgx/v5 v5.4.3
 	github.com/lib/pq v1.10.9
 	github.com/madflojo/testcerts v1.1.1
+	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/pierrre/geohash v1.0.0
 	github.com/sergi/go-diff v1.1.0
 	github.com/shopspring/decimal v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -661,6 +661,8 @@ github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFW
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
+github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
+github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/server/server.go
+++ b/server/server.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	Version = "0.8.0"
+	Version      = "0.8.0"
 	DefUserName  = "postres"
 	DefUserEmail = "postgres@somewhere.com"
 	DoltgresDir  = "doltgres"

--- a/server/server.go
+++ b/server/server.go
@@ -44,12 +44,6 @@ import (
 
 const (
 	Version = "0.8.0"
-
-	// DOLTGRES_DATA_DIR is an environment variable that defines the location of DoltgreSQL databases
-	DOLTGRES_DATA_DIR = "DOLTGRES_DATA_DIR"
-	// DOLTGRES_DATA_DIR_DEFAULT is the portion to append to the user's home directory if DOLTGRES_DATA_DIR has not been specified
-	DOLTGRES_DATA_DIR_DEFAULT = "doltgres/databases"
-
 	DefUserName  = "postres"
 	DefUserEmail = "postgres@somewhere.com"
 	DoltgresDir  = "doltgres"
@@ -140,7 +134,7 @@ func runServer(ctx context.Context, cfg *servercfg.DoltgresConfig, dEnv *env.Dol
 		// enforce the creation of a Doltgres database/directory, which would create a name conflict with the file
 		return nil, fmt.Errorf("Attempted to create the default `doltgres` database at `%s`, but a file with "+
 			"the same name was found. Either remove the file, change the directory using the `--data-dir` argument, "+
-			"or change the environment variable `%s` so that it points to a different directory.", workingDir, DOLTGRES_DATA_DIR)
+			"or change the environment variable `%s` so that it points to a different directory.", workingDir, servercfg.DOLTGRES_DATA_DIR)
 	}
 
 	controller := svcs.NewController()

--- a/servercfg/config.go
+++ b/servercfg/config.go
@@ -501,7 +501,7 @@ func ptr[T any](t T) *T {
 	return &t
 }
 
-func ReadConfigFromYamlFile(fs filesys.Filesys, configFilePath string, overrides map[string]string) (*DoltgresConfig, error) {
+func ReadConfigFromYamlFile(fs filesys.Filesys, configFilePath string) (*DoltgresConfig, error) {
 	configFileData, err := fs.ReadFile(configFilePath)
 	if err != nil {
 		absPath, absErr := fs.Abs(configFilePath)
@@ -511,25 +511,15 @@ func ReadConfigFromYamlFile(fs filesys.Filesys, configFilePath string, overrides
 			return nil, fmt.Errorf("error reading config file '%s': %w", absPath, err)
 		}
 	}
-	return ConfigFromYamlData(configFileData, overrides)
+	return ConfigFromYamlData(configFileData)
 }
 
-func ConfigFromYamlData(configFileData []byte, overrides map[string]string) (*DoltgresConfig, error) {
+func ConfigFromYamlData(configFileData []byte) (*DoltgresConfig, error) {
 	var cfg DoltgresConfig
 	err := yaml.UnmarshalStrict(configFileData, &cfg)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshalling config data: %w", err)
 	}
-
-	for k, v := range overrides {
-		switch k {
-		case OverrideDataDirKey:
-			cfg.DataDirStr = &v
-		default:
-			// this only happens if code to add an override is added but code to handle the override is not.
-			panic(fmt.Sprintf("unknown override key: %s", k))
-		}
-	}
-
+	
 	return &cfg, err
 }

--- a/servercfg/config.go
+++ b/servercfg/config.go
@@ -50,13 +50,12 @@ const (
 
 const (
 	DefaultHost                    = "localhost"
-	DefaultPort                    = 3306
+	DefaultPort                    = 5432
 	DefaultUser                    = ""
 	DefaultPass                    = ""
 	DefaultTimeout                 = 8 * 60 * 60 * 1000 // 8 hours, same as MySQL
 	DefaultReadOnly                = false
 	DefaultLogLevel                = LogLevel_Info
-	DefaultAutoCommit              = true
 	DefaultDoltTransactionCommit   = false
 	DefaultMaxConnections          = 100
 	DefaultQueryParallelism        = 0

--- a/servercfg/config.go
+++ b/servercfg/config.go
@@ -483,7 +483,7 @@ func DefaultServerConfig() *DoltgresConfig {
 	if err == nil {
 		dataDir = filepath.Join(homeDir, DOLTGRES_DATA_DIR_DEFAULT)
 	}
-	
+
 	return &DoltgresConfig{
 		LogLevelStr:       Ptr(string(DefaultLogLevel)),
 		EncodeLoggedQuery: Ptr(DefaultEncodeLoggedQuery),
@@ -503,7 +503,7 @@ func DefaultServerConfig() *DoltgresConfig {
 			AllowCleartextPasswords: Ptr(DefaultAllowCleartextPasswords),
 		},
 		PerformanceConfig: &DoltgresPerformanceConfig{QueryParallelism: Ptr(DefaultQueryParallelism)},
-		
+
 		DataDirStr:        Ptr(dataDir),
 		CfgDirStr:         Ptr(filepath.Join(DefaultDataDir, DefaultCfgDir)),
 		PrivilegeFile:     Ptr(filepath.Join(DefaultDataDir, DefaultCfgDir, DefaultPrivilegeFilePath)),
@@ -530,7 +530,7 @@ func ConfigFromYamlData(configFileData []byte) (*DoltgresConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshalling config data: %w", err)
 	}
-	
+
 	return &cfg, err
 }
 

--- a/servercfg/config.go
+++ b/servercfg/config.go
@@ -36,16 +36,13 @@ const (
 	OverrideDataDirKey = "data_dir"
 )
 
-// LogLevel defines the available levels of logging for the server.
-type LogLevel string
-
 const (
-	LogLevel_Trace   LogLevel = "trace"
-	LogLevel_Debug   LogLevel = "debug"
-	LogLevel_Info    LogLevel = "info"
-	LogLevel_Warning LogLevel = "warning"
-	LogLevel_Error   LogLevel = "error"
-	LogLevel_Fatal   LogLevel = "fatal"
+	LogLevel_Trace   = "trace"
+	LogLevel_Debug   = "debug"
+	LogLevel_Info    = "info"
+	LogLevel_Warning = "warn"
+	LogLevel_Error   = "error"
+	LogLevel_Fatal   = "fatal"
 )
 
 const (
@@ -178,7 +175,8 @@ type DoltgresConfig struct {
 	PostgresReplicationConfig *PostgresReplicationConfig `yaml:"postgres_replication,omitempty" minver:"0.7.4"`
 }
 
-// Ptr is a helper function that returns a pointer to the value passed in.
+// Ptr is a helper function that returns a pointer to the value passed in. This is necessary to e.g. get a pointer to
+// a const value without assigning to an intermediate variable.
 func Ptr[T any](v T) *T {
 	return &v
 }
@@ -273,17 +271,17 @@ func (cfg *DoltgresConfig) LogLevel() servercfg.LogLevel {
 	}
 
 	switch *cfg.LogLevelStr {
-	case "trace":
+	case LogLevel_Trace:
 		return servercfg.LogLevel_Trace
-	case "debug":
+	case LogLevel_Debug:
 		return servercfg.LogLevel_Debug
-	case "info":
+	case LogLevel_Info:
 		return servercfg.LogLevel_Info
-	case "warn":
+	case LogLevel_Warning:
 		return servercfg.LogLevel_Warning
-	case "error":
+	case LogLevel_Error:
 		return servercfg.LogLevel_Error
-	case "fatal":
+	case LogLevel_Fatal:
 		return servercfg.LogLevel_Fatal
 	default:
 		return servercfg.LogLevel_Info

--- a/servercfg/config.go
+++ b/servercfg/config.go
@@ -27,10 +27,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func Ptr[T any](v T) *T {
-	return &v
-}
-
 const (
 	maxConnectionsKey = "max_connections"
 	readTimeoutKey    = "net_read_timeout"
@@ -180,6 +176,11 @@ type DoltgresConfig struct {
 	GoldenMysqlConn *string                   `yaml:"golden_mysql_conn,omitempty" minver:"0.7.4"`
 
 	PostgresReplicationConfig *PostgresReplicationConfig `yaml:"postgres_replication,omitempty" minver:"0.7.4"`
+}
+
+// Ptr is a helper function that returns a pointer to the value passed in.
+func Ptr[T any](v T) *T {
+	return &v
 }
 
 func (cfg *DoltgresConfig) AutoCommit() bool {
@@ -486,34 +487,30 @@ func DefaultServerConfig() *DoltgresConfig {
 	}
 	
 	return &DoltgresConfig{
-		LogLevelStr:       ptr(string(DefaultLogLevel)),
-		EncodeLoggedQuery: ptr(DefaultEncodeLoggedQuery),
+		LogLevelStr:       Ptr(string(DefaultLogLevel)),
+		EncodeLoggedQuery: Ptr(DefaultEncodeLoggedQuery),
 		BehaviorConfig: &DoltgresBehaviorConfig{
-			ReadOnly:              ptr(DefaultReadOnly),
-			DoltTransactionCommit: ptr(DefaultDoltTransactionCommit),
+			ReadOnly:              Ptr(DefaultReadOnly),
+			DoltTransactionCommit: Ptr(DefaultDoltTransactionCommit),
 		},
 		UserConfig: &DoltgresUserConfig{
-			Name:     ptr(DefaultUser),
-			Password: ptr(DefaultPass),
+			Name:     Ptr(DefaultUser),
+			Password: Ptr(DefaultPass),
 		},
 		ListenerConfig: &DoltgresListenerConfig{
-			HostStr:                 ptr(DefaultHost),
-			PortNumber:              ptr(DefaultPort),
-			ReadTimeoutMillis:       ptr(uint64(DefaultTimeout)),
-			WriteTimeoutMillis:      ptr(uint64(DefaultTimeout)),
-			AllowCleartextPasswords: ptr(DefaultAllowCleartextPasswords),
+			HostStr:                 Ptr(DefaultHost),
+			PortNumber:              Ptr(DefaultPort),
+			ReadTimeoutMillis:       Ptr(uint64(DefaultTimeout)),
+			WriteTimeoutMillis:      Ptr(uint64(DefaultTimeout)),
+			AllowCleartextPasswords: Ptr(DefaultAllowCleartextPasswords),
 		},
-		PerformanceConfig: &DoltgresPerformanceConfig{QueryParallelism: ptr(DefaultQueryParallelism)},
+		PerformanceConfig: &DoltgresPerformanceConfig{QueryParallelism: Ptr(DefaultQueryParallelism)},
 		
-		DataDirStr:        ptr(dataDir),
-		CfgDirStr:         ptr(filepath.Join(DefaultDataDir, DefaultCfgDir)),
-		PrivilegeFile:     ptr(filepath.Join(DefaultDataDir, DefaultCfgDir, DefaultPrivilegeFilePath)),
-		BranchControlFile: ptr(filepath.Join(DefaultDataDir, DefaultCfgDir, DefaultBranchControlFilePath)),
+		DataDirStr:        Ptr(dataDir),
+		CfgDirStr:         Ptr(filepath.Join(DefaultDataDir, DefaultCfgDir)),
+		PrivilegeFile:     Ptr(filepath.Join(DefaultDataDir, DefaultCfgDir, DefaultPrivilegeFilePath)),
+		BranchControlFile: Ptr(filepath.Join(DefaultDataDir, DefaultCfgDir, DefaultBranchControlFilePath)),
 	}
-}
-
-func ptr[T any](t T) *T {
-	return &t
 }
 
 func ReadConfigFromYamlFile(fs filesys.Filesys, configFilePath string) (*DoltgresConfig, error) {

--- a/testing/bats/doltgres.bats
+++ b/testing/bats/doltgres.bats
@@ -9,6 +9,24 @@ teardown() {
     teardown_common
 }
 
+@test 'doltgres: no arguments' {
+    PORT=5432
+    doltgres > server.out 2>&1 &
+    SERVER_PID=$!
+    run wait_for_connection $PORT 7500
+
+    cat server.out
+    echo "$output"
+    [ "$status" -eq 0 ]
+    
+    query_server -c "create table t1 (a int primary key, b int)"
+    query_server -c "insert into t1 values (1,2)"
+
+    run query_server -c "select * from t1" -t
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1 | 2" ]] || false
+}
+
 @test 'doltgres: config file' {
     PORT=$( definePORT )
     CONFIG=$( defineCONFIG $PORT )

--- a/testing/bats/doltgres.bats
+++ b/testing/bats/doltgres.bats
@@ -9,6 +9,16 @@ teardown() {
     teardown_common
 }
 
+@test 'doltgres: --help' {
+    # just a smoke test
+    doltgres --help
+}
+
+@test 'doltgres: --config-help' {
+    # just a smoke test
+    doltgres --config-help
+}
+
 @test 'doltgres: no arguments' {
     PORT=5432
     mkdir test-home

--- a/testing/bats/doltgres.bats
+++ b/testing/bats/doltgres.bats
@@ -151,7 +151,7 @@ EOF
     [[ "$output" =~ "1 | 2" ]] || false
 
     [ ! -d test/doltgres ]
-    [ ! -d local-override/doltgres ]
+    [ -d local-override/doltgres ]
 }
 
 @test 'doltgres: config file' {


### PR DESCRIPTION
This change reworks how the data dir, config file and related initialization values are loaded. The main effect is that it's now possible to run `doltgres` without a config.yaml file.

The sever config is now resolved in this order

1. --config flag
2. config.yaml file if present
3. Built-in default config values

The data-dir for this config is then overridden as necessary with a similar pattern:

1. --data-dir flag
2. The value in a config.yaml file if, if a file was loaded
3. The env var `DOLTGRES_DATA_DIR`
4. The default ($home/doltgres/databases)

