### PR TITLE
Perform function analysis once

### DIFF
--- a/server/functions/framework/catalog.go
+++ b/server/functions/framework/catalog.go
@@ -121,13 +121,7 @@ func Initialize() {
 
 		// Store the compiled function into the engine's built-in functions
 		createFunc := func(params ...sql.Expression) (sql.Expression, error) {
-			return &CompiledFunction{
-				Name:         funcName,
-				Parameters:   params,
-				Functions:    baseOverload,
-				AllOverloads: baseOverload.collectOverloadPermutations(),
-				IsOperator:   false,
-			}, nil
+			return NewCompiledFunction(funcName, params, baseOverload, false), nil
 		}
 		function.BuiltIns = append(function.BuiltIns, sql.FunctionN{
 			Name: funcName,

--- a/server/functions/framework/intermediate_function.go
+++ b/server/functions/framework/intermediate_function.go
@@ -33,11 +33,5 @@ func (f IntermediateFunction) Compile(name string, parameters ...sql.Expression)
 	if f.Functions == nil {
 		return nil
 	}
-	return &CompiledFunction{
-		Name:         name,
-		Parameters:   parameters,
-		Functions:    f.Functions,
-		AllOverloads: f.AllOverloads,
-		IsOperator:   f.IsOperator,
-	}
+	return newCompiledFunctionInternal(name, parameters, f.Functions, f.AllOverloads, f.IsOperator)
 }


### PR DESCRIPTION
Functions did their entire overload resolution during `Eval`, meaning if a function was called 1000 times, then we did overload resolution 1000 times for the exact same function. This changes it so that we only do it once. This optimization was made while investigating our performance benchmarks.

Of note, errors found during overload resolution are stashed for later. This ensures that other steps in the pipeline retain their error priority. Previously, when this was all done in `Eval`, stashing wasn't needed.