### PR TITLE
Reworked PSQL statements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/madflojo/testcerts v1.1.1
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/pierrre/geohash v1.0.0
+	github.com/pkg/profile v1.5.0
 	github.com/sergi/go-diff v1.1.0
 	github.com/shopspring/decimal v1.3.1
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -738,6 +738,8 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
+github.com/pkg/profile v1.5.0 h1:042Buzk+NhDI+DeSAA62RwJL8VAuZUMQZUjCsRz1Mug=
+github.com/pkg/profile v1.5.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pkg/sftp v1.13.0/go.mod h1:41g+FIPlQUTDCveupEmEA65IoiQFrtgCeDopC4ajGIM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/server/connection_handler.go
+++ b/server/connection_handler.go
@@ -311,7 +311,6 @@ func (h *ConnectionHandler) handleMessage(message connection.Message) (stop, end
 		} else {
 			delete(h.portals, message.Target)
 		}
-
 		return false, false, connection.Send(h.Conn(), messages.CloseComplete{})
 	default:
 		return false, true, fmt.Errorf(`Unhandled message "%s"`, message.DefaultMessage().Name)
@@ -774,21 +773,21 @@ func (h *ConnectionHandler) handledPSQLCommands(statement string) (bool, error) 
 	// Command: \dt
 	if statement == "select n.nspname as \"schema\",\n  c.relname as \"name\",\n  case c.relkind when 'r' then 'table' when 'v' then 'view' when 'm' then 'materialized view' when 'i' then 'index' when 's' then 'sequence' when 't' then 'toast table' when 'f' then 'foreign table' when 'p' then 'partitioned table' when 'i' then 'partitioned index' end as \"type\",\n  pg_catalog.pg_get_userbyid(c.relowner) as \"owner\"\nfrom pg_catalog.pg_class c\n     left join pg_catalog.pg_namespace n on n.oid = c.relnamespace\n     left join pg_catalog.pg_am am on am.oid = c.relam\nwhere c.relkind in ('r','p','')\n      and n.nspname <> 'pg_catalog'\n      and n.nspname !~ '^pg_toast'\n      and n.nspname <> 'information_schema'\n  and pg_catalog.pg_table_is_visible(c.oid)\norder by 1,2;" {
 		return true, h.query(ConvertedQuery{
-			String:       `SELECT 'public' AS 'Schema', TABLE_NAME AS 'Name', 'table' AS 'Type', 'postgres' AS 'Owner' FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = database() AND TABLE_TYPE = 'BASE TABLE' ORDER BY 2;`,
+			String:       `SELECT 'public' AS 'Schema', TABLE_NAME AS 'Name', 'table' AS 'Type', 'postgres' AS 'Owner' FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = database() AND CONVERT(TABLE_TYPE, CHAR) = 'BASE TABLE' ORDER BY 2;`,
 			StatementTag: "SELECT",
 		})
 	}
 	// Command: \d
 	if statement == "select n.nspname as \"schema\",\n  c.relname as \"name\",\n  case c.relkind when 'r' then 'table' when 'v' then 'view' when 'm' then 'materialized view' when 'i' then 'index' when 's' then 'sequence' when 't' then 'toast table' when 'f' then 'foreign table' when 'p' then 'partitioned table' when 'i' then 'partitioned index' end as \"type\",\n  pg_catalog.pg_get_userbyid(c.relowner) as \"owner\"\nfrom pg_catalog.pg_class c\n     left join pg_catalog.pg_namespace n on n.oid = c.relnamespace\n     left join pg_catalog.pg_am am on am.oid = c.relam\nwhere c.relkind in ('r','p','v','m','s','f','')\n      and n.nspname <> 'pg_catalog'\n      and n.nspname !~ '^pg_toast'\n      and n.nspname <> 'information_schema'\n  and pg_catalog.pg_table_is_visible(c.oid)\norder by 1,2;" {
 		return true, h.query(ConvertedQuery{
-			String:       `SELECT 'public' AS 'Schema', TABLE_NAME AS 'Name', 'table' AS 'Type', 'postgres' AS 'Owner' FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = database() AND TABLE_TYPE = 'BASE TABLE' ORDER BY 2;`,
+			String:       `SELECT 'public' AS 'Schema', TABLE_NAME AS 'Name', 'table' AS 'Type', 'postgres' AS 'Owner' FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = database() AND CONVERT(TABLE_TYPE, CHAR) = 'BASE TABLE' ORDER BY 2;`,
 			StatementTag: "SELECT",
 		})
 	}
 	// Alternate \d for psql 14
 	if statement == "select n.nspname as \"schema\",\n  c.relname as \"name\",\n  case c.relkind when 'r' then 'table' when 'v' then 'view' when 'm' then 'materialized view' when 'i' then 'index' when 's' then 'sequence' when 's' then 'special' when 't' then 'toast table' when 'f' then 'foreign table' when 'p' then 'partitioned table' when 'i' then 'partitioned index' end as \"type\",\n  pg_catalog.pg_get_userbyid(c.relowner) as \"owner\"\nfrom pg_catalog.pg_class c\n     left join pg_catalog.pg_namespace n on n.oid = c.relnamespace\n     left join pg_catalog.pg_am am on am.oid = c.relam\nwhere c.relkind in ('r','p','v','m','s','f','')\n      and n.nspname <> 'pg_catalog'\n      and n.nspname !~ '^pg_toast'\n      and n.nspname <> 'information_schema'\n  and pg_catalog.pg_table_is_visible(c.oid)\norder by 1,2;" {
 		return true, h.query(ConvertedQuery{
-			String:       `SELECT 'public' AS 'Schema', TABLE_NAME AS 'Name', 'table' AS 'Type', 'postgres' AS 'Owner' FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = database() AND TABLE_TYPE = 'BASE TABLE' ORDER BY 2;`,
+			String:       `SELECT 'public' AS 'Schema', TABLE_NAME AS 'Name', 'table' AS 'Type', 'postgres' AS 'Owner' FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = database() AND CONVERT(TABLE_TYPE, CHAR) = 'BASE TABLE' ORDER BY 2;`,
 			StatementTag: "SELECT",
 		})
 	}

--- a/testing/bats/psql-commands.bats
+++ b/testing/bats/psql-commands.bats
@@ -26,7 +26,6 @@ teardown() {
 }
 
 @test 'psql-commands: \dt' {
-    skip "Need to implement comparison operators"
     run query_server --csv -c "\dt"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "public,test1,table,postgres" ]] || false
@@ -35,7 +34,6 @@ teardown() {
 }
 
 @test 'psql-commands: \d' {
-    skip "Need to implement comparison operators"
     run query_server --csv -c "\d"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "public,test1,table,postgres" ]] || false

--- a/utils/pprof.go
+++ b/utils/pprof.go
@@ -1,0 +1,79 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"sync"
+
+	"github.com/pkg/profile"
+)
+
+// prof is the global profiler that is in use. This should only be interacted with via StartProfiling and StopProfiling.
+var prof interface{ Stop() }
+
+// profMutex is the mutex that handles concurrent manipulations of prof.
+var profMutex = &sync.Mutex{}
+
+// ProfilingOptions contains all options for starting the profiler.
+type ProfilingOptions struct {
+	CPU    bool
+	Memory bool
+	Block  bool
+	Trace  bool
+	Path   string
+}
+
+// StartProfiling starts profiling the CPU.
+func StartProfiling(options ProfilingOptions) {
+	profMutex.Lock()
+	defer profMutex.Unlock()
+
+	if !options.HasOptions() {
+		return
+	}
+	profOpts := []func(p *profile.Profile){profile.NoShutdownHook}
+	if options.CPU {
+		profOpts = append(profOpts, profile.CPUProfile)
+	}
+	if options.Memory {
+		profOpts = append(profOpts, profile.MemProfile)
+	}
+	if options.Block {
+		profOpts = append(profOpts, profile.BlockProfile)
+	}
+	if options.Trace {
+		profOpts = append(profOpts, profile.TraceProfile)
+	}
+	if len(options.Path) > 0 {
+		profOpts = append(profOpts, profile.ProfilePath(options.Path))
+	}
+	prof = profile.Start(profOpts...)
+}
+
+// StopProfiling stops profiling the CPU.
+func StopProfiling() {
+	profMutex.Lock()
+	defer profMutex.Unlock()
+
+	if prof != nil {
+		prof.Stop()
+		prof = nil
+	}
+}
+
+// HasOptions returns true when at least one profiler target has been selected.
+func (options ProfilingOptions) HasOptions() bool {
+	return options.CPU || options.Memory || options.Block || options.Trace
+}


### PR DESCRIPTION
This changes the hardcoded PSQL statements that were no longer working so that they now work. In addition, I'm including the `pprof` additions here, as I added this for sysbench testing. I more-or-less copied the implementation from Dolt. I think we used to have it in Doltgres, but removed it when we removed the `sql-server` command.