### PR TITLE
Add schemas with empty row iters for some `pg_catalog` tables

### DIFF
--- a/server/tables/pgcatalog/init.go
+++ b/server/tables/pgcatalog/init.go
@@ -19,6 +19,7 @@ const PgCatalogName = "pg_catalog"
 
 // Init initializes everything necessary for the pg_catalog tables.
 func Init() {
+	InitPgAm()
 	InitPgAttribute()
 	InitPgClass()
 	InitPgDatabase()

--- a/server/tables/pgcatalog/init.go
+++ b/server/tables/pgcatalog/init.go
@@ -26,5 +26,6 @@ func Init() {
 	InitPgDatabase()
 	InitPgEventTrigger()
 	InitPgIndex()
+	InitPgNamespace()
 	InitPgSequence()
 }

--- a/server/tables/pgcatalog/init.go
+++ b/server/tables/pgcatalog/init.go
@@ -27,5 +27,6 @@ func Init() {
 	InitPgEventTrigger()
 	InitPgIndex()
 	InitPgNamespace()
+	InitPgProc()
 	InitPgSequence()
 }

--- a/server/tables/pgcatalog/init.go
+++ b/server/tables/pgcatalog/init.go
@@ -25,5 +25,6 @@ func Init() {
 	InitPgConstraint()
 	InitPgDatabase()
 	InitPgEventTrigger()
+	InitPgIndex()
 	InitPgSequence()
 }

--- a/server/tables/pgcatalog/init.go
+++ b/server/tables/pgcatalog/init.go
@@ -29,4 +29,5 @@ func Init() {
 	InitPgNamespace()
 	InitPgProc()
 	InitPgSequence()
+	InitPgTrigger()
 }

--- a/server/tables/pgcatalog/init.go
+++ b/server/tables/pgcatalog/init.go
@@ -19,6 +19,7 @@ const PgCatalogName = "pg_catalog"
 
 // Init initializes everything necessary for the pg_catalog tables.
 func Init() {
+	InitPgAttribute()
 	InitPgDatabase()
 	InitPgSequence()
 }

--- a/server/tables/pgcatalog/init.go
+++ b/server/tables/pgcatalog/init.go
@@ -22,6 +22,7 @@ func Init() {
 	InitPgAm()
 	InitPgAttribute()
 	InitPgClass()
+	InitPgConstraint()
 	InitPgDatabase()
 	InitPgSequence()
 }

--- a/server/tables/pgcatalog/init.go
+++ b/server/tables/pgcatalog/init.go
@@ -30,4 +30,5 @@ func Init() {
 	InitPgProc()
 	InitPgSequence()
 	InitPgTrigger()
+	InitPgType()
 }

--- a/server/tables/pgcatalog/init.go
+++ b/server/tables/pgcatalog/init.go
@@ -20,6 +20,7 @@ const PgCatalogName = "pg_catalog"
 // Init initializes everything necessary for the pg_catalog tables.
 func Init() {
 	InitPgAttribute()
+	InitPgClass()
 	InitPgDatabase()
 	InitPgSequence()
 }

--- a/server/tables/pgcatalog/init.go
+++ b/server/tables/pgcatalog/init.go
@@ -24,5 +24,6 @@ func Init() {
 	InitPgClass()
 	InitPgConstraint()
 	InitPgDatabase()
+	InitPgEventTrigger()
 	InitPgSequence()
 }

--- a/server/tables/pgcatalog/pg_am.go
+++ b/server/tables/pgcatalog/pg_am.go
@@ -65,7 +65,6 @@ var pgAmSchema = sql.Schema{
 
 // pgAmRowIter is the sql.RowIter for the pg_am table.
 type pgAmRowIter struct {
-	idx int
 }
 
 var _ sql.RowIter = (*pgAmRowIter)(nil)

--- a/server/tables/pgcatalog/pg_am.go
+++ b/server/tables/pgcatalog/pg_am.go
@@ -43,6 +43,7 @@ func (p PgAmHandler) Name() string {
 
 // RowIter implements the interface tables.Handler.
 func (p PgAmHandler) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	// TODO: Implement pg_am row iter
 	return emptyRowIter()
 }
 

--- a/server/tables/pgcatalog/pg_am.go
+++ b/server/tables/pgcatalog/pg_am.go
@@ -1,0 +1,80 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgcatalog
+
+import (
+	"io"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/tables"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// PgAmName is a constant to the pg_am name.
+const PgAmName = "pg_am"
+
+// InitPgAm handles registration of the pg_am handler.
+func InitPgAm() {
+	tables.AddHandler(PgCatalogName, PgAmName, PgAmHandler{})
+}
+
+// PgAmHandler is the handler for the pg_am table.
+type PgAmHandler struct{}
+
+var _ tables.Handler = PgAmHandler{}
+
+// Name implements the interface tables.Handler.
+func (p PgAmHandler) Name() string {
+	return PgAmName
+}
+
+// RowIter implements the interface tables.Handler.
+func (p PgAmHandler) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	return emptyRowIter()
+}
+
+// Schema implements the interface tables.Handler.
+func (p PgAmHandler) Schema() sql.PrimaryKeySchema {
+	return sql.PrimaryKeySchema{
+		Schema:     pgAmSchema,
+		PkOrdinals: nil,
+	}
+}
+
+// pgAmSchema is the schema for pg_am.
+var pgAmSchema = sql.Schema{
+	{Name: "oid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgAmName},
+	{Name: "amname", Type: pgtypes.Name, Default: nil, Nullable: false, Source: PgAmName},
+	{Name: "amhandler", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgAmName}, // TODO: type regproc
+	{Name: "amtype", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgAmName},
+}
+
+// pgAmRowIter is the sql.RowIter for the pg_am table.
+type pgAmRowIter struct {
+	idx int
+}
+
+var _ sql.RowIter = (*pgAmRowIter)(nil)
+
+// Next implements the interface sql.RowIter.
+func (iter *pgAmRowIter) Next(ctx *sql.Context) (sql.Row, error) {
+	return nil, io.EOF
+}
+
+// Close implements the interface sql.RowIter.
+func (iter *pgAmRowIter) Close(ctx *sql.Context) error {
+	return nil
+}

--- a/server/tables/pgcatalog/pg_attribute.go
+++ b/server/tables/pgcatalog/pg_attribute.go
@@ -1,0 +1,172 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgcatalog
+
+import (
+	"io"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	sqle "github.com/dolthub/go-mysql-server"
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/tables"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// PgAttributeName is a constant to the pg_attribute name.
+const PgAttributeName = "pg_attribute"
+
+// InitPgAttribute handles registration of the pg_attribute handler.
+func InitPgAttribute() {
+	tables.AddHandler(PgCatalogName, PgAttributeName, PgAttributeHandler{})
+}
+
+// PgAttributeHandler is the handler for the pg_attribute table.
+type PgAttributeHandler struct{}
+
+var _ tables.Handler = PgAttributeHandler{}
+
+// Name implements the interface tables.Handler.
+func (p PgAttributeHandler) Name() string {
+	return PgAttributeName
+}
+
+// RowIter implements the interface tables.Handler.
+func (p PgAttributeHandler) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	doltSession := dsess.DSessFromSess(ctx.Session)
+	c := sqle.NewDefault(doltSession.Provider()).Analyzer.Catalog
+
+	var cols []*sql.Column
+
+	for _, db := range c.AllDatabases(ctx) {
+		err := sql.DBTableIter(ctx, db, func(t sql.Table) (cont bool, err error) {
+			for _, col := range t.Schema() {
+				cols = append(cols, col)
+			}
+			return true, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &pgAttributeRowIter{
+		cols: cols,
+		idx:  0,
+	}, nil
+}
+
+// Schema implements the interface tables.Handler.
+func (p PgAttributeHandler) Schema() sql.PrimaryKeySchema {
+	return sql.PrimaryKeySchema{
+		Schema:     pgAttributeSchema,
+		PkOrdinals: nil,
+	}
+}
+
+// pgAttributeSchema is the schema for pg_attribute.
+var pgAttributeSchema = sql.Schema{
+	{Name: "attrelid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attname", Type: pgtypes.Name, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "atttypid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attlen", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attnum", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attcacheoff", Type: pgtypes.Int32, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "atttypmod", Type: pgtypes.Int32, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attndims", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attbyval", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attalign", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attstorage", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attcompression", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attnotnull", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "atthasdef", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "atthasmissing", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attidentity", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attgenerated", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attisdropped", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attislocal", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attinhcount", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attstattarget", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attcollation", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgAttributeName},
+	{Name: "attacl", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: PgAttributeName},        // TODO: type aclitem[]
+	{Name: "attoptions", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: PgAttributeName},    // TODO: collation C
+	{Name: "attfdwoptions", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: PgAttributeName}, // TODO: collation C
+	{Name: "attmissingval", Type: pgtypes.AnyArray, Default: nil, Nullable: true, Source: PgAttributeName},
+}
+
+// pgAttributeRowIter is the sql.RowIter for the pg_attribute table.
+type pgAttributeRowIter struct {
+	cols []*sql.Column
+	idx  int
+}
+
+var _ sql.RowIter = (*pgAttributeRowIter)(nil)
+
+// Next implements the interface sql.RowIter.
+func (iter *pgAttributeRowIter) Next(ctx *sql.Context) (sql.Row, error) {
+	if iter.idx >= len(iter.cols) {
+		return nil, io.EOF
+	}
+	iter.idx++
+	col := iter.cols[iter.idx-1]
+
+	generated := ""
+	if col.Generated != nil {
+		generated = "s"
+	}
+
+	dimensions := 0
+	s, ok := col.Type.(sql.SetType)
+	if ok {
+		dimensions = int(s.NumberOfElements())
+	}
+
+	hasDefault := col.Default != nil
+
+	// TODO: Fill in the rest of the pg_attribute columns
+	return sql.Row{
+		uint32(0),         // attrelid
+		col.Name,          // attname
+		uint32(0),         // atttypid
+		int16(0),          // attlen
+		int16(iter.idx),   // attnum
+		int32(-1),         // attcacheoff
+		int32(-1),         // atttypmod
+		int16(dimensions), // attndims
+		false,             // attbyval
+		"i",               // attalign
+		"p",               // attstorage
+		"",                // attcompression
+		!col.Nullable,     // attnotnull
+		hasDefault,        // atthasdef
+		false,             // atthasmissing
+		"",                // attidentity
+		generated,         // attgenerated
+		false,             // attisdropped
+		true,              // attislocal
+		int16(0),          // attinhcount
+		int16(-1),         // attstattarget
+		uint32(0),         // attcollation
+		nil,               // attacl
+		nil,               // attoptions
+		nil,               // attfdwoptions
+		nil,               // attmissingval
+	}, nil
+}
+
+// Close implements the interface sql.RowIter.
+func (iter *pgAttributeRowIter) Close(ctx *sql.Context) error {
+	return nil
+}

--- a/server/tables/pgcatalog/pg_attribute.go
+++ b/server/tables/pgcatalog/pg_attribute.go
@@ -48,6 +48,7 @@ func emptyRowIter() (sql.RowIter, error) {
 
 // RowIter implements the interface tables.Handler.
 func (p PgAttributeHandler) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	// TODO: Implement pg_attribute row iter
 	return emptyRowIter()
 }
 

--- a/server/tables/pgcatalog/pg_attribute.go
+++ b/server/tables/pgcatalog/pg_attribute.go
@@ -92,7 +92,6 @@ var pgAttributeSchema = sql.Schema{
 
 // pgAttributeRowIter is the sql.RowIter for the pg_attribute table.
 type pgAttributeRowIter struct {
-	idx int
 }
 
 var _ sql.RowIter = (*pgAttributeRowIter)(nil)

--- a/server/tables/pgcatalog/pg_class.go
+++ b/server/tables/pgcatalog/pg_class.go
@@ -43,6 +43,7 @@ func (p PgClassHandler) Name() string {
 
 // RowIter implements the interface tables.Handler.
 func (p PgClassHandler) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	// TODO: Implement pg_class row iter
 	return emptyRowIter()
 }
 

--- a/server/tables/pgcatalog/pg_class.go
+++ b/server/tables/pgcatalog/pg_class.go
@@ -1,0 +1,109 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgcatalog
+
+import (
+	"io"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/tables"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// PgClassName is a constant to the pg_class name.
+const PgClassName = "pg_class"
+
+// InitPgClass handles registration of the pg_class handler.
+func InitPgClass() {
+	tables.AddHandler(PgCatalogName, PgClassName, PgClassHandler{})
+}
+
+// PgClassHandler is the handler for the pg_class table.
+type PgClassHandler struct{}
+
+var _ tables.Handler = PgClassHandler{}
+
+// Name implements the interface tables.Handler.
+func (p PgClassHandler) Name() string {
+	return PgClassName
+}
+
+// RowIter implements the interface tables.Handler.
+func (p PgClassHandler) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	return emptyRowIter()
+}
+
+// Schema implements the interface tables.Handler.
+func (p PgClassHandler) Schema() sql.PrimaryKeySchema {
+	return sql.PrimaryKeySchema{
+		Schema:     pgClassSchema,
+		PkOrdinals: nil,
+	}
+}
+
+// pgClassSchema is the schema for pg_class.
+var pgClassSchema = sql.Schema{
+	{Name: "oid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relname", Type: pgtypes.Name, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relnamespace", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "reltype", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "reloftype", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relowner", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relam", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relfilenode", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "reltablespace", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relpages", Type: pgtypes.Int32, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "reltuples", Type: pgtypes.Float32, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relallvisible", Type: pgtypes.Int32, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "reltoastrelid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relhasindex", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relisshared", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relpersistence", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relkind", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relnatts", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relchecks", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relhasrules", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relhastriggers", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relhassubclass", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relrowsecurity", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relforcerowsecurity", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relispopulated", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relreplident", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relispartition", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relrewrite", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relfrozenxid", Type: pgtypes.Xid, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relminmxid", Type: pgtypes.Xid, Default: nil, Nullable: false, Source: PgClassName},
+	{Name: "relacl", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: PgClassName},     // TODO: type aclitem[]
+	{Name: "reloptions", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: PgClassName}, // TODO: collation C
+	{Name: "relpartbound", Type: pgtypes.Text, Default: nil, Nullable: true, Source: PgClassName},    // TODO: type pg_node_tree, collation C
+}
+
+// pgClassRowIter is the sql.RowIter for the pg_class table.
+type pgClassRowIter struct {
+	idx int
+}
+
+var _ sql.RowIter = (*pgClassRowIter)(nil)
+
+// Next implements the interface sql.RowIter.
+func (iter *pgClassRowIter) Next(ctx *sql.Context) (sql.Row, error) {
+	return nil, io.EOF
+}
+
+// Close implements the interface sql.RowIter.
+func (iter *pgClassRowIter) Close(ctx *sql.Context) error {
+	return nil
+}

--- a/server/tables/pgcatalog/pg_class.go
+++ b/server/tables/pgcatalog/pg_class.go
@@ -94,7 +94,6 @@ var pgClassSchema = sql.Schema{
 
 // pgClassRowIter is the sql.RowIter for the pg_class table.
 type pgClassRowIter struct {
-	idx int
 }
 
 var _ sql.RowIter = (*pgClassRowIter)(nil)

--- a/server/tables/pgcatalog/pg_constraint.go
+++ b/server/tables/pgcatalog/pg_constraint.go
@@ -1,0 +1,103 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgcatalog
+
+import (
+	"io"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/tables"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// PgConstraintName is a constant to the pg_constraint name.
+const PgConstraintName = "pg_constraint"
+
+// InitPgConstraint handles registration of the pg_constraint handler.
+func InitPgConstraint() {
+	tables.AddHandler(PgCatalogName, PgConstraintName, PgConstraintHandler{})
+}
+
+// PgConstraintHandler is the handler for the pg_constraint table.
+type PgConstraintHandler struct{}
+
+var _ tables.Handler = PgConstraintHandler{}
+
+// Name implements the interface tables.Handler.
+func (p PgConstraintHandler) Name() string {
+	return PgConstraintName
+}
+
+// RowIter implements the interface tables.Handler.
+func (p PgConstraintHandler) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	// TODO: Implement pg_constraint row iter
+	return emptyRowIter()
+}
+
+// Schema implements the interface tables.Handler.
+func (p PgConstraintHandler) Schema() sql.PrimaryKeySchema {
+	return sql.PrimaryKeySchema{
+		Schema:     PgConstraintSchema,
+		PkOrdinals: nil,
+	}
+}
+
+// PgConstraintSchema is the schema for pg_constraint.
+var PgConstraintSchema = sql.Schema{
+	{Name: "oid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "conname", Type: pgtypes.Name, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "connamespace", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "contype", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "condeferrable", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "condeferred", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "convalidated", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "conrelid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "contypid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "conindid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "conparentid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "confrelid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "confupdtype", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "confdeltype", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "confmatchtype", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "conislocal", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "coninhcount", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "connoinherit", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgConstraintName},
+	{Name: "conkey", Type: pgtypes.Int16Array, Default: nil, Nullable: true, Source: PgConstraintName},
+	{Name: "confkey", Type: pgtypes.Int16Array, Default: nil, Nullable: true, Source: PgConstraintName},
+	{Name: "conpfeqop", Type: pgtypes.OidArray, Default: nil, Nullable: true, Source: PgConstraintName},
+	{Name: "conppeqop", Type: pgtypes.OidArray, Default: nil, Nullable: true, Source: PgConstraintName},
+	{Name: "conffeqop", Type: pgtypes.OidArray, Default: nil, Nullable: true, Source: PgConstraintName},
+	{Name: "confdelsetcols", Type: pgtypes.Int16Array, Default: nil, Nullable: true, Source: PgConstraintName},
+	{Name: "conexclop", Type: pgtypes.OidArray, Default: nil, Nullable: true, Source: PgConstraintName},
+	{Name: "conbin", Type: pgtypes.Text, Default: nil, Nullable: true, Source: PgConstraintName}, // TODO: type pg_node_tree, collation C
+}
+
+// PgConstraintRowIter is the sql.RowIter for the pg_constraint table.
+type PgConstraintRowIter struct {
+	idx int
+}
+
+var _ sql.RowIter = (*PgConstraintRowIter)(nil)
+
+// Next implements the interface sql.RowIter.
+func (iter *PgConstraintRowIter) Next(ctx *sql.Context) (sql.Row, error) {
+	return nil, io.EOF
+}
+
+// Close implements the interface sql.RowIter.
+func (iter *PgConstraintRowIter) Close(ctx *sql.Context) error {
+	return nil
+}

--- a/server/tables/pgcatalog/pg_constraint.go
+++ b/server/tables/pgcatalog/pg_constraint.go
@@ -85,19 +85,18 @@ var PgConstraintSchema = sql.Schema{
 	{Name: "conbin", Type: pgtypes.Text, Default: nil, Nullable: true, Source: PgConstraintName}, // TODO: type pg_node_tree, collation C
 }
 
-// PgConstraintRowIter is the sql.RowIter for the pg_constraint table.
-type PgConstraintRowIter struct {
-	idx int
+// pgConstraintRowIter is the sql.RowIter for the pg_constraint table.
+type pgConstraintRowIter struct {
 }
 
-var _ sql.RowIter = (*PgConstraintRowIter)(nil)
+var _ sql.RowIter = (*pgConstraintRowIter)(nil)
 
 // Next implements the interface sql.RowIter.
-func (iter *PgConstraintRowIter) Next(ctx *sql.Context) (sql.Row, error) {
+func (iter *pgConstraintRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 	return nil, io.EOF
 }
 
 // Close implements the interface sql.RowIter.
-func (iter *PgConstraintRowIter) Close(ctx *sql.Context) error {
+func (iter *pgConstraintRowIter) Close(ctx *sql.Context) error {
 	return nil
 }

--- a/server/tables/pgcatalog/pg_event_trigger.go
+++ b/server/tables/pgcatalog/pg_event_trigger.go
@@ -66,19 +66,18 @@ var PgEventTriggerSchema = sql.Schema{
 	{Name: "evttags", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: PgEventTriggerName}, // TODO: collation C
 }
 
-// PgEventTriggerRowIter is the sql.RowIter for the pg_event_trigger table.
-type PgEventTriggerRowIter struct {
-	idx int
+// pgEventTriggerRowIter is the sql.RowIter for the pg_event_trigger table.
+type pgEventTriggerRowIter struct {
 }
 
-var _ sql.RowIter = (*PgEventTriggerRowIter)(nil)
+var _ sql.RowIter = (*pgEventTriggerRowIter)(nil)
 
 // Next implements the interface sql.RowIter.
-func (iter *PgEventTriggerRowIter) Next(ctx *sql.Context) (sql.Row, error) {
+func (iter *pgEventTriggerRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 	return nil, io.EOF
 }
 
 // Close implements the interface sql.RowIter.
-func (iter *PgEventTriggerRowIter) Close(ctx *sql.Context) error {
+func (iter *pgEventTriggerRowIter) Close(ctx *sql.Context) error {
 	return nil
 }

--- a/server/tables/pgcatalog/pg_event_trigger.go
+++ b/server/tables/pgcatalog/pg_event_trigger.go
@@ -1,0 +1,84 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgcatalog
+
+import (
+	"io"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/tables"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// PgEventTriggerName is a constant to the pg_event_trigger name.
+const PgEventTriggerName = "pg_event_trigger"
+
+// InitPgEventTrigger handles registration of the pg_event_trigger handler.
+func InitPgEventTrigger() {
+	tables.AddHandler(PgCatalogName, PgEventTriggerName, PgEventTriggerHandler{})
+}
+
+// PgEventTriggerHandler is the handler for the pg_event_trigger table.
+type PgEventTriggerHandler struct{}
+
+var _ tables.Handler = PgEventTriggerHandler{}
+
+// Name implements the interface tables.Handler.
+func (p PgEventTriggerHandler) Name() string {
+	return PgEventTriggerName
+}
+
+// RowIter implements the interface tables.Handler.
+func (p PgEventTriggerHandler) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	// TODO: Implement pg_event_trigger row iter
+	return emptyRowIter()
+}
+
+// Schema implements the interface tables.Handler.
+func (p PgEventTriggerHandler) Schema() sql.PrimaryKeySchema {
+	return sql.PrimaryKeySchema{
+		Schema:     PgEventTriggerSchema,
+		PkOrdinals: nil,
+	}
+}
+
+// PgEventTriggerSchema is the schema for pg_event_trigger.
+var PgEventTriggerSchema = sql.Schema{
+	{Name: "oid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgEventTriggerName},
+	{Name: "evtname", Type: pgtypes.Name, Default: nil, Nullable: false, Source: PgEventTriggerName},
+	{Name: "evtevent", Type: pgtypes.Name, Default: nil, Nullable: false, Source: PgEventTriggerName},
+	{Name: "evtowner", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgEventTriggerName},
+	{Name: "evtfoid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgEventTriggerName},
+	{Name: "evtenabled", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgEventTriggerName},
+	{Name: "evttags", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: PgEventTriggerName}, // TODO: collation C
+}
+
+// PgEventTriggerRowIter is the sql.RowIter for the pg_event_trigger table.
+type PgEventTriggerRowIter struct {
+	idx int
+}
+
+var _ sql.RowIter = (*PgEventTriggerRowIter)(nil)
+
+// Next implements the interface sql.RowIter.
+func (iter *PgEventTriggerRowIter) Next(ctx *sql.Context) (sql.Row, error) {
+	return nil, io.EOF
+}
+
+// Close implements the interface sql.RowIter.
+func (iter *PgEventTriggerRowIter) Close(ctx *sql.Context) error {
+	return nil
+}

--- a/server/tables/pgcatalog/pg_index.go
+++ b/server/tables/pgcatalog/pg_index.go
@@ -82,7 +82,6 @@ var pgIndexSchema = sql.Schema{
 
 // pgIndexRowIter is the sql.RowIter for the pg_index table.
 type pgIndexRowIter struct {
-	idx int
 }
 
 var _ sql.RowIter = (*pgIndexRowIter)(nil)

--- a/server/tables/pgcatalog/pg_index.go
+++ b/server/tables/pgcatalog/pg_index.go
@@ -1,0 +1,98 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgcatalog
+
+import (
+	"io"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/tables"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// PgIndexName is a constant to the pg_index name.
+const PgIndexName = "pg_index"
+
+// InitPgIndex handles registration of the pg_index handler.
+func InitPgIndex() {
+	tables.AddHandler(PgCatalogName, PgIndexName, PgIndexHandler{})
+}
+
+// PgIndexHandler is the handler for the pg_index table.
+type PgIndexHandler struct{}
+
+var _ tables.Handler = PgIndexHandler{}
+
+// Name implements the interface tables.Handler.
+func (p PgIndexHandler) Name() string {
+	return PgIndexName
+}
+
+// RowIter implements the interface tables.Handler.
+func (p PgIndexHandler) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	// TODO: Implement pg_index row iter
+	return emptyRowIter()
+}
+
+// Schema implements the interface tables.Handler.
+func (p PgIndexHandler) Schema() sql.PrimaryKeySchema {
+	return sql.PrimaryKeySchema{
+		Schema:     pgIndexSchema,
+		PkOrdinals: nil,
+	}
+}
+
+// pgIndexSchema is the schema for pg_index.
+var pgIndexSchema = sql.Schema{
+	{Name: "indexrelid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgIndexName},
+	{Name: "indrelid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgIndexName},
+	{Name: "indnatts", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: PgIndexName},
+	{Name: "indnkeyatts", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: PgIndexName},
+	{Name: "indisunique", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgIndexName},
+	{Name: "indnullsnotdistinct", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgIndexName},
+	{Name: "indisprimary", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgIndexName},
+	{Name: "indisexclusion", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgIndexName},
+	{Name: "indimmediate", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgIndexName},
+	{Name: "indisclustered", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgIndexName},
+	{Name: "indisvalid", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgIndexName},
+	{Name: "indcheckxmin", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgIndexName},
+	{Name: "indisready", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgIndexName},
+	{Name: "indislive", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgIndexName},
+	{Name: "indisreplident", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgIndexName},
+	{Name: "indkey", Type: pgtypes.Int16Array, Default: nil, Nullable: false, Source: PgIndexName},     // TODO: type int2vector
+	{Name: "indcollation", Type: pgtypes.OidArray, Default: nil, Nullable: false, Source: PgIndexName}, // TODO: type oidvector
+	{Name: "indclass", Type: pgtypes.OidArray, Default: nil, Nullable: false, Source: PgIndexName},     // TODO: type oidvector
+	{Name: "indoption", Type: pgtypes.Int16Array, Default: nil, Nullable: false, Source: PgIndexName},  // TODO: type int2vector
+	{Name: "indexprs", Type: pgtypes.Text, Default: nil, Nullable: true, Source: PgIndexName},          // TODO: type pg_node_tree, collation C
+	{Name: "indpred", Type: pgtypes.Text, Default: nil, Nullable: true, Source: PgIndexName},           // TODO: type pg_node_tree, collation C
+}
+
+// pgIndexRowIter is the sql.RowIter for the pg_index table.
+type pgIndexRowIter struct {
+	idx int
+}
+
+var _ sql.RowIter = (*pgIndexRowIter)(nil)
+
+// Next implements the interface sql.RowIter.
+func (iter *pgIndexRowIter) Next(ctx *sql.Context) (sql.Row, error) {
+	return nil, io.EOF
+}
+
+// Close implements the interface sql.RowIter.
+func (iter *pgIndexRowIter) Close(ctx *sql.Context) error {
+	return nil
+}

--- a/server/tables/pgcatalog/pg_namespace.go
+++ b/server/tables/pgcatalog/pg_namespace.go
@@ -1,0 +1,81 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgcatalog
+
+import (
+	"io"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/tables"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// PgNamespaceName is a constant to the pg_namespace name.
+const PgNamespaceName = "pg_namespace"
+
+// InitPgNamespace handles registration of the pg_namespace handler.
+func InitPgNamespace() {
+	tables.AddHandler(PgCatalogName, PgNamespaceName, PgNamespaceHandler{})
+}
+
+// PgNamespaceHandler is the handler for the pg_namespace table.
+type PgNamespaceHandler struct{}
+
+var _ tables.Handler = PgNamespaceHandler{}
+
+// Name implements the interface tables.Handler.
+func (p PgNamespaceHandler) Name() string {
+	return PgNamespaceName
+}
+
+// RowIter implements the interface tables.Handler.
+func (p PgNamespaceHandler) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	// TODO: Implement pg_namespace row iter
+	return emptyRowIter()
+}
+
+// Schema implements the interface tables.Handler.
+func (p PgNamespaceHandler) Schema() sql.PrimaryKeySchema {
+	return sql.PrimaryKeySchema{
+		Schema:     pgNamespaceSchema,
+		PkOrdinals: nil,
+	}
+}
+
+// pgNamespaceSchema is the schema for pg_namespace.
+var pgNamespaceSchema = sql.Schema{
+	{Name: "oid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgNamespaceName},
+	{Name: "nspname", Type: pgtypes.Name, Default: nil, Nullable: false, Source: PgNamespaceName},
+	{Name: "nspowner", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgNamespaceName},
+	{Name: "nspacl", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: PgNamespaceName}, // TODO: type aclitem[]         // TODO: type pg_node_tree, collation C
+}
+
+// pgNamespaceRowIter is the sql.RowIter for the pg_namespace table.
+type pgNamespaceRowIter struct {
+	idx int
+}
+
+var _ sql.RowIter = (*pgNamespaceRowIter)(nil)
+
+// Next implements the interface sql.RowIter.
+func (iter *pgNamespaceRowIter) Next(ctx *sql.Context) (sql.Row, error) {
+	return nil, io.EOF
+}
+
+// Close implements the interface sql.RowIter.
+func (iter *pgNamespaceRowIter) Close(ctx *sql.Context) error {
+	return nil
+}

--- a/server/tables/pgcatalog/pg_namespace.go
+++ b/server/tables/pgcatalog/pg_namespace.go
@@ -60,7 +60,7 @@ var pgNamespaceSchema = sql.Schema{
 	{Name: "oid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgNamespaceName},
 	{Name: "nspname", Type: pgtypes.Name, Default: nil, Nullable: false, Source: PgNamespaceName},
 	{Name: "nspowner", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgNamespaceName},
-	{Name: "nspacl", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: PgNamespaceName}, // TODO: type aclitem[]         // TODO: type pg_node_tree, collation C
+	{Name: "nspacl", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: PgNamespaceName}, // TODO: type aclitem[]
 }
 
 // pgNamespaceRowIter is the sql.RowIter for the pg_namespace table.

--- a/server/tables/pgcatalog/pg_namespace.go
+++ b/server/tables/pgcatalog/pg_namespace.go
@@ -65,7 +65,6 @@ var pgNamespaceSchema = sql.Schema{
 
 // pgNamespaceRowIter is the sql.RowIter for the pg_namespace table.
 type pgNamespaceRowIter struct {
-	idx int
 }
 
 var _ sql.RowIter = (*pgNamespaceRowIter)(nil)

--- a/server/tables/pgcatalog/pg_proc.go
+++ b/server/tables/pgcatalog/pg_proc.go
@@ -91,7 +91,6 @@ var pgProcSchema = sql.Schema{
 
 // pgProcRowIter is the sql.RowIter for the pg_proc table.
 type pgProcRowIter struct {
-	idx int
 }
 
 var _ sql.RowIter = (*pgProcRowIter)(nil)

--- a/server/tables/pgcatalog/pg_proc.go
+++ b/server/tables/pgcatalog/pg_proc.go
@@ -1,0 +1,107 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgcatalog
+
+import (
+	"io"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/tables"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// PgProcName is a constant to the pg_proc name.
+const PgProcName = "pg_proc"
+
+// InitPgProc handles registration of the pg_proc handler.
+func InitPgProc() {
+	tables.AddHandler(PgCatalogName, PgProcName, PgProcHandler{})
+}
+
+// PgProcHandler is the handler for the pg_proc table.
+type PgProcHandler struct{}
+
+var _ tables.Handler = PgProcHandler{}
+
+// Name implements the interface tables.Handler.
+func (p PgProcHandler) Name() string {
+	return PgProcName
+}
+
+// RowIter implements the interface tables.Handler.
+func (p PgProcHandler) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	// TODO: Implement pg_proc row iter
+	return emptyRowIter()
+}
+
+// Schema implements the interface tables.Handler.
+func (p PgProcHandler) Schema() sql.PrimaryKeySchema {
+	return sql.PrimaryKeySchema{
+		Schema:     pgProcSchema,
+		PkOrdinals: nil,
+	}
+}
+
+// pgProcSchema is the schema for pg_proc.
+var pgProcSchema = sql.Schema{
+	{Name: "oid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "proname", Type: pgtypes.Name, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "pronamespace", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "proowner", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "prolang", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "procost", Type: pgtypes.Float32, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "prorows", Type: pgtypes.Float32, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "provariadic", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "prosupport", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgProcName}, // TODO: type regproc
+	{Name: "prokind", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "prosecdef", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "proleakproof", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "proisstrict", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "proretset", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "provolatile", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "proparallel", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "pronargs", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "pronargdefaults", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "prorettype", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgProcName},
+	{Name: "proargtypes", Type: pgtypes.OidArray, Default: nil, Nullable: false, Source: PgProcName}, // TODO: type oidvector
+	{Name: "proallargtypes", Type: pgtypes.OidArray, Default: nil, Nullable: true, Source: PgProcName},
+	{Name: "proargmodes", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: PgProcName}, // TODO: type char[]
+	{Name: "proargnames", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: PgProcName}, // TODO: collation C
+	{Name: "proargdefaults", Type: pgtypes.Text, Default: nil, Nullable: true, Source: PgProcName},   // TODO: type pg_node_tree, collation C
+	{Name: "protrftypes", Type: pgtypes.OidArray, Default: nil, Nullable: true, Source: PgProcName},
+	{Name: "prosrc", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgProcName}, // TODO: collation C
+	{Name: "probin", Type: pgtypes.Text, Default: nil, Nullable: true, Source: PgProcName},
+	{Name: "prosqlbody", Type: pgtypes.Text, Default: nil, Nullable: true, Source: PgProcName},     // TODO: type pg_node_tree, collation C
+	{Name: "proconfig", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: PgProcName}, // TODO: collation C
+	{Name: "proacl", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: PgProcName},    // TODO: type aclitem[]
+}
+
+// pgProcRowIter is the sql.RowIter for the pg_proc table.
+type pgProcRowIter struct {
+	idx int
+}
+
+var _ sql.RowIter = (*pgProcRowIter)(nil)
+
+// Next implements the interface sql.RowIter.
+func (iter *pgProcRowIter) Next(ctx *sql.Context) (sql.Row, error) {
+	return nil, io.EOF
+}
+
+// Close implements the interface sql.RowIter.
+func (iter *pgProcRowIter) Close(ctx *sql.Context) error {
+	return nil
+}

--- a/server/tables/pgcatalog/pg_trigger.go
+++ b/server/tables/pgcatalog/pg_trigger.go
@@ -80,7 +80,6 @@ var pgTriggerSchema = sql.Schema{
 
 // pgTriggerRowIter is the sql.RowIter for the pg_trigger table.
 type pgTriggerRowIter struct {
-	idx int
 }
 
 var _ sql.RowIter = (*pgTriggerRowIter)(nil)

--- a/server/tables/pgcatalog/pg_trigger.go
+++ b/server/tables/pgcatalog/pg_trigger.go
@@ -1,0 +1,96 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgcatalog
+
+import (
+	"io"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/tables"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// PgTriggerName is a constant to the pg_trigger name.
+const PgTriggerName = "pg_trigger"
+
+// InitPgTrigger handles registration of the pg_trigger handler.
+func InitPgTrigger() {
+	tables.AddHandler(PgCatalogName, PgTriggerName, PgTriggerHandler{})
+}
+
+// PgTriggerHandler is the handler for the pg_trigger table.
+type PgTriggerHandler struct{}
+
+var _ tables.Handler = PgTriggerHandler{}
+
+// Name implements the interface tables.Handler.
+func (p PgTriggerHandler) Name() string {
+	return PgTriggerName
+}
+
+// RowIter implements the interface tables.Handler.
+func (p PgTriggerHandler) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	// TODO: Implement pg_trigger row iter
+	return emptyRowIter()
+}
+
+// Schema implements the interface tables.Handler.
+func (p PgTriggerHandler) Schema() sql.PrimaryKeySchema {
+	return sql.PrimaryKeySchema{
+		Schema:     pgTriggerSchema,
+		PkOrdinals: nil,
+	}
+}
+
+// pgTriggerSchema is the schema for pg_trigger.
+var pgTriggerSchema = sql.Schema{
+	{Name: "oid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTriggerName},
+	{Name: "tgrelid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTriggerName},
+	{Name: "tgparentid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTriggerName},
+	{Name: "tgname", Type: pgtypes.Name, Default: nil, Nullable: false, Source: PgTriggerName},
+	{Name: "tgfoid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTriggerName},
+	{Name: "tgtype", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: PgTriggerName},
+	{Name: "tgenabled", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgTriggerName},
+	{Name: "tgisinternal", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgTriggerName},
+	{Name: "tgconstrrelid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTriggerName},
+	{Name: "tgconstrindid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTriggerName},
+	{Name: "tgconstraint", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTriggerName},
+	{Name: "tgdeferrable", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgTriggerName},
+	{Name: "tginitdeferred", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgTriggerName},
+	{Name: "tgnargs", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: PgTriggerName},
+	{Name: "tgattr", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: PgTriggerName}, // TODO: type int2vector
+	{Name: "tgargs", Type: pgtypes.Bytea, Default: nil, Nullable: false, Source: PgTriggerName},
+	{Name: "tgqual", Type: pgtypes.Text, Default: nil, Nullable: true, Source: PgTriggerName}, // TODO: type pg_node_tree, collation C
+	{Name: "tgoldtable", Type: pgtypes.Name, Default: nil, Nullable: true, Source: PgTriggerName},
+	{Name: "tgnewtable", Type: pgtypes.Name, Default: nil, Nullable: true, Source: PgTriggerName},
+}
+
+// pgTriggerRowIter is the sql.RowIter for the pg_trigger table.
+type pgTriggerRowIter struct {
+	idx int
+}
+
+var _ sql.RowIter = (*pgTriggerRowIter)(nil)
+
+// Next implements the interface sql.RowIter.
+func (iter *pgTriggerRowIter) Next(ctx *sql.Context) (sql.Row, error) {
+	return nil, io.EOF
+}
+
+// Close implements the interface sql.RowIter.
+func (iter *pgTriggerRowIter) Close(ctx *sql.Context) error {
+	return nil
+}

--- a/server/tables/pgcatalog/pg_type.go
+++ b/server/tables/pgcatalog/pg_type.go
@@ -93,7 +93,6 @@ var pgTypeSchema = sql.Schema{
 
 // pgTypeRowIter is the sql.RowIter for the pg_type table.
 type pgTypeRowIter struct {
-	idx int
 }
 
 var _ sql.RowIter = (*pgTypeRowIter)(nil)

--- a/server/tables/pgcatalog/pg_type.go
+++ b/server/tables/pgcatalog/pg_type.go
@@ -1,0 +1,109 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgcatalog
+
+import (
+	"io"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/tables"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// PgTypeName is a constant to the pg_type name.
+const PgTypeName = "pg_type"
+
+// InitPgType handles registration of the pg_type handler.
+func InitPgType() {
+	tables.AddHandler(PgCatalogName, PgTypeName, PgTypeHandler{})
+}
+
+// PgTypeHandler is the handler for the pg_type table.
+type PgTypeHandler struct{}
+
+var _ tables.Handler = PgTypeHandler{}
+
+// Name implements the interface tables.Handler.
+func (p PgTypeHandler) Name() string {
+	return PgTypeName
+}
+
+// RowIter implements the interface tables.Handler.
+func (p PgTypeHandler) RowIter(ctx *sql.Context) (sql.RowIter, error) {
+	// TODO: Implement pg_type row iter
+	return emptyRowIter()
+}
+
+// Schema implements the interface tables.Handler.
+func (p PgTypeHandler) Schema() sql.PrimaryKeySchema {
+	return sql.PrimaryKeySchema{
+		Schema:     pgTypeSchema,
+		PkOrdinals: nil,
+	}
+}
+
+// pgTypeSchema is the schema for pg_type.
+var pgTypeSchema = sql.Schema{
+	{Name: "oid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typname", Type: pgtypes.Name, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typnamespace", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typowner", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typlen", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typbyval", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typtype", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typcategory", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typispreferred", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typisdefined", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typdelim", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typrelid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typsubscript", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgTypeName}, // TODO: type regproc
+	{Name: "typelem", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typarray", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typinput", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgTypeName},   // TODO: type regproc
+	{Name: "typoutput", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgTypeName},  // TODO: type regproc
+	{Name: "typreceive", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgTypeName}, // TODO: type regproc
+	{Name: "typsend", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgTypeName},    // TODO: type regproc
+	{Name: "typmodin", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgTypeName},   // TODO: type regproc
+	{Name: "typmodout", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgTypeName},  // TODO: type regproc
+	{Name: "typanalyze", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgTypeName}, // TODO: type regproc
+	{Name: "typalign", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typstorage", Type: pgtypes.BpChar, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typnotnull", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typbasetype", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typtypmod", Type: pgtypes.Int32, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typndims", Type: pgtypes.Int32, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typcollation", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTypeName},
+	{Name: "typdefaultbin", Type: pgtypes.Text, Default: nil, Nullable: true, Source: PgTypeName}, // TODO: type pg_node_tree, collation C
+	{Name: "typdefault", Type: pgtypes.Text, Default: nil, Nullable: true, Source: PgTypeName},    // TODO: collation C
+	{Name: "typacl", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: PgTypeName},   // TODO: type aclitem[]
+}
+
+// pgTypeRowIter is the sql.RowIter for the pg_type table.
+type pgTypeRowIter struct {
+	idx int
+}
+
+var _ sql.RowIter = (*pgTypeRowIter)(nil)
+
+// Next implements the interface sql.RowIter.
+func (iter *pgTypeRowIter) Next(ctx *sql.Context) (sql.Row, error) {
+	return nil, io.EOF
+}
+
+// Close implements the interface sql.RowIter.
+func (iter *pgTypeRowIter) Close(ctx *sql.Context) error {
+	return nil
+}

--- a/testing/bats/psql-commands.bats
+++ b/testing/bats/psql-commands.bats
@@ -29,22 +29,42 @@ teardown() {
 @test 'psql-commands: \dt' {
     run query_server --csv -c "\dt"
     [ "$status" -eq 0 ]
+    [[ "$output" =~ "public,pg_am,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_attribute,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_class,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_constraint,table,postgres" ]] || false
     [[ "$output" =~ "public,pg_database,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_event_trigger,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_index,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_namespace,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_proc,table,postgres" ]] || false
     [[ "$output" =~ "public,pg_sequence,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_trigger,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_type,table,postgres" ]] || false
     [[ "$output" =~ "public,test1,table,postgres" ]] || false
     [[ "$output" =~ "public,test2,table,postgres" ]] || false
-    [ "${#lines[@]}" -eq 5 ]
+    [ "${#lines[@]}" -eq 15 ]
 }
 
 @test 'psql-commands: \d' {
     run query_server --csv -c "\d"
     echo "$output"
     [ "$status" -eq 0 ]
+    [[ "$output" =~ "public,pg_am,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_attribute,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_class,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_constraint,table,postgres" ]] || false
     [[ "$output" =~ "public,pg_database,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_event_trigger,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_index,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_namespace,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_proc,table,postgres" ]] || false
     [[ "$output" =~ "public,pg_sequence,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_trigger,table,postgres" ]] || false
+    [[ "$output" =~ "public,pg_type,table,postgres" ]] || false
     [[ "$output" =~ "public,test1,table,postgres" ]] || false
     [[ "$output" =~ "public,test2,table,postgres" ]] || false
-    [ "${#lines[@]}" -eq 5 ]
+    [ "${#lines[@]}" -eq 15 ]
 }
 
 @test 'psql-commands: \d table' {

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -6,6 +6,58 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
+func TestPgAttribute(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "pg_attribute",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT * FROM "pg_catalog"."pg_attribute";`,
+					Expected: []sql.Row{},
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "PG_catalog"."pg_attribute";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "pg_catalog"."PG_attribute";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases but non-quoted, so it works
+					Query:    "SELECT attname FROM PG_catalog.pg_ATTRIBUTE ORDER BY attname;",
+					Expected: []sql.Row{},
+				},
+			},
+		},
+	})
+}
+
+func TestPgClass(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "pg_class",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT * FROM "pg_catalog"."pg_class";`,
+					Expected: []sql.Row{},
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "PG_catalog"."pg_class";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "pg_catalog"."PG_class";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases but non-quoted, so it works
+					Query:    "SELECT relname FROM PG_catalog.pg_CLASS ORDER BY relname;",
+					Expected: []sql.Row{},
+				},
+			},
+		},
+	})
+}
+
 // TODO: Figure out why there is not a doltgres database when running these tests locally
 func TestPgDatabase(t *testing.T) {
 	RunScripts(t, []ScriptTest{
@@ -53,32 +105,6 @@ func TestPgDatabase(t *testing.T) {
 					Expected: []sql.Row{
 						{3, "test", 0, 0, "i", "f", "t", -1, 0, 0, 0, "", "", nil, "", nil, nil},
 					},
-				},
-			},
-		},
-	})
-}
-
-func TestPgAttribute(t *testing.T) {
-	RunScripts(t, []ScriptTest{
-		{
-			Name: "pg_attribute",
-			Assertions: []ScriptTestAssertion{
-				{
-					Query:    `SELECT * FROM "pg_catalog"."pg_attribute";`,
-					Expected: []sql.Row{},
-				},
-				{ // Different cases and quoted, so it fails
-					Query:       `SELECT * FROM "PG_catalog"."pg_attribute";`,
-					ExpectedErr: "not",
-				},
-				{ // Different cases and quoted, so it fails
-					Query:       `SELECT * FROM "pg_catalog"."PG_attribute";`,
-					ExpectedErr: "not",
-				},
-				{ // Different cases but non-quoted, so it works
-					Query:    "SELECT attname FROM PG_catalog.pg_ATTRIBUTE ORDER BY attname;",
-					Expected: []sql.Row{},
 				},
 			},
 		},

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -162,3 +162,29 @@ func TestPgDatabase(t *testing.T) {
 		},
 	})
 }
+
+func TestPgEventTrigger(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "pg_event_trigger",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT * FROM "pg_catalog"."pg_event_trigger";`,
+					Expected: []sql.Row{},
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "PG_catalog"."pg_event_trigger";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "pg_catalog"."PG_event_trigger";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases but non-quoted, so it works
+					Query:    "SELECT evtname FROM PG_catalog.pg_EVENT_TRIGGER ORDER BY evtname;",
+					Expected: []sql.Row{},
+				},
+			},
+		},
+	})
+}

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -6,6 +6,32 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
+func TestPgAm(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "pg_am",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT * FROM "pg_catalog"."pg_am";`,
+					Expected: []sql.Row{},
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "PG_catalog"."pg_am";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "pg_catalog"."PG_am";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases but non-quoted, so it works
+					Query:    "SELECT amname FROM PG_catalog.pg_AM ORDER BY amname;",
+					Expected: []sql.Row{},
+				},
+			},
+		},
+	})
+}
+
 func TestPgAttribute(t *testing.T) {
 	RunScripts(t, []ScriptTest{
 		{

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -68,6 +68,18 @@ func TestPgAttribute(t *testing.T) {
 					Query:    `SELECT * FROM "pg_catalog"."pg_attribute";`,
 					Expected: []sql.Row{},
 				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "PG_catalog"."pg_attribute";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "pg_catalog"."PG_attribute";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases but non-quoted, so it works
+					Query:    "SELECT attname FROM PG_catalog.pg_ATTRIBUTE ORDER BY attname;",
+					Expected: []sql.Row{},
+				},
 			},
 		},
 	})

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -214,3 +214,29 @@ func TestPgIndex(t *testing.T) {
 		},
 	})
 }
+
+func TestPgNamespace(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "pg_namespace",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT * FROM "pg_catalog"."pg_namespace";`,
+					Expected: []sql.Row{},
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "PG_catalog"."pg_namespace";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "pg_catalog"."PG_namespace";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases but non-quoted, so it works
+					Query:    "SELECT nspname FROM PG_catalog.pg_NAMESPACE ORDER BY nspname;",
+					Expected: []sql.Row{},
+				},
+			},
+		},
+	})
+}

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -84,6 +84,32 @@ func TestPgClass(t *testing.T) {
 	})
 }
 
+func TestPgConstraint(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "pg_constraint",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT * FROM "pg_catalog"."pg_constraint";`,
+					Expected: []sql.Row{},
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "PG_catalog"."pg_constraint";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "pg_catalog"."PG_constraint";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases but non-quoted, so it works
+					Query:    "SELECT conname FROM PG_catalog.pg_CONSTRAINT ORDER BY conname;",
+					Expected: []sql.Row{},
+				},
+			},
+		},
+	})
+}
+
 // TODO: Figure out why there is not a doltgres database when running these tests locally
 func TestPgDatabase(t *testing.T) {
 	RunScripts(t, []ScriptTest{

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -240,3 +240,29 @@ func TestPgNamespace(t *testing.T) {
 		},
 	})
 }
+
+func TestPgProc(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "pg_proc",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT * FROM "pg_catalog"."pg_proc";`,
+					Expected: []sql.Row{},
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "PG_catalog"."pg_proc";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "pg_catalog"."PG_proc";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases but non-quoted, so it works
+					Query:    "SELECT proname FROM PG_catalog.pg_PROC ORDER BY proname;",
+					Expected: []sql.Row{},
+				},
+			},
+		},
+	})
+}

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -292,3 +292,29 @@ func TestPgTrigger(t *testing.T) {
 		},
 	})
 }
+
+func TestPgType(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "pg_type",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT * FROM "pg_catalog"."pg_type";`,
+					Expected: []sql.Row{},
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "PG_catalog"."pg_type";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "pg_catalog"."PG_type";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases but non-quoted, so it works
+					Query:    "SELECT typname FROM PG_catalog.pg_TYPE ORDER BY typname;",
+					Expected: []sql.Row{},
+				},
+			},
+		},
+	})
+}

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -58,3 +58,17 @@ func TestPgDatabase(t *testing.T) {
 		},
 	})
 }
+
+func TestPgAttribute(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "pg_attribute",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT * FROM "pg_catalog"."pg_attribute";`,
+					Expected: []sql.Row{},
+				},
+			},
+		},
+	})
+}

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -188,3 +188,29 @@ func TestPgEventTrigger(t *testing.T) {
 		},
 	})
 }
+
+func TestPgIndex(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "pg_index",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT * FROM "pg_catalog"."pg_index";`,
+					Expected: []sql.Row{},
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "PG_catalog"."pg_index";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "pg_catalog"."PG_index";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases but non-quoted, so it works
+					Query:    "SELECT indexrelid FROM PG_catalog.pg_INDEX ORDER BY indexrelid;",
+					Expected: []sql.Row{},
+				},
+			},
+		},
+	})
+}

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -266,3 +266,29 @@ func TestPgProc(t *testing.T) {
 		},
 	})
 }
+
+func TestPgTrigger(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "pg_trigger",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT * FROM "pg_catalog"."pg_trigger";`,
+					Expected: []sql.Row{},
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "PG_catalog"."pg_trigger";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases and quoted, so it fails
+					Query:       `SELECT * FROM "pg_catalog"."PG_trigger";`,
+					ExpectedErr: "not",
+				},
+				{ // Different cases but non-quoted, so it works
+					Query:    "SELECT tgname FROM PG_catalog.pg_TRIGGER ORDER BY tgname;",
+					Expected: []sql.Row{},
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
Moves over already defined schemas from [this PR](https://github.com/dolthub/doltgresql/pull/190).

Includes pg_am, pg_attribute, pg_class, pg_constraint, pg_event_trigger, pg_index, pg_namespace, pg_proc, pg_trigger, and pg_type