### PR TITLE
Enable partial index support

### DIFF
--- a/server/analyzer/indexes.go
+++ b/server/analyzer/indexes.go
@@ -1,0 +1,85 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzer
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/analyzer"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+
+	pgexprs "github.com/dolthub/doltgresql/server/expression"
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// IndexLeafChildren overrides the IndexLeafChildren function in GMS to use Doltgres types.
+func IndexLeafChildren(e sql.Expression) (analyzer.IndexScanOp, sql.Expression, sql.Expression, bool) {
+	var op analyzer.IndexScanOp
+	var left sql.Expression
+	var right sql.Expression
+	switch expr := e.(type) {
+	case *pgexprs.BinaryOperator:
+		switch expr.Operator() {
+		case framework.Operator_BinaryEqual:
+			op = analyzer.IndexScanOpEq
+			left = expr.Left()
+			right = expr.Right()
+		case framework.Operator_BinaryGreaterOrEqual:
+			op = analyzer.IndexScanOpGt
+			left = expr.Left()
+			right = expr.Right()
+		case framework.Operator_BinaryGreaterThan:
+			op = analyzer.IndexScanOpGte
+			left = expr.Left()
+			right = expr.Right()
+		case framework.Operator_BinaryLessOrEqual:
+			op = analyzer.IndexScanOpLte
+			left = expr.Left()
+			right = expr.Right()
+		case framework.Operator_BinaryLessThan:
+			op = analyzer.IndexScanOpLt
+			left = expr.Left()
+			right = expr.Right()
+		default:
+			return 0, nil, nil, false
+		}
+	default:
+		return 0, nil, nil, false
+	}
+	// GMS indexes do not use our operator functions, so they fail for comparisons between different types.
+	// As a workaround, we'll cast the value to the same type as the GetField.
+	// GMS only uses indexes when one of the two expressions is a GetField, so we can make use of that restriction here.
+	// We need to transition indexes to use our operator functions, which will require a complete overhaul of indexing.
+	if _, ok := left.(*expression.GetField); !ok {
+		left, right = right, left
+		op = op.Swap()
+	}
+	getField, ok := left.(*expression.GetField)
+	if !ok {
+		return 0, nil, nil, false
+	}
+	leftType, ok := getField.Type().(pgtypes.DoltgresType)
+	if !ok {
+		return 0, nil, nil, false
+	}
+	rightType, ok := right.Type().(pgtypes.DoltgresType)
+	if !ok {
+		return 0, nil, nil, false
+	}
+	if !leftType.Equals(rightType) {
+		right = pgexprs.NewExplicitCast(right, leftType)
+	}
+	return op, left, right, true
+}

--- a/server/analyzer/init.go
+++ b/server/analyzer/init.go
@@ -52,6 +52,9 @@ func Init() {
 	// The auto-commit rule writes the contents of the context, so we need to insert our finalizer before that
 	analyzer.OnceAfterAll = insertAnalyzerRules(analyzer.OnceAfterAll, analyzer.AutocommitId, true,
 		analyzer.Rule{Id: ruleId_InsertContextRootFinalizer, Apply: InsertContextRootFinalizer})
+
+	// Handle the function overrides
+	analyzer.IndexLeafChildren = IndexLeafChildren
 }
 
 // getAnalyzerRule returns the rule matching the given ID.

--- a/server/ast/expr.go
+++ b/server/ast/expr.go
@@ -234,7 +234,7 @@ func nodeExpr(node tree.Expr) (vitess.Expr, error) {
 
 		// If we have the resolved type, then we've got a Doltgres type instead of a GMS type
 		if resolvedType != nil {
-			cast, err := pgexprs.NewExplicitCast(resolvedType)
+			cast, err := pgexprs.NewExplicitCastInjectable(resolvedType)
 			if err != nil {
 				return nil, err
 			}

--- a/server/expression/binary_operator.go
+++ b/server/expression/binary_operator.go
@@ -114,6 +114,11 @@ func (b *BinaryOperator) WithResolvedChildren(children []any) (any, error) {
 	}, nil
 }
 
+// Operator returns the operator that is used.
+func (b *BinaryOperator) Operator() framework.Operator {
+	return b.operator
+}
+
 // Left implements the expression.BinaryExpression interface.
 func (b *BinaryOperator) Left() sql.Expression {
 	// We know that we'll always have two parameters here

--- a/server/expression/explicit_cast.go
+++ b/server/expression/explicit_cast.go
@@ -34,8 +34,8 @@ type ExplicitCast struct {
 var _ vitess.Injectable = (*ExplicitCast)(nil)
 var _ sql.Expression = (*ExplicitCast)(nil)
 
-// NewExplicitCast returns a new *ExplicitCast.
-func NewExplicitCast(castToType sql.Type) (*ExplicitCast, error) {
+// NewExplicitCastInjectable returns an incomplete *ExplicitCast that must be resolved through the vitess.Injectable interface.
+func NewExplicitCastInjectable(castToType sql.Type) (*ExplicitCast, error) {
 	pgtype, ok := castToType.(pgtypes.DoltgresType)
 	if !ok {
 		return nil, fmt.Errorf("cast expects a Doltgres type as the target type")
@@ -44,6 +44,14 @@ func NewExplicitCast(castToType sql.Type) (*ExplicitCast, error) {
 		sqlChild:   nil,
 		castToType: pgtype,
 	}, nil
+}
+
+// NewExplicitCast returns a new *ExplicitCast expression.
+func NewExplicitCast(expr sql.Expression, toType pgtypes.DoltgresType) *ExplicitCast {
+	return &ExplicitCast{
+		sqlChild:   expr,
+		castToType: toType,
+	}
 }
 
 // Children implements the sql.Expression interface.


### PR DESCRIPTION
Companion PR: https://github.com/dolthub/go-mysql-server/pull/2566
This enables partial index support for a constrained set of comparisons.