### PR TITLE
Fixed some index issues and IN comparisons

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/cockroachdb/apd/v2 v2.0.3-0.20200518165714-d020e156310a
 	github.com/cockroachdb/errors v1.7.5
-	github.com/dolthub/dolt/go v0.40.5-0.20240625223514-4c704c3daeca
+	github.com/dolthub/dolt/go v0.40.5-0.20240626110258-b40bfe8858ba
 	github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20240529071237-4a099b896ce8
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
 	github.com/dolthub/go-mysql-server v0.18.2-0.20240625212035-80f4e402d726

--- a/go.sum
+++ b/go.sum
@@ -214,8 +214,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/dolthub/dolt/go v0.40.5-0.20240625223514-4c704c3daeca h1:iaw0jiEb9QmF0wtrYyN0+xrYfZzjrtnNmKtNlumEVS0=
-github.com/dolthub/dolt/go v0.40.5-0.20240625223514-4c704c3daeca/go.mod h1:3AsoVPqO/ELL1eBO9wOZYdUy0Iy7kpJ4Y9t87UN8mlI=
+github.com/dolthub/dolt/go v0.40.5-0.20240626110258-b40bfe8858ba h1:SYLU0o0UHAjD3Q8+GsWZF4k/4jWS9iP9IITqSRMbsFI=
+github.com/dolthub/dolt/go v0.40.5-0.20240626110258-b40bfe8858ba/go.mod h1:3AsoVPqO/ELL1eBO9wOZYdUy0Iy7kpJ4Y9t87UN8mlI=
 github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20240529071237-4a099b896ce8 h1:izuogF6KRc6Pr5g5KevRtn8JK/KwyEGjbpqWJIORbQo=
 github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20240529071237-4a099b896ce8/go.mod h1:L5RDYZbC9BBWmoU2+TjTekeqqhFXX5EqH9ln00O0stY=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=

--- a/server/analyzer/type_sanitizer.go
+++ b/server/analyzer/type_sanitizer.go
@@ -55,11 +55,14 @@ func TypeSanitizer(ctx *sql.Context, a *analyzer.Analyzer, node sql.Node, scope 
 		case sql.FunctionExpression:
 			// Compiled functions are Doltgres functions. We're only concerned with GMS functions.
 			if _, ok := expr.(*framework.CompiledFunction); !ok {
-				// The COUNT functions cannot be wrapped due to expectations in the analyzer, so we exclude them here.
+				// Some aggregation functions cannot be wrapped due to expectations in the analyzer, so we exclude them here.
 				switch expr.FunctionName() {
-				case "Count", "CountDistinct", "GroupConcat", "JSONObjectAgg":
+				case "Count", "CountDistinct", "GroupConcat", "JSONObjectAgg", "Sum":
 				default:
-					return pgexprs.NewGMSCast(expr), transform.NewTree, nil
+					// Some GMS functions wrap Doltgres parameters, so we'll only handle those that return GMS types
+					if _, ok := expr.Type().(pgtypes.DoltgresType); !ok {
+						return pgexprs.NewGMSCast(expr), transform.NewTree, nil
+					}
 				}
 			}
 		case *sql.ColumnDefaultValue:

--- a/testing/go/smoke_test.go
+++ b/testing/go/smoke_test.go
@@ -545,6 +545,63 @@ func TestSmokeTests(t *testing.T) {
 			},
 		},
 		{
+			Name: "IN",
+			SetUpScript: []string{
+				"CREATE TABLE test(v1 INT4, v2 INT4);",
+				"INSERT INTO test VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5);",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT * FROM test WHERE v1 IN (2, '3', 4) ORDER BY v1;",
+					Expected: []sql.Row{
+						{2, 2},
+						{3, 3},
+						{4, 4},
+					},
+				},
+				{
+					Query:    "CREATE INDEX v2_idx ON test(v2);",
+					Skip:     true,
+					Expected: []sql.Row{},
+				},
+				{
+					Query: "SELECT * FROM test WHERE v2 IN (2, '3', 4) ORDER BY v1;",
+					Skip:  true,
+					Expected: []sql.Row{
+						{2, 2},
+						{3, 3},
+						{4, 4},
+					},
+				},
+			},
+		},
+		{
+			Name: "SUM",
+			SetUpScript: []string{
+				"CREATE TABLE test(pk SERIAL PRIMARY KEY, v1 INT4);",
+				"INSERT INTO test (v1) VALUES (1), (2), (3), (4), (5);",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT SUM(v1) FROM test WHERE v1 BETWEEN 3 AND 5;",
+					Expected: []sql.Row{
+						{12.0},
+					},
+				},
+				{
+					Query:    "CREATE INDEX v1_idx ON test(v1);",
+					Expected: []sql.Row{},
+				},
+				{
+					Query: "SELECT SUM(v1) FROM test WHERE v1 BETWEEN 3 AND 5;",
+					Skip:  true,
+					Expected: []sql.Row{
+						{12.0},
+					},
+				},
+			},
+		},
+		{
 			Name: "Empty statement",
 			Assertions: []ScriptTestAssertion{
 				{


### PR DESCRIPTION
Companion PR: https://github.com/dolthub/dolt/pull/8073
Created indexes in Doltgres were not actually added to the table, which was fixed in the above PR. In addition, `IN` was corrected to use comparison functions (`IN` predates their creation) and `SUM` was excluded from the list of cast functions since GMS does not search children when looking for certain aggregate functions.

In addition, `IN` was overhauled so that comparison functions are resolved once. More details may be found in the accompanying comments.