### PR TITLE
Fixed secondary indexing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/cockroachdb/apd/v2 v2.0.3-0.20200518165714-d020e156310a
 	github.com/cockroachdb/errors v1.7.5
-	github.com/dolthub/dolt/go v0.40.5-0.20240626185946-7aef8fcde146
+	github.com/dolthub/dolt/go v0.40.5-0.20240627102126-e14c64baf663
 	github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20240529071237-4a099b896ce8
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
 	github.com/dolthub/go-mysql-server v0.18.2-0.20240626180128-807a2e35937f

--- a/go.sum
+++ b/go.sum
@@ -214,8 +214,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/dolthub/dolt/go v0.40.5-0.20240626185946-7aef8fcde146 h1:PoVHlUEWWnkS7VlyVnryfumvFyHJnmwojCNOQ17QbnM=
-github.com/dolthub/dolt/go v0.40.5-0.20240626185946-7aef8fcde146/go.mod h1:t9SrujEmNlUnQ/fPjpXfGUoQ4CQMkjIuASq5GT6bUnw=
+github.com/dolthub/dolt/go v0.40.5-0.20240627102126-e14c64baf663 h1:yKRm2Hj8MkfttgxRnyGjmSMqDaBAv2Oznmzn4bmJwB8=
+github.com/dolthub/dolt/go v0.40.5-0.20240627102126-e14c64baf663/go.mod h1:t9SrujEmNlUnQ/fPjpXfGUoQ4CQMkjIuASq5GT6bUnw=
 github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20240529071237-4a099b896ce8 h1:izuogF6KRc6Pr5g5KevRtn8JK/KwyEGjbpqWJIORbQo=
 github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20240529071237-4a099b896ce8/go.mod h1:L5RDYZbC9BBWmoU2+TjTekeqqhFXX5EqH9ln00O0stY=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=

--- a/testing/go/smoke_test.go
+++ b/testing/go/smoke_test.go
@@ -561,12 +561,10 @@ func TestSmokeTests(t *testing.T) {
 				},
 				{
 					Query:    "CREATE INDEX v2_idx ON test(v2);",
-					Skip:     true,
 					Expected: []sql.Row{},
 				},
 				{
 					Query: "SELECT * FROM test WHERE v2 IN (2, '3', 4) ORDER BY v1;",
-					Skip:  true,
 					Expected: []sql.Row{
 						{2, 2},
 						{3, 3},
@@ -594,7 +592,6 @@ func TestSmokeTests(t *testing.T) {
 				},
 				{
 					Query: "SELECT SUM(v1) FROM test WHERE v1 BETWEEN 3 AND 5;",
-					Skip:  true,
 					Expected: []sql.Row{
 						{12.0},
 					},


### PR DESCRIPTION
* Companion PR: https://github.com/dolthub/dolt/pull/8081

The companion PR fixes two issues regarding the creation of the secondary index map, which resulted in the now-unskipped tests either panicking or returning incorrect results. With the merger of the aforementioned PR, both of these issues will be fixed.