### PR TITLE
Added function support for polymorphic types

### DIFF
--- a/server/functions/abs.go
+++ b/server/functions/abs.go
@@ -36,53 +36,53 @@ func initAbs() {
 var abs_int16 = framework.Function1{
 	Name:       "abs",
 	Return:     pgtypes.Int16,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return utils.Abs(val1.(int16)), nil
 	},
-	Strict: true,
 }
 
 // abs_int32 represents the PostgreSQL function of the same name, taking the same parameters.
 var abs_int32 = framework.Function1{
 	Name:       "abs",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return utils.Abs(val1.(int32)), nil
 	},
-	Strict: true,
 }
 
 // abs_int64 represents the PostgreSQL function of the same name, taking the same parameters.
 var abs_int64 = framework.Function1{
 	Name:       "abs",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return utils.Abs(val1.(int64)), nil
 	},
-	Strict: true,
 }
 
 // abs_float64 represents the PostgreSQL function of the same name, taking the same parameters.
 var abs_float64 = framework.Function1{
 	Name:       "abs",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return utils.Abs(val1.(float64)), nil
 	},
-	Strict: true,
 }
 
 // abs_numeric represents the PostgreSQL function of the same name, taking the same parameters.
 var abs_numeric = framework.Function1{
 	Name:       "abs",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return val1.(decimal.Decimal).Abs(), nil
 	},
-	Strict: true,
 }

--- a/server/functions/acos.go
+++ b/server/functions/acos.go
@@ -33,13 +33,13 @@ func initAcos() {
 var acos_float64 = framework.Function1{
 	Name:       "acos",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Acos(val1.(float64))
 		if math.IsNaN(r) {
 			return nil, fmt.Errorf("input is out of range")
 		}
 		return r, nil
 	},
-	Strict: true,
 }

--- a/server/functions/acosd.go
+++ b/server/functions/acosd.go
@@ -33,13 +33,13 @@ func initAcosd() {
 var acosd_float64 = framework.Function1{
 	Name:       "acosd",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Acos(val1.(float64))
 		if math.IsNaN(r) {
 			return nil, fmt.Errorf("input is out of range")
 		}
 		return toDegrees(r), nil
 	},
-	Strict: true,
 }

--- a/server/functions/acosh.go
+++ b/server/functions/acosh.go
@@ -33,13 +33,13 @@ func initAcosh() {
 var acosh_float64 = framework.Function1{
 	Name:       "acosh",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Acosh(val1.(float64))
 		if math.IsNaN(r) {
 			return nil, fmt.Errorf("input is out of range")
 		}
 		return r, nil
 	},
-	Strict: true,
 }

--- a/server/functions/array_append.go
+++ b/server/functions/array_append.go
@@ -21,22 +21,22 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// initReverse registers the functions to the catalog.
-func initReverse() {
-	framework.RegisterFunction(reverse_varchar)
+// initArrayAppend registers the functions to the catalog.
+func initArrayAppend() {
+	framework.RegisterFunction(array_append_anyarray_anyelement)
 }
 
-// reverse_varchar represents the PostgreSQL function of the same name, taking the same parameters.
-var reverse_varchar = framework.Function1{
-	Name:       "reverse",
-	Return:     pgtypes.VarChar,
-	Parameters: [1]pgtypes.DoltgresType{pgtypes.VarChar},
+// array_append_anyarray_anyelement represents the PostgreSQL function of the same name, taking the same parameters.
+var array_append_anyarray_anyelement = framework.Function2{
+	Name:       "array_append",
+	Return:     pgtypes.AnyArray,
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.AnyArray, pgtypes.AnyElement},
 	Strict:     true,
-	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
-		runes := []rune(val1.(string))
-		for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
-			runes[i], runes[j] = runes[j], runes[i]
-		}
-		return string(runes), nil
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
+		array := val1.([]any)
+		returnArray := make([]any, len(array)+1)
+		copy(returnArray, array)
+		returnArray[len(returnArray)-1] = val2
+		return returnArray, nil
 	},
 }

--- a/server/functions/ascii.go
+++ b/server/functions/ascii.go
@@ -30,8 +30,9 @@ func initAscii() {
 var ascii_varchar = framework.Function1{
 	Name:       "ascii",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, val1Interface any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1Interface any) (any, error) {
 		val1 := val1Interface.(string)
 		if len(val1) == 0 {
 			return int32(0), nil
@@ -39,5 +40,4 @@ var ascii_varchar = framework.Function1{
 		runes := []rune(val1)
 		return int32(runes[0]), nil
 	},
-	Strict: true,
 }

--- a/server/functions/asin.go
+++ b/server/functions/asin.go
@@ -33,13 +33,13 @@ func initAsin() {
 var asin_float64 = framework.Function1{
 	Name:       "asin",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Asin(val1.(float64))
 		if math.IsNaN(r) {
 			return nil, fmt.Errorf("input is out of range")
 		}
 		return r, nil
 	},
-	Strict: true,
 }

--- a/server/functions/asind.go
+++ b/server/functions/asind.go
@@ -33,13 +33,13 @@ func initAsind() {
 var asind_float64 = framework.Function1{
 	Name:       "asind",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Asin(val1.(float64))
 		if math.IsNaN(r) {
 			return nil, fmt.Errorf("input is out of range")
 		}
 		return toDegrees(r), nil
 	},
-	Strict: true,
 }

--- a/server/functions/asinh.go
+++ b/server/functions/asinh.go
@@ -33,13 +33,13 @@ func initAsinh() {
 var asinh_float64 = framework.Function1{
 	Name:       "asinh",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Asinh(val1.(float64))
 		if math.IsNaN(r) {
 			return nil, fmt.Errorf("input is out of range")
 		}
 		return r, nil
 	},
-	Strict: true,
 }

--- a/server/functions/atan.go
+++ b/server/functions/atan.go
@@ -33,13 +33,13 @@ func initAtan() {
 var atan_float64 = framework.Function1{
 	Name:       "atan",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Atan(val1.(float64))
 		if math.IsNaN(r) {
 			return nil, fmt.Errorf("input is out of range")
 		}
 		return r, nil
 	},
-	Strict: true,
 }

--- a/server/functions/atan2.go
+++ b/server/functions/atan2.go
@@ -33,13 +33,13 @@ func initAtan2() {
 var atan2_float64 = framework.Function2{
 	Name:       "atan2",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, y any, x any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, y any, x any) (any, error) {
 		r := math.Atan2(y.(float64), x.(float64))
 		if math.IsNaN(r) {
 			return nil, fmt.Errorf("input is out of range")
 		}
 		return r, nil
 	},
-	Strict: true,
 }

--- a/server/functions/atan2d.go
+++ b/server/functions/atan2d.go
@@ -33,13 +33,13 @@ func initAtan2d() {
 var atan2d_float64 = framework.Function2{
 	Name:       "atan2d",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, y any, x any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, y any, x any) (any, error) {
 		r := math.Atan2(y.(float64), x.(float64))
 		if math.IsNaN(r) {
 			return nil, fmt.Errorf("input is out of range")
 		}
 		return toDegrees(r), nil
 	},
-	Strict: true,
 }

--- a/server/functions/atand.go
+++ b/server/functions/atand.go
@@ -33,13 +33,13 @@ func initAtand() {
 var atand_float64 = framework.Function1{
 	Name:       "atand",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Atan(val1.(float64))
 		if math.IsNaN(r) {
 			return nil, fmt.Errorf("input is out of range")
 		}
 		return toDegrees(r), nil
 	},
-	Strict: true,
 }

--- a/server/functions/atanh.go
+++ b/server/functions/atanh.go
@@ -33,13 +33,13 @@ func initAtanh() {
 var atanh_float64 = framework.Function1{
 	Name:       "atanh",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Atanh(val1.(float64))
 		if math.IsNaN(r) {
 			return nil, fmt.Errorf("input is out of range")
 		}
 		return r, nil
 	},
-	Strict: true,
 }

--- a/server/functions/binary/bit_and.go
+++ b/server/functions/binary/bit_and.go
@@ -35,31 +35,31 @@ func initBinaryBitAnd() {
 var int2and = framework.Function2{
 	Name:       "int2and",
 	Return:     pgtypes.Int16,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return int16(val1.(int16) & val2.(int16)), nil
 	},
-	Strict: true,
 }
 
 // int4and represents the PostgreSQL function of the same name, taking the same parameters.
 var int4and = framework.Function2{
 	Name:       "int4and",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return int32(val1.(int32) & val2.(int32)), nil
 	},
-	Strict: true,
 }
 
 // int8and represents the PostgreSQL function of the same name, taking the same parameters.
 var int8and = framework.Function2{
 	Name:       "int8and",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return int64(val1.(int64) & val2.(int64)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/binary/bit_or.go
+++ b/server/functions/binary/bit_or.go
@@ -35,31 +35,31 @@ func initBinaryBitOr() {
 var int2or = framework.Function2{
 	Name:       "int2or",
 	Return:     pgtypes.Int16,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return int16(val1.(int16) | val2.(int16)), nil
 	},
-	Strict: true,
 }
 
 // int4or represents the PostgreSQL function of the same name, taking the same parameters.
 var int4or = framework.Function2{
 	Name:       "int4or",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return int32(val1.(int32) | val2.(int32)), nil
 	},
-	Strict: true,
 }
 
 // int8or represents the PostgreSQL function of the same name, taking the same parameters.
 var int8or = framework.Function2{
 	Name:       "int8or",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return int64(val1.(int64) | val2.(int64)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/binary/bit_xor.go
+++ b/server/functions/binary/bit_xor.go
@@ -35,31 +35,31 @@ func initBinaryBitXor() {
 var int2xor = framework.Function2{
 	Name:       "int2xor",
 	Return:     pgtypes.Int16,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return int16(val1.(int16) ^ val2.(int16)), nil
 	},
-	Strict: true,
 }
 
 // int4xor represents the PostgreSQL function of the same name, taking the same parameters.
 var int4xor = framework.Function2{
 	Name:       "int4xor",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return int32(val1.(int32) ^ val2.(int32)), nil
 	},
-	Strict: true,
 }
 
 // int8xor represents the PostgreSQL function of the same name, taking the same parameters.
 var int8xor = framework.Function2{
 	Name:       "int8xor",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return int64(val1.(int64) ^ val2.(int64)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/binary/divide.go
+++ b/server/functions/binary/divide.go
@@ -49,194 +49,194 @@ func initBinaryDivide() {
 var float4div = framework.Function2{
 	Name:       "float4div",
 	Return:     pgtypes.Float32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(float32) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(float32) / val2.(float32), nil
 	},
-	Strict: true,
 }
 
 // float48div represents the PostgreSQL function of the same name, taking the same parameters.
 var float48div = framework.Function2{
 	Name:       "float48div",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(float64) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return float64(val1.(float32)) / val2.(float64), nil
 	},
-	Strict: true,
 }
 
 // float8div represents the PostgreSQL function of the same name, taking the same parameters.
 var float8div = framework.Function2{
 	Name:       "float8div",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(float64) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(float64) / val2.(float64), nil
 	},
-	Strict: true,
 }
 
 // float84div represents the PostgreSQL function of the same name, taking the same parameters.
 var float84div = framework.Function2{
 	Name:       "float84div",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(float32) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(float64) / float64(val2.(float32)), nil
 	},
-	Strict: true,
 }
 
 // int2div represents the PostgreSQL function of the same name, taking the same parameters.
 var int2div = framework.Function2{
 	Name:       "int2div",
 	Return:     pgtypes.Int16,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int16) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(int16) / val2.(int16), nil
 	},
-	Strict: true,
 }
 
 // int24div represents the PostgreSQL function of the same name, taking the same parameters.
 var int24div = framework.Function2{
 	Name:       "int24div",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int32) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return int32(val1.(int16)) / val2.(int32), nil
 	},
-	Strict: true,
 }
 
 // int28div represents the PostgreSQL function of the same name, taking the same parameters.
 var int28div = framework.Function2{
 	Name:       "int28div",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int64) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return int64(val1.(int16)) / val2.(int64), nil
 	},
-	Strict: true,
 }
 
 // int4div represents the PostgreSQL function of the same name, taking the same parameters.
 var int4div = framework.Function2{
 	Name:       "int4div",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int32) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(int32) / val2.(int32), nil
 	},
-	Strict: true,
 }
 
 // int42div represents the PostgreSQL function of the same name, taking the same parameters.
 var int42div = framework.Function2{
 	Name:       "int42div",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int16) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(int32) / int32(val2.(int16)), nil
 	},
-	Strict: true,
 }
 
 // int48div represents the PostgreSQL function of the same name, taking the same parameters.
 var int48div = framework.Function2{
 	Name:       "int48div",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int64) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return int64(val1.(int32)) / val2.(int64), nil
 	},
-	Strict: true,
 }
 
 // int8div represents the PostgreSQL function of the same name, taking the same parameters.
 var int8div = framework.Function2{
 	Name:       "int8div",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int64) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(int64) / val2.(int64), nil
 	},
-	Strict: true,
 }
 
 // int82div represents the PostgreSQL function of the same name, taking the same parameters.
 var int82div = framework.Function2{
 	Name:       "int82div",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int16) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(int64) / int64(val2.(int16)), nil
 	},
-	Strict: true,
 }
 
 // int84div represents the PostgreSQL function of the same name, taking the same parameters.
 var int84div = framework.Function2{
 	Name:       "int84div",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int32) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(int64) / int64(val2.(int32)), nil
 	},
-	Strict: true,
 }
 
 // numeric_div represents the PostgreSQL function of the same name, taking the same parameters.
 var numeric_div = framework.Function2{
 	Name:       "numeric_div",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(decimal.Decimal).Equal(decimal.Zero) {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(decimal.Decimal).Div(val2.(decimal.Decimal)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/binary/equal.go
+++ b/server/functions/binary/equal.go
@@ -73,443 +73,443 @@ func initBinaryEqual() {
 var booleq = framework.Function2{
 	Name:       "booleq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Bool, pgtypes.Bool},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Bool, pgtypes.Bool},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Bool.Compare(val1.(bool), val2.(bool))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // bpchareq represents the PostgreSQL function of the same name, taking the same parameters.
 var bpchareq = framework.Function2{
 	Name:       "bpchareq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.BpChar.Compare(val1.(string), val2.(string))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // byteaeq represents the PostgreSQL function of the same name, taking the same parameters.
 var byteaeq = framework.Function2{
 	Name:       "byteaeq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Bytea, pgtypes.Bytea},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Bytea, pgtypes.Bytea},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Bytea.Compare(val1.([]byte), val2.([]byte))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // date_eq represents the PostgreSQL function of the same name, taking the same parameters.
 var date_eq = framework.Function2{
 	Name:       "date_eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Date.Compare(val1.(time.Time), val2.(time.Time))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // date_eq_timestamp represents the PostgreSQL function of the same name, taking the same parameters.
 var date_eq_timestamp = framework.Function2{
 	Name:       "date_eq_timestamp",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res == 0, nil
 	},
-	Strict: true,
 }
 
 // date_eq_timestamptz represents the PostgreSQL function of the same name, taking the same parameters.
 var date_eq_timestamptz = framework.Function2{
 	Name:       "date_eq_timestamptz",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res == 0, nil
 	},
-	Strict: true,
 }
 
 // float4eq represents the PostgreSQL function of the same name, taking the same parameters.
 var float4eq = framework.Function2{
 	Name:       "float4eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float32.Compare(val1.(float32), val2.(float32))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // float48eq represents the PostgreSQL function of the same name, taking the same parameters.
 var float48eq = framework.Function2{
 	Name:       "float48eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(float64(val1.(float32)), val2.(float64))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // float84eq represents the PostgreSQL function of the same name, taking the same parameters.
 var float84eq = framework.Function2{
 	Name:       "float84eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(val1.(float64), float64(val2.(float32)))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // float8eq represents the PostgreSQL function of the same name, taking the same parameters.
 var float8eq = framework.Function2{
 	Name:       "float8eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(val1.(float64), val2.(float64))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // int2eq represents the PostgreSQL function of the same name, taking the same parameters.
 var int2eq = framework.Function2{
 	Name:       "int2eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int16.Compare(val1.(int16), val2.(int16))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // int24eq represents the PostgreSQL function of the same name, taking the same parameters.
 var int24eq = framework.Function2{
 	Name:       "int24eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(int32(val1.(int16)), val2.(int32))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // int28eq represents the PostgreSQL function of the same name, taking the same parameters.
 var int28eq = framework.Function2{
 	Name:       "int28eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(int64(val1.(int16)), val2.(int64))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // int42eq represents the PostgreSQL function of the same name, taking the same parameters.
 var int42eq = framework.Function2{
 	Name:       "int42eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(val1.(int32), int32(val2.(int16)))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // int4eq represents the PostgreSQL function of the same name, taking the same parameters.
 var int4eq = framework.Function2{
 	Name:       "int4eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(val1.(int32), val2.(int32))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // int48eq represents the PostgreSQL function of the same name, taking the same parameters.
 var int48eq = framework.Function2{
 	Name:       "int48eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(int64(val1.(int32)), val2.(int64))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // int82eq represents the PostgreSQL function of the same name, taking the same parameters.
 var int82eq = framework.Function2{
 	Name:       "int82eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), int64(val2.(int16)))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // int84eq represents the PostgreSQL function of the same name, taking the same parameters.
 var int84eq = framework.Function2{
 	Name:       "int84eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), int64(val2.(int32)))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // int8eq represents the PostgreSQL function of the same name, taking the same parameters.
 var int8eq = framework.Function2{
 	Name:       "int8eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), val2.(int64))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // jsonb_eq represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_eq = framework.Function2{
 	Name:       "jsonb_eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.JsonB.Compare(val1.(pgtypes.JsonDocument), val2.(pgtypes.JsonDocument))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // nameeq represents the PostgreSQL function of the same name, taking the same parameters.
 var nameeq = framework.Function2{
 	Name:       "nameeq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Name.Compare(val1.(string), val2.(string))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // nameeqtext represents the PostgreSQL function of the same name, taking the same parameters.
 var nameeqtext = framework.Function2{
 	Name:       "nameeqtext",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // numeric_eq represents the PostgreSQL function of the same name, taking the same parameters.
 var numeric_eq = framework.Function2{
 	Name:       "numeric_eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Numeric.Compare(val1.(decimal.Decimal), val2.(decimal.Decimal))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // oideq represents the PostgreSQL function of the same name, taking the same parameters.
 var oideq = framework.Function2{
 	Name:       "oideq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Oid, pgtypes.Oid},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Oid, pgtypes.Oid},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Oid.Compare(val1.(uint32), val2.(uint32))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // texteqname represents the PostgreSQL function of the same name, taking the same parameters.
 var texteqname = framework.Function2{
 	Name:       "texteqname",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // text_eq represents the PostgreSQL function of the same name, taking the same parameters.
 var text_eq = framework.Function2{
 	Name:       "text_eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // time_eq represents the PostgreSQL function of the same name, taking the same parameters.
 var time_eq = framework.Function2{
 	Name:       "time_eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Time.Compare(val1.(time.Time), val2.(time.Time))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // timestamp_eq_date represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_eq_date = framework.Function2{
 	Name:       "timestamp_eq_date",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res == 0, nil
 	},
-	Strict: true,
 }
 
 // timestamp_eq represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_eq = framework.Function2{
 	Name:       "timestamp_eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Timestamp.Compare(val1.(time.Time), val2.(time.Time))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // timestamp_eq_timestamptz represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_eq_timestamptz = framework.Function2{
 	Name:       "timestamp_eq_timestamptz",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // timestamptz_eq_date represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_eq_date = framework.Function2{
 	Name:       "timestamptz_eq_date",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res == 0, nil
 	},
-	Strict: true,
 }
 
 // timestamptz_eq_timestamp represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_eq_timestamp = framework.Function2{
 	Name:       "timestamptz_eq_timestamp",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // timestamptz_eq represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_eq = framework.Function2{
 	Name:       "timestamptz_eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // timetz_eq represents the PostgreSQL function of the same name, taking the same parameters.
 var timetz_eq = framework.Function2{
 	Name:       "timetz_eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimeTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // uuid_eq represents the PostgreSQL function of the same name, taking the same parameters.
 var uuid_eq = framework.Function2{
 	Name:       "uuid_eq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Uuid, pgtypes.Uuid},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Uuid, pgtypes.Uuid},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Uuid.Compare(val1.(uuid.UUID), val2.(uuid.UUID))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // xideqint4 represents the PostgreSQL function of the same name, taking the same parameters.
 var xideqint4 = framework.Function2{
 	Name:       "xideqint4",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Xid, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Xid, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		// TODO: investigate the edge cases
 		res, err := pgtypes.Int64.Compare(int64(val1.(uint32)), int64(val2.(int32)))
 		return res == 0, err
 	},
-	Strict: true,
 }
 
 // xideq represents the PostgreSQL function of the same name, taking the same parameters.
 var xideq = framework.Function2{
 	Name:       "xideq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Xid, pgtypes.Xid},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Xid, pgtypes.Xid},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Xid.Compare(val1.(uint32), val2.(uint32))
 		return res == 0, err
 	},
-	Strict: true,
 }

--- a/server/functions/binary/greater.go
+++ b/server/functions/binary/greater.go
@@ -71,418 +71,418 @@ func initBinaryGreaterThan() {
 var boolgt = framework.Function2{
 	Name:       "boolgt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Bool, pgtypes.Bool},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Bool, pgtypes.Bool},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Bool.Compare(val1.(bool), val2.(bool))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // bpchargt represents the PostgreSQL function of the same name, taking the same parameters.
 var bpchargt = framework.Function2{
 	Name:       "bpchargt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.BpChar.Compare(val1.(string), val2.(string))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // byteagt represents the PostgreSQL function of the same name, taking the same parameters.
 var byteagt = framework.Function2{
 	Name:       "byteagt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Bytea, pgtypes.Bytea},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Bytea, pgtypes.Bytea},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Bytea.Compare(val1.([]byte), val2.([]byte))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // date_gt represents the PostgreSQL function of the same name, taking the same parameters.
 var date_gt = framework.Function2{
 	Name:       "date_gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Date.Compare(val1.(time.Time), val2.(time.Time))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // date_gt_timestamp represents the PostgreSQL function of the same name, taking the same parameters.
 var date_gt_timestamp = framework.Function2{
 	Name:       "date_gt_timestamp",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res == 1, nil
 	},
-	Strict: true,
 }
 
 // date_gt_timestamptz represents the PostgreSQL function of the same name, taking the same parameters.
 var date_gt_timestamptz = framework.Function2{
 	Name:       "date_gt_timestamptz",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res == 1, nil
 	},
-	Strict: true,
 }
 
 // float4gt represents the PostgreSQL function of the same name, taking the same parameters.
 var float4gt = framework.Function2{
 	Name:       "float4gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float32.Compare(val1.(float32), val2.(float32))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // float48gt represents the PostgreSQL function of the same name, taking the same parameters.
 var float48gt = framework.Function2{
 	Name:       "float48gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(float64(val1.(float32)), val2.(float64))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // float84gt represents the PostgreSQL function of the same name, taking the same parameters.
 var float84gt = framework.Function2{
 	Name:       "float84gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(val1.(float64), float64(val2.(float32)))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // float8gt represents the PostgreSQL function of the same name, taking the same parameters.
 var float8gt = framework.Function2{
 	Name:       "float8gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(val1.(float64), val2.(float64))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // int2gt represents the PostgreSQL function of the same name, taking the same parameters.
 var int2gt = framework.Function2{
 	Name:       "int2gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int16.Compare(val1.(int16), val2.(int16))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // int24gt represents the PostgreSQL function of the same name, taking the same parameters.
 var int24gt = framework.Function2{
 	Name:       "int24gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(int32(val1.(int16)), val2.(int32))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // int28gt represents the PostgreSQL function of the same name, taking the same parameters.
 var int28gt = framework.Function2{
 	Name:       "int28gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(int64(val1.(int16)), val2.(int64))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // int42gt represents the PostgreSQL function of the same name, taking the same parameters.
 var int42gt = framework.Function2{
 	Name:       "int42gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(val1.(int32), int32(val2.(int16)))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // int4gt represents the PostgreSQL function of the same name, taking the same parameters.
 var int4gt = framework.Function2{
 	Name:       "int4gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(val1.(int32), val2.(int32))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // int48gt represents the PostgreSQL function of the same name, taking the same parameters.
 var int48gt = framework.Function2{
 	Name:       "int48gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(int64(val1.(int32)), val2.(int64))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // int82gt represents the PostgreSQL function of the same name, taking the same parameters.
 var int82gt = framework.Function2{
 	Name:       "int82gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), int64(val2.(int16)))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // int84gt represents the PostgreSQL function of the same name, taking the same parameters.
 var int84gt = framework.Function2{
 	Name:       "int84gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), int64(val2.(int32)))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // int8gt represents the PostgreSQL function of the same name, taking the same parameters.
 var int8gt = framework.Function2{
 	Name:       "int8gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), val2.(int64))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // jsonb_gt represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_gt = framework.Function2{
 	Name:       "jsonb_gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.JsonB.Compare(val1.(pgtypes.JsonDocument), val2.(pgtypes.JsonDocument))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // namegt represents the PostgreSQL function of the same name, taking the same parameters.
 var namegt = framework.Function2{
 	Name:       "namegt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Name.Compare(val1.(string), val2.(string))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // namegttext represents the PostgreSQL function of the same name, taking the same parameters.
 var namegttext = framework.Function2{
 	Name:       "namegttext",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // numeric_gt represents the PostgreSQL function of the same name, taking the same parameters.
 var numeric_gt = framework.Function2{
 	Name:       "numeric_gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Numeric.Compare(val1.(decimal.Decimal), val2.(decimal.Decimal))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // oidgt represents the PostgreSQL function of the same name, taking the same parameters.
 var oidgt = framework.Function2{
 	Name:       "oidgt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Oid, pgtypes.Oid},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Oid, pgtypes.Oid},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Oid.Compare(val1.(uint32), val2.(uint32))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // textgtname represents the PostgreSQL function of the same name, taking the same parameters.
 var textgtname = framework.Function2{
 	Name:       "textgtname",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // text_gt represents the PostgreSQL function of the same name, taking the same parameters.
 var text_gt = framework.Function2{
 	Name:       "text_gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // time_gt represents the PostgreSQL function of the same name, taking the same parameters.
 var time_gt = framework.Function2{
 	Name:       "time_gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Time.Compare(val1.(time.Time), val2.(time.Time))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // timestamp_gt_date represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_gt_date = framework.Function2{
 	Name:       "timestamp_gt_date",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res == 1, nil
 	},
-	Strict: true,
 }
 
 // timestamp_gt represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_gt = framework.Function2{
 	Name:       "timestamp_gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Timestamp.Compare(val1.(time.Time), val2.(time.Time))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // timestamp_gt_timestamptz represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_gt_timestamptz = framework.Function2{
 	Name:       "timestamp_gt_timestamptz",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // timestamptz_gt_date represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_gt_date = framework.Function2{
 	Name:       "timestamptz_gt_date",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res == 1, nil
 	},
-	Strict: true,
 }
 
 // timestamptz_gt_timestamp represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_gt_timestamp = framework.Function2{
 	Name:       "timestamptz_gt_timestamp",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // timestamptz_gt represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_gt = framework.Function2{
 	Name:       "timestamptz_gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // timetz_gt represents the PostgreSQL function of the same name, taking the same parameters.
 var timetz_gt = framework.Function2{
 	Name:       "timetz_gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimeTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res == 1, err
 	},
-	Strict: true,
 }
 
 // uuid_gt represents the PostgreSQL function of the same name, taking the same parameters.
 var uuid_gt = framework.Function2{
 	Name:       "uuid_gt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Uuid, pgtypes.Uuid},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Uuid, pgtypes.Uuid},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Uuid.Compare(val1.(uuid.UUID), val2.(uuid.UUID))
 		return res == 1, err
 	},
-	Strict: true,
 }

--- a/server/functions/binary/greater_equal.go
+++ b/server/functions/binary/greater_equal.go
@@ -71,418 +71,418 @@ func initBinaryGreaterOrEqual() {
 var boolge = framework.Function2{
 	Name:       "boolge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Bool, pgtypes.Bool},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Bool, pgtypes.Bool},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Bool.Compare(val1.(bool), val2.(bool))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // bpcharge represents the PostgreSQL function of the same name, taking the same parameters.
 var bpcharge = framework.Function2{
 	Name:       "bpcharge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.BpChar.Compare(val1.(string), val2.(string))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // byteage represents the PostgreSQL function of the same name, taking the same parameters.
 var byteage = framework.Function2{
 	Name:       "byteage",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Bytea, pgtypes.Bytea},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Bytea, pgtypes.Bytea},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Bytea.Compare(val1.([]byte), val2.([]byte))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // date_ge represents the PostgreSQL function of the same name, taking the same parameters.
 var date_ge = framework.Function2{
 	Name:       "date_ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Date.Compare(val1.(time.Time), val2.(time.Time))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // date_ge_timestamp represents the PostgreSQL function of the same name, taking the same parameters.
 var date_ge_timestamp = framework.Function2{
 	Name:       "date_ge_timestamp",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res >= 0, nil
 	},
-	Strict: true,
 }
 
 // date_ge_timestamptz represents the PostgreSQL function of the same name, taking the same parameters.
 var date_ge_timestamptz = framework.Function2{
 	Name:       "date_ge_timestamptz",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res >= 0, nil
 	},
-	Strict: true,
 }
 
 // float4ge represents the PostgreSQL function of the same name, taking the same parameters.
 var float4ge = framework.Function2{
 	Name:       "float4ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float32.Compare(val1.(float32), val2.(float32))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // float48ge represents the PostgreSQL function of the same name, taking the same parameters.
 var float48ge = framework.Function2{
 	Name:       "float48ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(float64(val1.(float32)), val2.(float64))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // float84ge represents the PostgreSQL function of the same name, taking the same parameters.
 var float84ge = framework.Function2{
 	Name:       "float84ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(val1.(float64), float64(val2.(float32)))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // float8ge represents the PostgreSQL function of the same name, taking the same parameters.
 var float8ge = framework.Function2{
 	Name:       "float8ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(val1.(float64), val2.(float64))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // int2ge represents the PostgreSQL function of the same name, taking the same parameters.
 var int2ge = framework.Function2{
 	Name:       "int2ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int16.Compare(val1.(int16), val2.(int16))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // int24ge represents the PostgreSQL function of the same name, taking the same parameters.
 var int24ge = framework.Function2{
 	Name:       "int24ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(int32(val1.(int16)), val2.(int32))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // int28ge represents the PostgreSQL function of the same name, taking the same parameters.
 var int28ge = framework.Function2{
 	Name:       "int28ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(int64(val1.(int16)), val2.(int64))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // int42ge represents the PostgreSQL function of the same name, taking the same parameters.
 var int42ge = framework.Function2{
 	Name:       "int42ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(val1.(int32), int32(val2.(int16)))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // int4ge represents the PostgreSQL function of the same name, taking the same parameters.
 var int4ge = framework.Function2{
 	Name:       "int4ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(val1.(int32), val2.(int32))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // int48ge represents the PostgreSQL function of the same name, taking the same parameters.
 var int48ge = framework.Function2{
 	Name:       "int48ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(int64(val1.(int32)), val2.(int64))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // int82ge represents the PostgreSQL function of the same name, taking the same parameters.
 var int82ge = framework.Function2{
 	Name:       "int82ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), int64(val2.(int16)))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // int84ge represents the PostgreSQL function of the same name, taking the same parameters.
 var int84ge = framework.Function2{
 	Name:       "int84ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), int64(val2.(int32)))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // int8ge represents the PostgreSQL function of the same name, taking the same parameters.
 var int8ge = framework.Function2{
 	Name:       "int8ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), val2.(int64))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // jsonb_ge represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_ge = framework.Function2{
 	Name:       "jsonb_ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.JsonB.Compare(val1.(pgtypes.JsonDocument), val2.(pgtypes.JsonDocument))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // namege represents the PostgreSQL function of the same name, taking the same parameters.
 var namege = framework.Function2{
 	Name:       "namege",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Name.Compare(val1.(string), val2.(string))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // namegetext represents the PostgreSQL function of the same name, taking the same parameters.
 var namegetext = framework.Function2{
 	Name:       "namegetext",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // numeric_ge represents the PostgreSQL function of the same name, taking the same parameters.
 var numeric_ge = framework.Function2{
 	Name:       "numeric_ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Numeric.Compare(val1.(decimal.Decimal), val2.(decimal.Decimal))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // oidge represents the PostgreSQL function of the same name, taking the same parameters.
 var oidge = framework.Function2{
 	Name:       "oidge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Oid, pgtypes.Oid},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Oid, pgtypes.Oid},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Oid.Compare(val1.(uint32), val2.(uint32))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // textgename represents the PostgreSQL function of the same name, taking the same parameters.
 var textgename = framework.Function2{
 	Name:       "textgename",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // text_ge represents the PostgreSQL function of the same name, taking the same parameters.
 var text_ge = framework.Function2{
 	Name:       "text_ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // time_ge represents the PostgreSQL function of the same name, taking the same parameters.
 var time_ge = framework.Function2{
 	Name:       "time_ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Time.Compare(val1.(time.Time), val2.(time.Time))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // timestamp_ge_date represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_ge_date = framework.Function2{
 	Name:       "timestamp_ge_date",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res >= 0, nil
 	},
-	Strict: true,
 }
 
 // timestamp_ge represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_ge = framework.Function2{
 	Name:       "timestamp_ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Timestamp.Compare(val1.(time.Time), val2.(time.Time))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // timestamp_ge_timestamptz represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_ge_timestamptz = framework.Function2{
 	Name:       "timestamp_ge_timestamptz",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // timestamptz_ge_date represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_ge_date = framework.Function2{
 	Name:       "timestamptz_ge_date",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res >= 0, nil
 	},
-	Strict: true,
 }
 
 // timestamptz_ge_timestamp represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_ge_timestamp = framework.Function2{
 	Name:       "timestamptz_ge_timestamp",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // timestamptz_ge represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_ge = framework.Function2{
 	Name:       "timestamptz_ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // timetz_ge represents the PostgreSQL function of the same name, taking the same parameters.
 var timetz_ge = framework.Function2{
 	Name:       "timetz_ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimeTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res >= 0, err
 	},
-	Strict: true,
 }
 
 // uuid_ge represents the PostgreSQL function of the same name, taking the same parameters.
 var uuid_ge = framework.Function2{
 	Name:       "uuid_ge",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Uuid, pgtypes.Uuid},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Uuid, pgtypes.Uuid},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Uuid.Compare(val1.(uuid.UUID), val2.(uuid.UUID))
 		return res >= 0, err
 	},
-	Strict: true,
 }

--- a/server/functions/binary/json.go
+++ b/server/functions/binary/json.go
@@ -58,28 +58,30 @@ func initJSON() {
 var json_array_element = framework.Function2{
 	Name:       "json_array_element",
 	Return:     pgtypes.Json,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Json, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Json, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		// TODO: make a bespoke implementation that preserves whitespace
 		newVal, err := pgtypes.JsonB.IoInput(val1.(string))
 		if err != nil {
 			return nil, err
 		}
-		retVal, err := jsonb_array_element.Callable(ctx, newVal, val2)
+		var unusedTypes [3]pgtypes.DoltgresType
+		retVal, err := jsonb_array_element.Callable(ctx, unusedTypes, newVal, val2)
 		if err != nil {
 			return nil, err
 		}
 		return pgtypes.JsonB.FormatValue(retVal)
 	},
-	Strict: true,
 }
 
 // jsonb_array_element represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_array_element = framework.Function2{
 	Name:       "jsonb_array_element",
 	Return:     pgtypes.JsonB,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		array, ok := val1.(pgtypes.JsonDocument).Value.(pgtypes.JsonValueArray)
 		if !ok {
 			return nil, nil
@@ -93,38 +95,36 @@ var jsonb_array_element = framework.Function2{
 		}
 		return pgtypes.JsonDocument{Value: array[idx]}, nil
 	},
-	Strict: true,
 }
 
 // json_object_field represents the PostgreSQL function of the same name, taking the same parameters.
 var json_object_field = framework.Function2{
 	Name:       "json_object_field",
 	Return:     pgtypes.Json,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Json, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Json, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		// TODO: make a bespoke implementation that preserves whitespace
 		newVal, err := pgtypes.JsonB.IoInput(val1.(string))
 		if err != nil {
 			return nil, err
 		}
-		retVal, err := jsonb_object_field.Callable(ctx, newVal, val2)
+		var unusedTypes [3]pgtypes.DoltgresType
+		retVal, err := jsonb_object_field.Callable(ctx, unusedTypes, newVal, val2)
 		if err != nil {
 			return nil, err
 		}
 		return pgtypes.JsonB.FormatValue(retVal)
 	},
-	Strict: true,
 }
 
 // jsonb_object_field represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_object_field = framework.Function2{
 	Name:       "jsonb_object_field",
 	Return:     pgtypes.JsonB,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
-		if val1 == nil || val2 == nil {
-			return nil, nil
-		}
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		object, ok := val1.(pgtypes.JsonDocument).Value.(pgtypes.JsonValueObject)
 		if !ok {
 			return nil, nil
@@ -135,32 +135,33 @@ var jsonb_object_field = framework.Function2{
 		}
 		return pgtypes.JsonDocument{Value: object.Items[idx].Value}, nil
 	},
-	Strict: true,
 }
 
 // json_array_element_text represents the PostgreSQL function of the same name, taking the same parameters.
 var json_array_element_text = framework.Function2{
 	Name:       "json_array_element_text",
 	Return:     pgtypes.Text,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Json, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Json, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		// TODO: make a bespoke implementation that preserves whitespace
 		newVal, err := pgtypes.JsonB.IoInput(val1.(string))
 		if err != nil {
 			return nil, err
 		}
-		return jsonb_array_element_text.Callable(ctx, newVal, val2)
+		var unusedTypes [3]pgtypes.DoltgresType
+		return jsonb_array_element_text.Callable(ctx, unusedTypes, newVal, val2)
 	},
-	Strict: true,
 }
 
 // jsonb_array_element_text represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_array_element_text = framework.Function2{
 	Name:       "jsonb_array_element_text",
 	Return:     pgtypes.Text,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
-		doc, err := jsonb_array_element.Callable(ctx, val1, val2)
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, dt [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
+		doc, err := jsonb_array_element.Callable(ctx, dt, val1, val2)
 		if err != nil || doc == nil {
 			return nil, err
 		}
@@ -171,32 +172,33 @@ var jsonb_array_element_text = framework.Function2{
 			return pgtypes.JsonB.FormatValue(pgtypes.JsonDocument{Value: value})
 		}
 	},
-	Strict: true,
 }
 
 // json_object_field_text represents the PostgreSQL function of the same name, taking the same parameters.
 var json_object_field_text = framework.Function2{
 	Name:       "json_object_field_text",
 	Return:     pgtypes.Text,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Json, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Json, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		// TODO: make a bespoke implementation that preserves whitespace
 		newVal, err := pgtypes.JsonB.IoInput(val1.(string))
 		if err != nil {
 			return nil, err
 		}
-		return jsonb_object_field_text.Callable(ctx, newVal, val2)
+		var unusedTypes [3]pgtypes.DoltgresType
+		return jsonb_object_field_text.Callable(ctx, unusedTypes, newVal, val2)
 	},
-	Strict: true,
 }
 
 // jsonb_object_field_tex_jsonb represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_object_field_text = framework.Function2{
 	Name:       "jsonb_object_field_text",
 	Return:     pgtypes.Text,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
-		doc, err := jsonb_object_field.Callable(ctx, val1, val2)
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, dt [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
+		doc, err := jsonb_object_field.Callable(ctx, dt, val1, val2)
 		if err != nil || doc == nil {
 			return nil, err
 		}
@@ -207,35 +209,36 @@ var jsonb_object_field_text = framework.Function2{
 			return pgtypes.JsonB.FormatValue(pgtypes.JsonDocument{Value: value})
 		}
 	},
-	Strict: true,
 }
 
 // json_extract_path represents the PostgreSQL function of the same name, taking the same parameters.
 var json_extract_path = framework.Function2{
 	Name:       "json_extract_path",
 	Return:     pgtypes.Json,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Json, pgtypes.TextArray},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Json, pgtypes.TextArray},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		// TODO: make a bespoke implementation that preserves whitespace
 		newVal, err := pgtypes.JsonB.IoInput(val1.(string))
 		if err != nil {
 			return nil, err
 		}
-		retVal, err := jsonb_extract_path.Callable(ctx, newVal, val2)
+		var unusedTypes [3]pgtypes.DoltgresType
+		retVal, err := jsonb_extract_path.Callable(ctx, unusedTypes, newVal, val2)
 		if err != nil {
 			return nil, err
 		}
 		return pgtypes.JsonB.FormatValue(retVal)
 	},
-	Strict: true,
 }
 
 // jsonb_extract_path represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_extract_path = framework.Function2{
 	Name:       "jsonb_extract_path",
 	Return:     pgtypes.JsonB,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.TextArray},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.TextArray},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		value := val1.(pgtypes.JsonDocument).Value
 		paths := val2.([]interface{})
 		for _, path := range paths {
@@ -263,32 +266,33 @@ var jsonb_extract_path = framework.Function2{
 		}
 		return pgtypes.JsonDocument{Value: value}, nil
 	},
-	Strict: true,
 }
 
 // json_extract_path_text represents the PostgreSQL function of the same name, taking the same parameters.
 var json_extract_path_text = framework.Function2{
 	Name:       "json_extract_path_text",
 	Return:     pgtypes.Text,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Json, pgtypes.TextArray},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Json, pgtypes.TextArray},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		// TODO: make a bespoke implementation that preserves whitespace
 		newVal, err := pgtypes.JsonB.IoInput(val1.(string))
 		if err != nil {
 			return nil, err
 		}
-		return jsonb_extract_path_text.Callable(ctx, newVal, val2)
+		var unusedTypes [3]pgtypes.DoltgresType
+		return jsonb_extract_path_text.Callable(ctx, unusedTypes, newVal, val2)
 	},
-	Strict: true,
 }
 
 // jsonb_extract_path_text represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_extract_path_text = framework.Function2{
 	Name:       "jsonb_extract_path_text",
 	Return:     pgtypes.Text,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.TextArray},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
-		doc, err := jsonb_extract_path.Callable(ctx, val1, val2)
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.TextArray},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, dt [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
+		doc, err := jsonb_extract_path.Callable(ctx, dt, val1, val2)
 		if err != nil || doc == nil {
 			return nil, err
 		}
@@ -299,37 +303,37 @@ var jsonb_extract_path_text = framework.Function2{
 			return pgtypes.JsonB.FormatValue(pgtypes.JsonDocument{Value: value})
 		}
 	},
-	Strict: true,
 }
 
 // jsonb_contains represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_contains = framework.Function2{
 	Name:       "jsonb_contains",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return nil, fmt.Errorf("JSON contains is not yet supported")
 	},
-	Strict: true,
 }
 
 // jsonb_contained represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_contained = framework.Function2{
 	Name:       "jsonb_contained",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
-		return jsonb_contains.Callable(ctx, val2, val1)
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, dt [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
+		return jsonb_contains.Callable(ctx, dt, val2, val1)
 	},
-	Strict: true,
 }
 
 // jsonb_exists represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_exists = framework.Function2{
 	Name:       "jsonb_exists",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		switch value := val1.(pgtypes.JsonDocument).Value.(type) {
 		case pgtypes.JsonValueObject:
 			_, ok := value.Index[val2.(string)]
@@ -349,15 +353,15 @@ var jsonb_exists = framework.Function2{
 			return false, nil
 		}
 	},
-	Strict: true,
 }
 
 // jsonb_exists_any represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_exists_any = framework.Function2{
 	Name:       "jsonb_exists_any",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.TextArray},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.TextArray},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		keys := val2.([]interface{})
 		switch value := val1.(pgtypes.JsonDocument).Value.(type) {
 		case pgtypes.JsonValueObject:
@@ -389,15 +393,15 @@ var jsonb_exists_any = framework.Function2{
 			return false, nil
 		}
 	},
-	Strict: true,
 }
 
 // jsonb_exists_all represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_exists_all = framework.Function2{
 	Name:       "jsonb_exists_all",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.TextArray},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.TextArray},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		keys := val2.([]interface{})
 		switch value := val1.(pgtypes.JsonDocument).Value.(type) {
 		case pgtypes.JsonValueObject:
@@ -434,15 +438,15 @@ var jsonb_exists_all = framework.Function2{
 			return false, nil
 		}
 	},
-	Strict: true,
 }
 
 // jsonb_concat represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_concat = framework.Function2{
 	Name:       "jsonb_concat",
 	Return:     pgtypes.JsonB,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
-	Callable: func(ctx *sql.Context, val1Interface any, val2Interface any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1Interface any, val2Interface any) (any, error) {
 		val1 := val1Interface.(pgtypes.JsonDocument).Value
 		val2 := val2Interface.(pgtypes.JsonDocument).Value
 		// First we'll merge objects if they're both objects
@@ -488,38 +492,37 @@ var jsonb_concat = framework.Function2{
 		copy(newArray[len(val1Array):], val2Array)
 		return pgtypes.JsonDocument{Value: newArray}, nil
 	},
-	Strict: true,
 }
 
 // jsonb_delete_text represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_delete_text = framework.Function2{
 	Name:       "jsonb_delete",
 	Return:     pgtypes.JsonB,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return nil, fmt.Errorf("JSON deletions are not yet supported")
 	},
-	Strict: true,
 }
 
 // jsonb_delete_text_array represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_delete_text_array = framework.Function2{
 	Name:       "jsonb_delete",
 	Return:     pgtypes.JsonB,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.TextArray},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.TextArray},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return nil, fmt.Errorf("JSON deletions are not yet supported")
 	},
-	Strict: true,
 }
 
 // jsonb_delete_int32 represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_delete_int32 = framework.Function2{
 	Name:       "jsonb_delete",
 	Return:     pgtypes.JsonB,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return nil, fmt.Errorf("JSON deletions are not yet supported")
 	},
-	Strict: true,
 }

--- a/server/functions/binary/less.go
+++ b/server/functions/binary/less.go
@@ -71,418 +71,418 @@ func initBinaryLessThan() {
 var boollt = framework.Function2{
 	Name:       "boollt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Bool, pgtypes.Bool},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Bool, pgtypes.Bool},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Bool.Compare(val1.(bool), val2.(bool))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // bpcharlt represents the PostgreSQL function of the same name, taking the same parameters.
 var bpcharlt = framework.Function2{
 	Name:       "bpcharlt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.BpChar.Compare(val1.(string), val2.(string))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // bytealt represents the PostgreSQL function of the same name, taking the same parameters.
 var bytealt = framework.Function2{
 	Name:       "bytealt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Bytea, pgtypes.Bytea},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Bytea, pgtypes.Bytea},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Bytea.Compare(val1.([]byte), val2.([]byte))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // date_lt represents the PostgreSQL function of the same name, taking the same parameters.
 var date_lt = framework.Function2{
 	Name:       "date_lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Date.Compare(val1.(time.Time), val2.(time.Time))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // date_lt_timestamp represents the PostgreSQL function of the same name, taking the same parameters.
 var date_lt_timestamp = framework.Function2{
 	Name:       "date_lt_timestamp",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res == -1, nil
 	},
-	Strict: true,
 }
 
 // date_lt_timestamptz represents the PostgreSQL function of the same name, taking the same parameters.
 var date_lt_timestamptz = framework.Function2{
 	Name:       "date_lt_timestamptz",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res == -1, nil
 	},
-	Strict: true,
 }
 
 // float4lt represents the PostgreSQL function of the same name, taking the same parameters.
 var float4lt = framework.Function2{
 	Name:       "float4lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float32.Compare(val1.(float32), val2.(float32))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // float48lt represents the PostgreSQL function of the same name, taking the same parameters.
 var float48lt = framework.Function2{
 	Name:       "float48lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(float64(val1.(float32)), val2.(float64))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // float84lt represents the PostgreSQL function of the same name, taking the same parameters.
 var float84lt = framework.Function2{
 	Name:       "float84lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(val1.(float64), float64(val2.(float32)))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // float8lt represents the PostgreSQL function of the same name, taking the same parameters.
 var float8lt = framework.Function2{
 	Name:       "float8lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(val1.(float64), val2.(float64))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // int2lt represents the PostgreSQL function of the same name, taking the same parameters.
 var int2lt = framework.Function2{
 	Name:       "int2lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int16.Compare(val1.(int16), val2.(int16))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // int24lt represents the PostgreSQL function of the same name, taking the same parameters.
 var int24lt = framework.Function2{
 	Name:       "int24lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(int32(val1.(int16)), val2.(int32))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // int28lt represents the PostgreSQL function of the same name, taking the same parameters.
 var int28lt = framework.Function2{
 	Name:       "int28lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(int64(val1.(int16)), val2.(int64))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // int42lt represents the PostgreSQL function of the same name, taking the same parameters.
 var int42lt = framework.Function2{
 	Name:       "int42lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(val1.(int32), int32(val2.(int16)))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // int4lt represents the PostgreSQL function of the same name, taking the same parameters.
 var int4lt = framework.Function2{
 	Name:       "int4lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(val1.(int32), val2.(int32))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // int48lt represents the PostgreSQL function of the same name, taking the same parameters.
 var int48lt = framework.Function2{
 	Name:       "int48lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(int64(val1.(int32)), val2.(int64))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // int82lt represents the PostgreSQL function of the same name, taking the same parameters.
 var int82lt = framework.Function2{
 	Name:       "int82lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), int64(val2.(int16)))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // int84lt represents the PostgreSQL function of the same name, taking the same parameters.
 var int84lt = framework.Function2{
 	Name:       "int84lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), int64(val2.(int32)))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // int8lt represents the PostgreSQL function of the same name, taking the same parameters.
 var int8lt = framework.Function2{
 	Name:       "int8lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), val2.(int64))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // jsonb_lt represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_lt = framework.Function2{
 	Name:       "jsonb_lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.JsonB.Compare(val1.(pgtypes.JsonDocument), val2.(pgtypes.JsonDocument))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // namelt represents the PostgreSQL function of the same name, taking the same parameters.
 var namelt = framework.Function2{
 	Name:       "namelt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Name.Compare(val1.(string), val2.(string))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // namelttext represents the PostgreSQL function of the same name, taking the same parameters.
 var namelttext = framework.Function2{
 	Name:       "namelttext",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // numeric_lt represents the PostgreSQL function of the same name, taking the same parameters.
 var numeric_lt = framework.Function2{
 	Name:       "numeric_lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Numeric.Compare(val1.(decimal.Decimal), val2.(decimal.Decimal))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // oidlt represents the PostgreSQL function of the same name, taking the same parameters.
 var oidlt = framework.Function2{
 	Name:       "oidlt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Oid, pgtypes.Oid},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Oid, pgtypes.Oid},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Oid.Compare(val1.(uint32), val2.(uint32))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // textltname represents the PostgreSQL function of the same name, taking the same parameters.
 var textltname = framework.Function2{
 	Name:       "textltname",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // text_lt represents the PostgreSQL function of the same name, taking the same parameters.
 var text_lt = framework.Function2{
 	Name:       "text_lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // time_lt represents the PostgreSQL function of the same name, taking the same parameters.
 var time_lt = framework.Function2{
 	Name:       "time_lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Time.Compare(val1.(time.Time), val2.(time.Time))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // timestamp_lt_date represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_lt_date = framework.Function2{
 	Name:       "timestamp_lt_date",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res == -1, nil
 	},
-	Strict: true,
 }
 
 // timestamp_lt represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_lt = framework.Function2{
 	Name:       "timestamp_lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Timestamp.Compare(val1.(time.Time), val2.(time.Time))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // timestamp_lt_timestamptz represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_lt_timestamptz = framework.Function2{
 	Name:       "timestamp_lt_timestamptz",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // timestamptz_lt_date represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_lt_date = framework.Function2{
 	Name:       "timestamptz_lt_date",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res == -1, nil
 	},
-	Strict: true,
 }
 
 // timestamptz_lt_timestamp represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_lt_timestamp = framework.Function2{
 	Name:       "timestamptz_lt_timestamp",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // timestamptz_lt represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_lt = framework.Function2{
 	Name:       "timestamptz_lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // timetz_lt represents the PostgreSQL function of the same name, taking the same parameters.
 var timetz_lt = framework.Function2{
 	Name:       "timetz_lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimeTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res == -1, err
 	},
-	Strict: true,
 }
 
 // uuid_lt represents the PostgreSQL function of the same name, taking the same parameters.
 var uuid_lt = framework.Function2{
 	Name:       "uuid_lt",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Uuid, pgtypes.Uuid},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Uuid, pgtypes.Uuid},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Uuid.Compare(val1.(uuid.UUID), val2.(uuid.UUID))
 		return res == -1, err
 	},
-	Strict: true,
 }

--- a/server/functions/binary/less_equal.go
+++ b/server/functions/binary/less_equal.go
@@ -71,418 +71,418 @@ func initBinaryLessOrEqual() {
 var boolle = framework.Function2{
 	Name:       "boolle",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Bool, pgtypes.Bool},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Bool, pgtypes.Bool},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Bool.Compare(val1.(bool), val2.(bool))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // bpcharle represents the PostgreSQL function of the same name, taking the same parameters.
 var bpcharle = framework.Function2{
 	Name:       "bpcharle",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.BpChar.Compare(val1.(string), val2.(string))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // byteale represents the PostgreSQL function of the same name, taking the same parameters.
 var byteale = framework.Function2{
 	Name:       "byteale",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Bytea, pgtypes.Bytea},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Bytea, pgtypes.Bytea},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Bytea.Compare(val1.([]byte), val2.([]byte))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // date_le represents the PostgreSQL function of the same name, taking the same parameters.
 var date_le = framework.Function2{
 	Name:       "date_le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Date.Compare(val1.(time.Time), val2.(time.Time))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // date_le_timestamp represents the PostgreSQL function of the same name, taking the same parameters.
 var date_le_timestamp = framework.Function2{
 	Name:       "date_le_timestamp",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res <= 0, nil
 	},
-	Strict: true,
 }
 
 // date_le_timestamptz represents the PostgreSQL function of the same name, taking the same parameters.
 var date_le_timestamptz = framework.Function2{
 	Name:       "date_le_timestamptz",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res <= 0, nil
 	},
-	Strict: true,
 }
 
 // float4le represents the PostgreSQL function of the same name, taking the same parameters.
 var float4le = framework.Function2{
 	Name:       "float4le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float32.Compare(val1.(float32), val2.(float32))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // float48le represents the PostgreSQL function of the same name, taking the same parameters.
 var float48le = framework.Function2{
 	Name:       "float48le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(float64(val1.(float32)), val2.(float64))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // float84le represents the PostgreSQL function of the same name, taking the same parameters.
 var float84le = framework.Function2{
 	Name:       "float84le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(val1.(float64), float64(val2.(float32)))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // float8le represents the PostgreSQL function of the same name, taking the same parameters.
 var float8le = framework.Function2{
 	Name:       "float8le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(val1.(float64), val2.(float64))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // int2le represents the PostgreSQL function of the same name, taking the same parameters.
 var int2le = framework.Function2{
 	Name:       "int2le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int16.Compare(val1.(int16), val2.(int16))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // int24le represents the PostgreSQL function of the same name, taking the same parameters.
 var int24le = framework.Function2{
 	Name:       "int24le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(int32(val1.(int16)), val2.(int32))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // int28le represents the PostgreSQL function of the same name, taking the same parameters.
 var int28le = framework.Function2{
 	Name:       "int28le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(int64(val1.(int16)), val2.(int64))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // int42le represents the PostgreSQL function of the same name, taking the same parameters.
 var int42le = framework.Function2{
 	Name:       "int42le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(val1.(int32), int32(val2.(int16)))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // int4le represents the PostgreSQL function of the same name, taking the same parameters.
 var int4le = framework.Function2{
 	Name:       "int4le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(val1.(int32), val2.(int32))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // int48le represents the PostgreSQL function of the same name, taking the same parameters.
 var int48le = framework.Function2{
 	Name:       "int48le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(int64(val1.(int32)), val2.(int64))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // int82le represents the PostgreSQL function of the same name, taking the same parameters.
 var int82le = framework.Function2{
 	Name:       "int82le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), int64(val2.(int16)))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // int84le represents the PostgreSQL function of the same name, taking the same parameters.
 var int84le = framework.Function2{
 	Name:       "int84le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), int64(val2.(int32)))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // int8le represents the PostgreSQL function of the same name, taking the same parameters.
 var int8le = framework.Function2{
 	Name:       "int8le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), val2.(int64))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // jsonb_le represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_le = framework.Function2{
 	Name:       "jsonb_le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.JsonB.Compare(val1.(pgtypes.JsonDocument), val2.(pgtypes.JsonDocument))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // namele represents the PostgreSQL function of the same name, taking the same parameters.
 var namele = framework.Function2{
 	Name:       "namele",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Name.Compare(val1.(string), val2.(string))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // nameletext represents the PostgreSQL function of the same name, taking the same parameters.
 var nameletext = framework.Function2{
 	Name:       "nameletext",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // numeric_le represents the PostgreSQL function of the same name, taking the same parameters.
 var numeric_le = framework.Function2{
 	Name:       "numeric_le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Numeric.Compare(val1.(decimal.Decimal), val2.(decimal.Decimal))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // oidle represents the PostgreSQL function of the same name, taking the same parameters.
 var oidle = framework.Function2{
 	Name:       "oidle",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Oid, pgtypes.Oid},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Oid, pgtypes.Oid},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Oid.Compare(val1.(uint32), val2.(uint32))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // textlename represents the PostgreSQL function of the same name, taking the same parameters.
 var textlename = framework.Function2{
 	Name:       "textlename",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // text_le represents the PostgreSQL function of the same name, taking the same parameters.
 var text_le = framework.Function2{
 	Name:       "text_le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // time_le represents the PostgreSQL function of the same name, taking the same parameters.
 var time_le = framework.Function2{
 	Name:       "time_le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Time.Compare(val1.(time.Time), val2.(time.Time))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // timestamp_le_date represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_le_date = framework.Function2{
 	Name:       "timestamp_le_date",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res <= 0, nil
 	},
-	Strict: true,
 }
 
 // timestamp_le represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_le = framework.Function2{
 	Name:       "timestamp_le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Timestamp.Compare(val1.(time.Time), val2.(time.Time))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // timestamp_le_timestamptz represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_le_timestamptz = framework.Function2{
 	Name:       "timestamp_le_timestamptz",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // timestamptz_le_date represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_le_date = framework.Function2{
 	Name:       "timestamptz_le_date",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res <= 0, nil
 	},
-	Strict: true,
 }
 
 // timestamptz_le_timestamp represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_le_timestamp = framework.Function2{
 	Name:       "timestamptz_le_timestamp",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // timestamptz_le represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_le = framework.Function2{
 	Name:       "timestamptz_le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // timetz_le represents the PostgreSQL function of the same name, taking the same parameters.
 var timetz_le = framework.Function2{
 	Name:       "timetz_le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimeTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res <= 0, err
 	},
-	Strict: true,
 }
 
 // uuid_le represents the PostgreSQL function of the same name, taking the same parameters.
 var uuid_le = framework.Function2{
 	Name:       "uuid_le",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Uuid, pgtypes.Uuid},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Uuid, pgtypes.Uuid},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Uuid.Compare(val1.(uuid.UUID), val2.(uuid.UUID))
 		return res <= 0, err
 	},
-	Strict: true,
 }

--- a/server/functions/binary/minus.go
+++ b/server/functions/binary/minus.go
@@ -50,170 +50,170 @@ func initBinaryMinus() {
 var float4mi = framework.Function2{
 	Name:       "float4mi",
 	Return:     pgtypes.Float32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return val1.(float32) - val2.(float32), nil
 	},
-	Strict: true,
 }
 
 // float48mi represents the PostgreSQL function of the same name, taking the same parameters.
 var float48mi = framework.Function2{
 	Name:       "float48mi",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return float64(val1.(float32)) - val2.(float64), nil
 	},
-	Strict: true,
 }
 
 // float8mi represents the PostgreSQL function of the same name, taking the same parameters.
 var float8mi = framework.Function2{
 	Name:       "float8mi",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return val1.(float64) - val2.(float64), nil
 	},
-	Strict: true,
 }
 
 // float84mi represents the PostgreSQL function of the same name, taking the same parameters.
 var float84mi = framework.Function2{
 	Name:       "float84mi",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return val1.(float64) - float64(val2.(float32)), nil
 	},
-	Strict: true,
 }
 
 // int2mi represents the PostgreSQL function of the same name, taking the same parameters.
 var int2mi = framework.Function2{
 	Name:       "int2mi",
 	Return:     pgtypes.Int16,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int16)) - int64(val2.(int16))
 		if result > math.MaxInt16 || result < math.MinInt16 {
 			return nil, fmt.Errorf("smallint out of range")
 		}
 		return int16(result), nil
 	},
-	Strict: true,
 }
 
 // int24mi represents the PostgreSQL function of the same name, taking the same parameters.
 var int24mi = framework.Function2{
 	Name:       "int24mi",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int16)) - int64(val2.(int32))
 		if result > math.MaxInt16 || result < math.MinInt16 {
 			return nil, fmt.Errorf("integer out of range")
 		}
 		return int32(result), nil
 	},
-	Strict: true,
 }
 
 // int28mi represents the PostgreSQL function of the same name, taking the same parameters.
 var int28mi = framework.Function2{
 	Name:       "int28mi",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return minusOverflow(int64(val1.(int16)), val2.(int64))
 	},
-	Strict: true,
 }
 
 // int4mi represents the PostgreSQL function of the same name, taking the same parameters.
 var int4mi = framework.Function2{
 	Name:       "int4mi",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int32)) - int64(val2.(int32))
 		if result > math.MaxInt32 || result < math.MinInt32 {
 			return nil, fmt.Errorf("integer out of range")
 		}
 		return int32(result), nil
 	},
-	Strict: true,
 }
 
 // int42mi represents the PostgreSQL function of the same name, taking the same parameters.
 var int42mi = framework.Function2{
 	Name:       "int42mi",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int32)) - int64(val2.(int16))
 		if result > math.MaxInt32 || result < math.MinInt32 {
 			return nil, fmt.Errorf("integer out of range")
 		}
 		return int32(result), nil
 	},
-	Strict: true,
 }
 
 // int48mi represents the PostgreSQL function of the same name, taking the same parameters.
 var int48mi = framework.Function2{
 	Name:       "int48mi",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return minusOverflow(int64(val1.(int32)), val2.(int64))
 	},
-	Strict: true,
 }
 
 // int8mi represents the PostgreSQL function of the same name, taking the same parameters.
 var int8mi = framework.Function2{
 	Name:       "int8mi",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return minusOverflow(val1.(int64), val2.(int64))
 	},
-	Strict: true,
 }
 
 // int82mi represents the PostgreSQL function of the same name, taking the same parameters.
 var int82mi = framework.Function2{
 	Name:       "int82mi",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return minusOverflow(val1.(int64), int64(val2.(int16)))
 	},
-	Strict: true,
 }
 
 // int84mi represents the PostgreSQL function of the same name, taking the same parameters.
 var int84mi = framework.Function2{
 	Name:       "int84mi",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return minusOverflow(val1.(int64), int64(val2.(int32)))
 	},
-	Strict: true,
 }
 
 // numeric_sub represents the PostgreSQL function of the same name, taking the same parameters.
 var numeric_sub = framework.Function2{
 	Name:       "numeric_sub",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return val1.(decimal.Decimal).Sub(val2.(decimal.Decimal)), nil
 	},
-	Strict: true,
 }
 
 // minusOverflow is a convenience function that checks for overflow for int64 subtraction.

--- a/server/functions/binary/mod.go
+++ b/server/functions/binary/mod.go
@@ -39,54 +39,54 @@ func initBinaryMod() {
 var int2mod = framework.Function2{
 	Name:       "int2mod",
 	Return:     pgtypes.Int16,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int16) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(int16) % val2.(int16), nil
 	},
-	Strict: true,
 }
 
 // int4mod represents the PostgreSQL function of the same name, taking the same parameters.
 var int4mod = framework.Function2{
 	Name:       "int4mod",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int32) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(int32) % val2.(int32), nil
 	},
-	Strict: true,
 }
 
 // int8mod represents the PostgreSQL function of the same name, taking the same parameters.
 var int8mod = framework.Function2{
 	Name:       "int8mod",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int64) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(int64) % val2.(int64), nil
 	},
-	Strict: true,
 }
 
 // numeric_mod represents the PostgreSQL function of the same name, taking the same parameters.
 var numeric_mod = framework.Function2{
 	Name:       "numeric_mod",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(decimal.Decimal).Equal(decimal.Zero) {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(decimal.Decimal).Mod(val2.(decimal.Decimal)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/binary/multiply.go
+++ b/server/functions/binary/multiply.go
@@ -50,170 +50,170 @@ func initBinaryMultiply() {
 var float4mul = framework.Function2{
 	Name:       "float4mul",
 	Return:     pgtypes.Float32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return val1.(float32) * val2.(float32), nil
 	},
-	Strict: true,
 }
 
 // float48mul represents the PostgreSQL function of the same name, taking the same parameters.
 var float48mul = framework.Function2{
 	Name:       "float48mul",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return float64(val1.(float32)) * val2.(float64), nil
 	},
-	Strict: true,
 }
 
 // float8mul represents the PostgreSQL function of the same name, taking the same parameters.
 var float8mul = framework.Function2{
 	Name:       "float8mul",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return val1.(float64) * val2.(float64), nil
 	},
-	Strict: true,
 }
 
 // float84mul represents the PostgreSQL function of the same name, taking the same parameters.
 var float84mul = framework.Function2{
 	Name:       "float84mul",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return val1.(float64) * float64(val2.(float32)), nil
 	},
-	Strict: true,
 }
 
 // int2mul represents the PostgreSQL function of the same name, taking the same parameters.
 var int2mul = framework.Function2{
 	Name:       "int2mul",
 	Return:     pgtypes.Int16,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int16)) * int64(val2.(int16))
 		if result > math.MaxInt16 || result < math.MinInt16 {
 			return nil, fmt.Errorf("smallint out of range")
 		}
 		return int16(result), nil
 	},
-	Strict: true,
 }
 
 // int24mul represents the PostgreSQL function of the same name, taking the same parameters.
 var int24mul = framework.Function2{
 	Name:       "int24mul",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int16)) * int64(val2.(int32))
 		if result > math.MaxInt16 || result < math.MinInt16 {
 			return nil, fmt.Errorf("integer out of range")
 		}
 		return int32(result), nil
 	},
-	Strict: true,
 }
 
 // int28mul represents the PostgreSQL function of the same name, taking the same parameters.
 var int28mul = framework.Function2{
 	Name:       "int28mul",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return multiplyOverflow(int64(val1.(int16)), val2.(int64))
 	},
-	Strict: true,
 }
 
 // int4mul represents the PostgreSQL function of the same name, taking the same parameters.
 var int4mul = framework.Function2{
 	Name:       "int4mul",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int32)) * int64(val2.(int32))
 		if result > math.MaxInt32 || result < math.MinInt32 {
 			return nil, fmt.Errorf("integer out of range")
 		}
 		return int32(result), nil
 	},
-	Strict: true,
 }
 
 // int42mul represents the PostgreSQL function of the same name, taking the same parameters.
 var int42mul = framework.Function2{
 	Name:       "int42mul",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int32)) * int64(val2.(int16))
 		if result > math.MaxInt32 || result < math.MinInt32 {
 			return nil, fmt.Errorf("integer out of range")
 		}
 		return int32(result), nil
 	},
-	Strict: true,
 }
 
 // int48mul represents the PostgreSQL function of the same name, taking the same parameters.
 var int48mul = framework.Function2{
 	Name:       "int48mul",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return multiplyOverflow(int64(val1.(int32)), val2.(int64))
 	},
-	Strict: true,
 }
 
 // int8mul represents the PostgreSQL function of the same name, taking the same parameters.
 var int8mul = framework.Function2{
 	Name:       "int8mul",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return multiplyOverflow(val1.(int64), val2.(int64))
 	},
-	Strict: true,
 }
 
 // int82mul represents the PostgreSQL function of the same name, taking the same parameters.
 var int82mul = framework.Function2{
 	Name:       "int82mul",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return multiplyOverflow(val1.(int64), int64(val2.(int16)))
 	},
-	Strict: true,
 }
 
 // int84mul represents the PostgreSQL function of the same name, taking the same parameters.
 var int84mul = framework.Function2{
 	Name:       "int84mul",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return multiplyOverflow(val1.(int64), int64(val2.(int32)))
 	},
-	Strict: true,
 }
 
 // numeric_mul represents the PostgreSQL function of the same name, taking the same parameters.
 var numeric_mul = framework.Function2{
 	Name:       "numeric_mul",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return val1.(decimal.Decimal).Mul(val2.(decimal.Decimal)), nil
 	},
-	Strict: true,
 }
 
 // multiplyOverflow is a convenience function that checks for overflow for int64 multiplication.

--- a/server/functions/binary/not_equal.go
+++ b/server/functions/binary/not_equal.go
@@ -73,443 +73,443 @@ func initBinaryNotEqual() {
 var boolne = framework.Function2{
 	Name:       "boolne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Bool, pgtypes.Bool},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Bool, pgtypes.Bool},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Bool.Compare(val1.(bool), val2.(bool))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // bpcharne represents the PostgreSQL function of the same name, taking the same parameters.
 var bpcharne = framework.Function2{
 	Name:       "bpcharne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.BpChar.Compare(val1.(string), val2.(string))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // byteane represents the PostgreSQL function of the same name, taking the same parameters.
 var byteane = framework.Function2{
 	Name:       "byteane",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Bytea, pgtypes.Bytea},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Bytea, pgtypes.Bytea},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Bytea.Compare(val1.([]byte), val2.([]byte))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // date_ne represents the PostgreSQL function of the same name, taking the same parameters.
 var date_ne = framework.Function2{
 	Name:       "date_ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Date.Compare(val1.(time.Time), val2.(time.Time))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // date_ne_timestamp represents the PostgreSQL function of the same name, taking the same parameters.
 var date_ne_timestamp = framework.Function2{
 	Name:       "date_ne_timestamp",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res != 0, nil
 	},
-	Strict: true,
 }
 
 // date_ne_timestamptz represents the PostgreSQL function of the same name, taking the same parameters.
 var date_ne_timestamptz = framework.Function2{
 	Name:       "date_ne_timestamptz",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Date, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Date, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res != 0, nil
 	},
-	Strict: true,
 }
 
 // float4ne represents the PostgreSQL function of the same name, taking the same parameters.
 var float4ne = framework.Function2{
 	Name:       "float4ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float32.Compare(val1.(float32), val2.(float32))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // float48ne represents the PostgreSQL function of the same name, taking the same parameters.
 var float48ne = framework.Function2{
 	Name:       "float48ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(float64(val1.(float32)), val2.(float64))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // float84ne represents the PostgreSQL function of the same name, taking the same parameters.
 var float84ne = framework.Function2{
 	Name:       "float84ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(val1.(float64), float64(val2.(float32)))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // float8ne represents the PostgreSQL function of the same name, taking the same parameters.
 var float8ne = framework.Function2{
 	Name:       "float8ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Float64.Compare(val1.(float64), val2.(float64))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // int2ne represents the PostgreSQL function of the same name, taking the same parameters.
 var int2ne = framework.Function2{
 	Name:       "int2ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int16.Compare(val1.(int16), val2.(int16))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // int24ne represents the PostgreSQL function of the same name, taking the same parameters.
 var int24ne = framework.Function2{
 	Name:       "int24ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(int32(val1.(int16)), val2.(int32))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // int28ne represents the PostgreSQL function of the same name, taking the same parameters.
 var int28ne = framework.Function2{
 	Name:       "int28ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(int64(val1.(int16)), val2.(int64))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // int42ne represents the PostgreSQL function of the same name, taking the same parameters.
 var int42ne = framework.Function2{
 	Name:       "int42ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(val1.(int32), int32(val2.(int16)))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // int4ne represents the PostgreSQL function of the same name, taking the same parameters.
 var int4ne = framework.Function2{
 	Name:       "int4ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int32.Compare(val1.(int32), val2.(int32))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // int48ne represents the PostgreSQL function of the same name, taking the same parameters.
 var int48ne = framework.Function2{
 	Name:       "int48ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(int64(val1.(int32)), val2.(int64))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // int82ne represents the PostgreSQL function of the same name, taking the same parameters.
 var int82ne = framework.Function2{
 	Name:       "int82ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), int64(val2.(int16)))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // int84ne represents the PostgreSQL function of the same name, taking the same parameters.
 var int84ne = framework.Function2{
 	Name:       "int84ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), int64(val2.(int32)))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // int8ne represents the PostgreSQL function of the same name, taking the same parameters.
 var int8ne = framework.Function2{
 	Name:       "int8ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Int64.Compare(val1.(int64), val2.(int64))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // jsonb_ne represents the PostgreSQL function of the same name, taking the same parameters.
 var jsonb_ne = framework.Function2{
 	Name:       "jsonb_ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.JsonB, pgtypes.JsonB},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.JsonB.Compare(val1.(pgtypes.JsonDocument), val2.(pgtypes.JsonDocument))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // namene represents the PostgreSQL function of the same name, taking the same parameters.
 var namene = framework.Function2{
 	Name:       "namene",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Name.Compare(val1.(string), val2.(string))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // namenetext represents the PostgreSQL function of the same name, taking the same parameters.
 var namenetext = framework.Function2{
 	Name:       "namenetext",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // numeric_ne represents the PostgreSQL function of the same name, taking the same parameters.
 var numeric_ne = framework.Function2{
 	Name:       "numeric_ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Numeric.Compare(val1.(decimal.Decimal), val2.(decimal.Decimal))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // oidne represents the PostgreSQL function of the same name, taking the same parameters.
 var oidne = framework.Function2{
 	Name:       "oidne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Oid, pgtypes.Oid},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Oid, pgtypes.Oid},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Oid.Compare(val1.(uint32), val2.(uint32))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // textnename represents the PostgreSQL function of the same name, taking the same parameters.
 var textnename = framework.Function2{
 	Name:       "textnename",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // text_ne represents the PostgreSQL function of the same name, taking the same parameters.
 var text_ne = framework.Function2{
 	Name:       "text_ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Text.Compare(val1.(string), val2.(string))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // time_ne represents the PostgreSQL function of the same name, taking the same parameters.
 var time_ne = framework.Function2{
 	Name:       "time_ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Time.Compare(val1.(time.Time), val2.(time.Time))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // timestamp_ne_date represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_ne_date = framework.Function2{
 	Name:       "timestamp_ne_date",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res != 0, nil
 	},
-	Strict: true,
 }
 
 // timestamp_ne represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_ne = framework.Function2{
 	Name:       "timestamp_ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Timestamp.Compare(val1.(time.Time), val2.(time.Time))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // timestamp_ne_timestamptz represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamp_ne_timestamptz = framework.Function2{
 	Name:       "timestamp_ne_timestamptz",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Timestamp, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // timestamptz_ne_date represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_ne_date = framework.Function2{
 	Name:       "timestamptz_ne_date",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Date},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Date},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res := val1.(time.Time).Compare(val2.(time.Time))
 		return res != 0, nil
 	},
-	Strict: true,
 }
 
 // timestamptz_ne_timestamp represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_ne_timestamp = framework.Function2{
 	Name:       "timestamptz_ne_timestamp",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Timestamp},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.Timestamp},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // timestamptz_ne represents the PostgreSQL function of the same name, taking the same parameters.
 var timestamptz_ne = framework.Function2{
 	Name:       "timestamptz_ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.TimestampTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimestampTZ, pgtypes.TimestampTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimestampTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // timetz_ne represents the PostgreSQL function of the same name, taking the same parameters.
 var timetz_ne = framework.Function2{
 	Name:       "timetz_ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.TimeTZ.Compare(val1.(time.Time), val2.(time.Time))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // uuid_ne represents the PostgreSQL function of the same name, taking the same parameters.
 var uuid_ne = framework.Function2{
 	Name:       "uuid_ne",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Uuid, pgtypes.Uuid},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Uuid, pgtypes.Uuid},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Uuid.Compare(val1.(uuid.UUID), val2.(uuid.UUID))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // xidneqint4 represents the PostgreSQL function of the same name, taking the same parameters.
 var xidneqint4 = framework.Function2{
 	Name:       "xidneqint4",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Xid, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Xid, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		// TODO: investigate the edge cases
 		res, err := pgtypes.Int64.Compare(int64(val1.(uint32)), int64(val2.(int32)))
 		return res != 0, err
 	},
-	Strict: true,
 }
 
 // xidneq represents the PostgreSQL function of the same name, taking the same parameters.
 var xidneq = framework.Function2{
 	Name:       "xidneq",
 	Return:     pgtypes.Bool,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Xid, pgtypes.Xid},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Xid, pgtypes.Xid},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		res, err := pgtypes.Xid.Compare(val1.(uint32), val2.(uint32))
 		return res != 0, err
 	},
-	Strict: true,
 }

--- a/server/functions/binary/plus.go
+++ b/server/functions/binary/plus.go
@@ -50,170 +50,170 @@ func initBinaryPlus() {
 var float4pl = framework.Function2{
 	Name:       "float4pl",
 	Return:     pgtypes.Float32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return val1.(float32) + val2.(float32), nil
 	},
-	Strict: true,
 }
 
 // float48pl represents the PostgreSQL function of the same name, taking the same parameters.
 var float48pl = framework.Function2{
 	Name:       "float48pl",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float32, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return float64(val1.(float32)) + val2.(float64), nil
 	},
-	Strict: true,
 }
 
 // float8pl represents the PostgreSQL function of the same name, taking the same parameters.
 var float8pl = framework.Function2{
 	Name:       "float8pl",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return val1.(float64) + val2.(float64), nil
 	},
-	Strict: true,
 }
 
 // float84pl represents the PostgreSQL function of the same name, taking the same parameters.
 var float84pl = framework.Function2{
 	Name:       "float84pl",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return val1.(float64) + float64(val2.(float32)), nil
 	},
-	Strict: true,
 }
 
 // int2pl represents the PostgreSQL function of the same name, taking the same parameters.
 var int2pl = framework.Function2{
 	Name:       "int2pl",
 	Return:     pgtypes.Int16,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int16)) + int64(val2.(int16))
 		if result > math.MaxInt16 || result < math.MinInt16 {
 			return nil, fmt.Errorf("smallint out of range")
 		}
 		return int16(result), nil
 	},
-	Strict: true,
 }
 
 // int24pl represents the PostgreSQL function of the same name, taking the same parameters.
 var int24pl = framework.Function2{
 	Name:       "int24pl",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int16)) + int64(val2.(int32))
 		if result > math.MaxInt16 || result < math.MinInt16 {
 			return nil, fmt.Errorf("integer out of range")
 		}
 		return int32(result), nil
 	},
-	Strict: true,
 }
 
 // int28pl represents the PostgreSQL function of the same name, taking the same parameters.
 var int28pl = framework.Function2{
 	Name:       "int28pl",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return plusOverflow(int64(val1.(int16)), val2.(int64))
 	},
-	Strict: true,
 }
 
 // int4pl represents the PostgreSQL function of the same name, taking the same parameters.
 var int4pl = framework.Function2{
 	Name:       "int4pl",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int32)) + int64(val2.(int32))
 		if result > math.MaxInt32 || result < math.MinInt32 {
 			return nil, fmt.Errorf("integer out of range")
 		}
 		return int32(result), nil
 	},
-	Strict: true,
 }
 
 // int42pl represents the PostgreSQL function of the same name, taking the same parameters.
 var int42pl = framework.Function2{
 	Name:       "int42pl",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int32)) + int64(val2.(int16))
 		if result > math.MaxInt32 || result < math.MinInt32 {
 			return nil, fmt.Errorf("integer out of range")
 		}
 		return int32(result), nil
 	},
-	Strict: true,
 }
 
 // int48pl represents the PostgreSQL function of the same name, taking the same parameters.
 var int48pl = framework.Function2{
 	Name:       "int48pl",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return plusOverflow(int64(val1.(int32)), val2.(int64))
 	},
-	Strict: true,
 }
 
 // int8pl represents the PostgreSQL function of the same name, taking the same parameters.
 var int8pl = framework.Function2{
 	Name:       "int8pl",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return plusOverflow(val1.(int64), val2.(int64))
 	},
-	Strict: true,
 }
 
 // int82pl represents the PostgreSQL function of the same name, taking the same parameters.
 var int82pl = framework.Function2{
 	Name:       "int82pl",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return plusOverflow(val1.(int64), int64(val2.(int16)))
 	},
-	Strict: true,
 }
 
 // int84pl represents the PostgreSQL function of the same name, taking the same parameters.
 var int84pl = framework.Function2{
 	Name:       "int84pl",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return plusOverflow(val1.(int64), int64(val2.(int32)))
 	},
-	Strict: true,
 }
 
 // numeric_add represents the PostgreSQL function of the same name, taking the same parameters.
 var numeric_add = framework.Function2{
 	Name:       "numeric_add",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return val1.(decimal.Decimal).Add(val2.(decimal.Decimal)), nil
 	},
-	Strict: true,
 }
 
 // plusOverflow is a convenience function that checks for overflow for int64 addition.

--- a/server/functions/binary/shift_left.go
+++ b/server/functions/binary/shift_left.go
@@ -35,31 +35,31 @@ func initBinaryShiftLeft() {
 var int2shl = framework.Function2{
 	Name:       "int2shl",
 	Return:     pgtypes.Int16,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return int16(int32(val1.(int16)) << val2.(int32)), nil
 	},
-	Strict: true,
 }
 
 // int4shl represents the PostgreSQL function of the same name, taking the same parameters.
 var int4shl = framework.Function2{
 	Name:       "int4shl",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return int32(val1.(int32) << val2.(int32)), nil
 	},
-	Strict: true,
 }
 
 // int8shl represents the PostgreSQL function of the same name, taking the same parameters.
 var int8shl = framework.Function2{
 	Name:       "int8shl",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return int64(val1.(int64) << int64(val2.(int32))), nil
 	},
-	Strict: true,
 }

--- a/server/functions/binary/shift_right.go
+++ b/server/functions/binary/shift_right.go
@@ -35,19 +35,20 @@ func initBinaryShiftRight() {
 var int2shr = framework.Function2{
 	Name:       "int2shr",
 	Return:     pgtypes.Int16,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return int16(int32(val1.(int16)) >> val2.(int32)), nil
 	},
-	Strict: true,
 }
 
 // int4shr represents the PostgreSQL function of the same name, taking the same parameters.
 var int4shr = framework.Function2{
 	Name:       "int4shr",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return int32(val1.(int32) >> val2.(int32)), nil
 	},
 }
@@ -56,8 +57,9 @@ var int4shr = framework.Function2{
 var int8shr = framework.Function2{
 	Name:       "int8shr",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return int64(val1.(int64) >> int64(val2.(int32))), nil
 	},
 }

--- a/server/functions/bit_length.go
+++ b/server/functions/bit_length.go
@@ -30,13 +30,13 @@ func initBitLength() {
 var bit_length_varchar = framework.Function1{
 	Name:       "bit_length",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
-		result, err := octet_length_varchar.Callable(ctx, val1)
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, t [2]pgtypes.DoltgresType, val1 any) (any, error) {
+		result, err := octet_length_varchar.Callable(ctx, t, val1)
 		if err != nil {
 			return nil, err
 		}
 		return result.(int32) * 8, nil
 	},
-	Strict: true,
 }

--- a/server/functions/btrim.go
+++ b/server/functions/btrim.go
@@ -30,13 +30,13 @@ func initBtrim() {
 var btrim_varchar_varchar = framework.Function2{
 	Name:       "btrim",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, str any, characters any) (any, error) {
-		result, err := ltrim_varchar_varchar.Callable(ctx, str, characters)
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, t [3]pgtypes.DoltgresType, str any, characters any) (any, error) {
+		result, err := ltrim_varchar_varchar.Callable(ctx, t, str, characters)
 		if err != nil {
 			return nil, err
 		}
-		return rtrim_varchar_varchar.Callable(ctx, result, characters)
+		return rtrim_varchar_varchar.Callable(ctx, t, result, characters)
 	},
-	Strict: true,
 }

--- a/server/functions/cbrt.go
+++ b/server/functions/cbrt.go
@@ -32,9 +32,9 @@ func initCbrt() {
 var cbrt_float64 = framework.Function1{
 	Name:       "cbrt",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return math.Cbrt(val1.(float64)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/ceil.go
+++ b/server/functions/ceil.go
@@ -41,20 +41,20 @@ func initCeil() {
 var ceil_float64 = framework.Function1{
 	Name:       "ceil",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return math.Ceil(val1.(float64)), nil
 	},
-	Strict: true,
 }
 
 // ceil_numeric represents the PostgreSQL function of the same name, taking the same parameters.
 var ceil_numeric = framework.Function1{
 	Name:       "ceil",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return val1.(decimal.Decimal).Ceil(), nil
 	},
-	Strict: true,
 }

--- a/server/functions/char_length.go
+++ b/server/functions/char_length.go
@@ -34,9 +34,9 @@ func initCharLength() {
 var char_length_varchar = framework.Function1{
 	Name:       "char_length",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return int32(len([]rune(val1.(string)))), nil
 	},
-	Strict: true,
 }

--- a/server/functions/chr.go
+++ b/server/functions/chr.go
@@ -33,8 +33,9 @@ func initChr() {
 var chr_int32 = framework.Function1{
 	Name:       "chr",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1Interface any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1Interface any) (any, error) {
 		val1 := val1Interface.(int32)
 		if val1 == 0 {
 			return nil, fmt.Errorf("null character not permitted")
@@ -47,5 +48,4 @@ var chr_int32 = framework.Function1{
 		}
 		return string(r), nil
 	},
-	Strict: true,
 }

--- a/server/functions/cos.go
+++ b/server/functions/cos.go
@@ -32,9 +32,9 @@ func initCos() {
 var cos_float64 = framework.Function1{
 	Name:       "cos",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return math.Cos(val1.(float64)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/cosd.go
+++ b/server/functions/cosd.go
@@ -32,9 +32,9 @@ func initCosd() {
 var cosd_float64 = framework.Function1{
 	Name:       "cosd",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return math.Cos(toRadians(val1.(float64))), nil
 	},
-	Strict: true,
 }

--- a/server/functions/cosh.go
+++ b/server/functions/cosh.go
@@ -32,9 +32,9 @@ func initCosh() {
 var cosh_float64 = framework.Function1{
 	Name:       "cosh",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return math.Cosh(val1.(float64)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/cot.go
+++ b/server/functions/cot.go
@@ -32,13 +32,13 @@ func initCot() {
 var cot_float64 = framework.Function1{
 	Name:       "cot",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1Interface any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1Interface any) (any, error) {
 		val1 := val1Interface.(float64)
 		if val1 == 0 {
 			return math.Inf(1), nil
 		}
 		return math.Cos(val1) / math.Sin(val1), nil
 	},
-	Strict: true,
 }

--- a/server/functions/cotd.go
+++ b/server/functions/cotd.go
@@ -32,13 +32,13 @@ func initCotd() {
 var cotd_float64 = framework.Function1{
 	Name:       "cotd",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1Interface any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1Interface any) (any, error) {
 		val1 := toRadians(val1Interface.(float64))
 		if val1 == 0 {
 			return math.Inf(1), nil
 		}
 		return math.Cos(val1) / math.Sin(val1), nil
 	},
-	Strict: true,
 }

--- a/server/functions/current_catalog.go
+++ b/server/functions/current_catalog.go
@@ -30,13 +30,12 @@ func initCurrentCatalog() {
 var current_catalog = framework.Function0{
 	Name:               "current_catalog",
 	Return:             pgtypes.Name,
-	Parameters:         []pgtypes.DoltgresType{},
 	IsNonDeterministic: true,
+	Strict:             true,
 	Callable: func(ctx *sql.Context) (any, error) {
 		if ctx.GetCurrentDatabase() == "" {
 			return nil, nil
 		}
 		return ctx.GetCurrentDatabase(), nil
 	},
-	Strict: true,
 }

--- a/server/functions/current_database.go
+++ b/server/functions/current_database.go
@@ -30,13 +30,12 @@ func initCurrentDatabase() {
 var current_database = framework.Function0{
 	Name:               "current_database",
 	Return:             pgtypes.Name,
-	Parameters:         []pgtypes.DoltgresType{},
 	IsNonDeterministic: true,
+	Strict:             true,
 	Callable: func(ctx *sql.Context) (any, error) {
 		if ctx.GetCurrentDatabase() == "" {
 			return nil, nil
 		}
 		return ctx.GetCurrentDatabase(), nil
 	},
-	Strict: true,
 }

--- a/server/functions/current_schema.go
+++ b/server/functions/current_schema.go
@@ -31,8 +31,8 @@ func initCurrentSchema() {
 var current_schema = framework.Function0{
 	Name:               "current_schema",
 	Return:             pgtypes.Name,
-	Parameters:         []pgtypes.DoltgresType{},
 	IsNonDeterministic: true,
+	Strict:             true,
 	Callable: func(ctx *sql.Context) (any, error) {
 		schemas, err := resolve.SearchPath(ctx)
 		if err != nil {
@@ -43,5 +43,4 @@ var current_schema = framework.Function0{
 		}
 		return schemas[0], nil
 	},
-	Strict: true,
 }

--- a/server/functions/current_schemas.go
+++ b/server/functions/current_schemas.go
@@ -33,11 +33,12 @@ func initCurrentSchemas() {
 var current_schemas = framework.Function1{
 	Name:               "current_schemas",
 	Return:             pgtypes.NameArray,
-	Parameters:         []pgtypes.DoltgresType{pgtypes.Bool},
+	Parameters:         [1]pgtypes.DoltgresType{pgtypes.Bool},
 	IsNonDeterministic: true,
-	Callable: func(ctx *sql.Context, val any) (any, error) {
+	Strict:             true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		schemas := make([]any, 0)
-		if val.(bool) {
+		if val1.(bool) {
 			schemas = append(schemas, sessiondata.PgCatalogName)
 		}
 		searchPaths, err := resolve.SearchPath(ctx)
@@ -49,5 +50,4 @@ var current_schemas = framework.Function1{
 		}
 		return schemas, nil
 	},
-	Strict: true,
 }

--- a/server/functions/degrees.go
+++ b/server/functions/degrees.go
@@ -32,11 +32,11 @@ func initDegrees() {
 var degrees_float64 = framework.Function1{
 	Name:       "degrees",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return toDegrees(val1.(float64)), nil
 	},
-	Strict: true,
 }
 
 // toDegrees converts the given radians to degrees.

--- a/server/functions/div.go
+++ b/server/functions/div.go
@@ -33,8 +33,9 @@ func initDiv() {
 var div_numeric = framework.Function2{
 	Name:       "div",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1Interface any, val2Interface any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1Interface any, val2Interface any) (any, error) {
 		val1 := val1Interface.(decimal.Decimal)
 		val2 := val2Interface.(decimal.Decimal)
 		if val2.Cmp(decimal.Zero) == 0 {
@@ -43,5 +44,4 @@ var div_numeric = framework.Function2{
 		val := val1.Div(val2)
 		return val.Truncate(0), nil
 	},
-	Strict: true,
 }

--- a/server/functions/exp.go
+++ b/server/functions/exp.go
@@ -34,23 +34,23 @@ func initExp() {
 var exp_float64 = framework.Function1{
 	Name:       "exp",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return math.Exp(val1.(float64)), nil
 	},
-	Strict: true,
 }
 
 // exp_numeric represents the PostgreSQL function of the same name, taking the same parameters.
 var exp_numeric = framework.Function1{
 	Name:       "exp",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		if val1 == nil {
 			return nil, nil
 		}
 		return val1.(decimal.Decimal).ExpHullAbrham(32)
 	},
-	Strict: true,
 }

--- a/server/functions/factorial.go
+++ b/server/functions/factorial.go
@@ -33,8 +33,9 @@ func initFactorial() {
 var factorial_int64 = framework.Function1{
 	Name:       "factorial",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1Interface any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1Interface any) (any, error) {
 		val1 := val1Interface.(int64)
 		if val1 < 0 {
 			return nil, fmt.Errorf("factorial of a negative number is undefined")
@@ -45,5 +46,4 @@ var factorial_int64 = framework.Function1{
 		}
 		return decimal.NewFromInt(total), nil
 	},
-	Strict: true,
 }

--- a/server/functions/floor.go
+++ b/server/functions/floor.go
@@ -34,23 +34,23 @@ func initFloor() {
 var floor_float64 = framework.Function1{
 	Name:       "floor",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return math.Floor(val1.(float64)), nil
 	},
-	Strict: true,
 }
 
 // floor_numeric represents the PostgreSQL function of the same name, taking the same parameters.
 var floor_numeric = framework.Function1{
 	Name:       "floor",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		if val1 == nil {
 			return nil, nil
 		}
 		return val1.(decimal.Decimal).Floor(), nil
 	},
-	Strict: true,
 }

--- a/server/functions/framework/functions.go
+++ b/server/functions/framework/functions.go
@@ -43,50 +43,56 @@ type FunctionInterface interface {
 type Function0 struct {
 	Name               string
 	Return             pgtypes.DoltgresType
-	Parameters         []pgtypes.DoltgresType
 	IsNonDeterministic bool
 	Strict             bool
 	Callable           func(ctx *sql.Context) (any, error)
 }
 
-// Function1 is a function that takes one parameter.
+// Function1 is a function that takes one parameter. The parameter and return type is passed into the Callable function
+// when the parameter (and possibly return type) is a polymorphic type. The return type is the last type in the array.
 type Function1 struct {
 	Name               string
 	Return             pgtypes.DoltgresType
-	Parameters         []pgtypes.DoltgresType
+	Parameters         [1]pgtypes.DoltgresType
 	IsNonDeterministic bool
 	Strict             bool
-	Callable           func(ctx *sql.Context, val1 any) (any, error)
+	Callable           func(ctx *sql.Context, paramsAndReturn [2]pgtypes.DoltgresType, val1 any) (any, error)
 }
 
-// Function2 is a function that takes two parameters.
+// Function2 is a function that takes two parameters. The parameter and return types are passed into the Callable
+// function when the parameters (and possibly return type) have at least one polymorphic type. The return type is the
+// last type in the array.
 type Function2 struct {
 	Name               string
 	Return             pgtypes.DoltgresType
-	Parameters         []pgtypes.DoltgresType
+	Parameters         [2]pgtypes.DoltgresType
 	IsNonDeterministic bool
 	Strict             bool
-	Callable           func(ctx *sql.Context, val1 any, val2 any) (any, error)
+	Callable           func(ctx *sql.Context, paramsAndReturn [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error)
 }
 
-// Function3 is a function that takes three parameters.
+// Function3 is a function that takes three parameters. The parameter and return types are passed into the Callable
+// function when the parameters (and possibly return type) have at least one polymorphic type. The return type is the
+// last type in the array.
 type Function3 struct {
 	Name               string
 	Return             pgtypes.DoltgresType
-	Parameters         []pgtypes.DoltgresType
+	Parameters         [3]pgtypes.DoltgresType
 	IsNonDeterministic bool
 	Strict             bool
-	Callable           func(ctx *sql.Context, val1 any, val2 any, val3 any) (any, error)
+	Callable           func(ctx *sql.Context, paramsAndReturn [4]pgtypes.DoltgresType, val1 any, val2 any, val3 any) (any, error)
 }
 
-// Function4 is a function that takes four parameters.
+// Function4 is a function that takes four parameters. The parameter and return types are passed into the Callable
+// function when the parameters (and possibly return type) have at least one polymorphic type. The return type is the
+// last type in the array.
 type Function4 struct {
 	Name               string
 	Return             pgtypes.DoltgresType
-	Parameters         []pgtypes.DoltgresType
+	Parameters         [4]pgtypes.DoltgresType
 	IsNonDeterministic bool
 	Strict             bool
-	Callable           func(ctx *sql.Context, val1 any, val2 any, val3 any, val4 any) (any, error)
+	Callable           func(ctx *sql.Context, paramsAndReturn [5]pgtypes.DoltgresType, val1 any, val2 any, val3 any, val4 any) (any, error)
 }
 
 var _ FunctionInterface = Function0{}
@@ -102,7 +108,7 @@ func (f Function0) GetName() string { return f.Name }
 func (f Function0) GetReturn() pgtypes.DoltgresType { return f.Return }
 
 // GetParameters implements the FunctionInterface interface.
-func (f Function0) GetParameters() []pgtypes.DoltgresType { return f.Parameters }
+func (f Function0) GetParameters() []pgtypes.DoltgresType { return nil }
 
 // GetExpectedParameterCount implements the FunctionInterface interface.
 func (f Function0) GetExpectedParameterCount() int { return 0 }
@@ -123,7 +129,7 @@ func (f Function1) GetName() string { return f.Name }
 func (f Function1) GetReturn() pgtypes.DoltgresType { return f.Return }
 
 // GetParameters implements the FunctionInterface interface.
-func (f Function1) GetParameters() []pgtypes.DoltgresType { return f.Parameters }
+func (f Function1) GetParameters() []pgtypes.DoltgresType { return f.Parameters[:] }
 
 // GetExpectedParameterCount implements the FunctionInterface interface.
 func (f Function1) GetExpectedParameterCount() int { return 1 }
@@ -144,7 +150,7 @@ func (f Function2) GetName() string { return f.Name }
 func (f Function2) GetReturn() pgtypes.DoltgresType { return f.Return }
 
 // GetParameters implements the FunctionInterface interface.
-func (f Function2) GetParameters() []pgtypes.DoltgresType { return f.Parameters }
+func (f Function2) GetParameters() []pgtypes.DoltgresType { return f.Parameters[:] }
 
 // GetExpectedParameterCount implements the FunctionInterface interface.
 func (f Function2) GetExpectedParameterCount() int { return 2 }
@@ -165,7 +171,7 @@ func (f Function3) GetName() string { return f.Name }
 func (f Function3) GetReturn() pgtypes.DoltgresType { return f.Return }
 
 // GetParameters implements the FunctionInterface interface.
-func (f Function3) GetParameters() []pgtypes.DoltgresType { return f.Parameters }
+func (f Function3) GetParameters() []pgtypes.DoltgresType { return f.Parameters[:] }
 
 // GetExpectedParameterCount implements the FunctionInterface interface.
 func (f Function3) GetExpectedParameterCount() int { return 3 }
@@ -186,7 +192,7 @@ func (f Function4) GetName() string { return f.Name }
 func (f Function4) GetReturn() pgtypes.DoltgresType { return f.Return }
 
 // GetParameters implements the FunctionInterface interface.
-func (f Function4) GetParameters() []pgtypes.DoltgresType { return f.Parameters }
+func (f Function4) GetParameters() []pgtypes.DoltgresType { return f.Parameters[:] }
 
 // GetExpectedParameterCount implements the FunctionInterface interface.
 func (f Function4) GetExpectedParameterCount() int { return 4 }

--- a/server/functions/gcd.go
+++ b/server/functions/gcd.go
@@ -31,8 +31,9 @@ func initGcd() {
 var gcd_int64_int64 = framework.Function2{
 	Name:       "gcd",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1Interface any, val2Interface any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1Interface any, val2Interface any) (any, error) {
 		val1 := val1Interface.(int64)
 		val2 := val2Interface.(int64)
 		for val2 != 0 {
@@ -42,5 +43,4 @@ var gcd_int64_int64 = framework.Function2{
 		}
 		return utils.Abs(val1), nil
 	},
-	Strict: true,
 }

--- a/server/functions/init.go
+++ b/server/functions/init.go
@@ -20,6 +20,7 @@ func Init() {
 	initAcos()
 	initAcosd()
 	initAcosh()
+	initArrayAppend()
 	initAscii()
 	initAsin()
 	initAsind()

--- a/server/functions/initcap.go
+++ b/server/functions/initcap.go
@@ -33,9 +33,9 @@ func initInitcap() {
 var initcap_varchar = framework.Function1{
 	Name:       "initcap",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return cases.Title(language.English).String(val1.(string)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/lcm.go
+++ b/server/functions/lcm.go
@@ -33,14 +33,15 @@ func initLcm() {
 var lcm_int64_int64 = framework.Function2{
 	Name:       "lcm",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1Int any, val2Int any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, dt [3]pgtypes.DoltgresType, val1Int any, val2Int any) (any, error) {
 		val1 := val1Int.(int64)
 		val2 := val2Int.(int64)
 		if val1 == val2 {
 			return utils.Abs(val1), nil
 		}
-		gcdResultInterface, err := gcd_int64_int64.Callable(ctx, val1, val2)
+		gcdResultInterface, err := gcd_int64_int64.Callable(ctx, dt, val1, val2)
 		if err != nil {
 			return nil, err
 		}
@@ -55,5 +56,4 @@ var lcm_int64_int64 = framework.Function2{
 		}
 		return utils.Abs(result / gcdResult), nil
 	},
-	Strict: true,
 }

--- a/server/functions/left.go
+++ b/server/functions/left.go
@@ -30,8 +30,9 @@ func initLeft() {
 var left_varchar_int32 = framework.Function2{
 	Name:       "left",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, strInt any, nInt any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, strInt any, nInt any) (any, error) {
 		str := strInt.(string)
 		n := nInt.(int32)
 		if n >= 0 {
@@ -46,5 +47,4 @@ var left_varchar_int32 = framework.Function2{
 			return str[:len(str)+int(n)], nil
 		}
 	},
-	Strict: true,
 }

--- a/server/functions/length.go
+++ b/server/functions/length.go
@@ -30,9 +30,9 @@ func initLength() {
 var length_varchar = framework.Function1{
 	Name:       "length",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return int32(len([]rune(val1.(string)))), nil
 	},
-	Strict: true,
 }

--- a/server/functions/ln.go
+++ b/server/functions/ln.go
@@ -35,8 +35,9 @@ func initLn() {
 var ln_float64 = framework.Function1{
 	Name:       "ln",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		if val1.(float64) == 0 {
 			return nil, fmt.Errorf("cannot take logarithm of zero")
 		} else if val1.(float64) < 0 {
@@ -44,15 +45,15 @@ var ln_float64 = framework.Function1{
 		}
 		return math.Log(val1.(float64)), nil
 	},
-	Strict: true,
 }
 
 // ln_numeric represents the PostgreSQL function of the same name, taking the same parameters.
 var ln_numeric = framework.Function1{
 	Name:       "ln",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		if val1 == nil {
 			return nil, nil
 		}
@@ -65,5 +66,4 @@ var ln_numeric = framework.Function1{
 		}
 		return decimal.NewFromFloat(math.Log(f)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/log.go
+++ b/server/functions/log.go
@@ -36,8 +36,9 @@ func initLog() {
 var log_float64 = framework.Function1{
 	Name:       "log",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1Interface any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1Interface any) (any, error) {
 		val1 := val1Interface.(float64)
 		if val1 == 0 {
 			return nil, fmt.Errorf("cannot take logarithm of zero")
@@ -46,15 +47,15 @@ var log_float64 = framework.Function1{
 		}
 		return math.Log10(val1), nil
 	},
-	Strict: true,
 }
 
 // log_numeric represents the PostgreSQL function of the same name, taking the same parameters.
 var log_numeric = framework.Function1{
 	Name:       "log",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1Interface any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1Interface any) (any, error) {
 		if val1Interface == nil {
 			return nil, nil
 		}
@@ -68,15 +69,15 @@ var log_numeric = framework.Function1{
 		f, _ := val1.Float64()
 		return decimal.NewFromFloat(math.Log10(f)), nil
 	},
-	Strict: true,
 }
 
 // log_numeric_numeric represents the PostgreSQL function of the same name, taking the same parameters.
 var log_numeric_numeric = framework.Function2{
 	Name:       "log",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1Interface any, val2Interface any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1Interface any, val2Interface any) (any, error) {
 		if val1Interface == nil || val2Interface == nil {
 			return nil, nil
 		}
@@ -97,5 +98,4 @@ var log_numeric_numeric = framework.Function2{
 		}
 		return decimal.NewFromFloat(logNum / logBase), nil
 	},
-	Strict: true,
 }

--- a/server/functions/lower.go
+++ b/server/functions/lower.go
@@ -32,10 +32,10 @@ func initLower() {
 var lower_varchar = framework.Function1{
 	Name:       "lower",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		//TODO: this doesn't respect collations
 		return strings.ToLower(val1.(string)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/lpad.go
+++ b/server/functions/lpad.go
@@ -31,19 +31,21 @@ func initLpad() {
 var lpad_varchar_int32 = framework.Function2{
 	Name:       "lpad",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
-		return lpad_varchar_int32_varchar.Callable(ctx, val1, val2, " ")
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
+		var unusedTypes [4]pgtypes.DoltgresType
+		return lpad_varchar_int32_varchar.Callable(ctx, unusedTypes, val1, val2, " ")
 	},
-	Strict: true,
 }
 
 // lpad_varchar_int32_varchar represents the PostgreSQL function of the same name, taking the same parameters.
 var lpad_varchar_int32_varchar = framework.Function3{
 	Name:       "lpad",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32, pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, str any, length any, fill any) (any, error) {
+	Parameters: [3]pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32, pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [4]pgtypes.DoltgresType, str any, length any, fill any) (any, error) {
 		if length.(int32) <= 0 {
 			return "", nil
 		}
@@ -60,5 +62,4 @@ var lpad_varchar_int32_varchar = framework.Function3{
 		result = append(result, runes...)
 		return string(result[:length.(int32)]), nil
 	},
-	Strict: true,
 }

--- a/server/functions/ltrim.go
+++ b/server/functions/ltrim.go
@@ -31,19 +31,21 @@ func initLtrim() {
 var ltrim_varchar = framework.Function1{
 	Name:       "ltrim",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
-		return ltrim_varchar_varchar.Callable(ctx, val1, " ")
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
+		var unusedTypes [3]pgtypes.DoltgresType
+		return ltrim_varchar_varchar.Callable(ctx, unusedTypes, val1, " ")
 	},
-	Strict: true,
 }
 
 // ltrim_varchar_varchar represents the PostgreSQL function of the same name, taking the same parameters.
 var ltrim_varchar_varchar = framework.Function2{
 	Name:       "ltrim",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, str any, characters any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, str any, characters any) (any, error) {
 		runes := []rune(str.(string))
 		trimChars := make(map[rune]struct{})
 		for _, c := range characters.(string) {
@@ -57,5 +59,4 @@ var ltrim_varchar_varchar = framework.Function2{
 		}
 		return string(runes[trimIdx:]), nil
 	},
-	Strict: true,
 }

--- a/server/functions/md5.go
+++ b/server/functions/md5.go
@@ -33,9 +33,9 @@ func initMd5() {
 var md5_varchar = framework.Function1{
 	Name:       "md5",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return fmt.Sprintf("%x", md5_package.Sum([]byte(val1.(string)))), nil
 	},
-	Strict: true,
 }

--- a/server/functions/min_scale.go
+++ b/server/functions/min_scale.go
@@ -33,8 +33,9 @@ func initMinScale() {
 var min_scale_numeric = framework.Function1{
 	Name:       "min_scale",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		str := val1.(decimal.Decimal).String()
 		if idx := strings.Index(str, "."); idx != -1 {
 			str = str[idx+1:]
@@ -48,5 +49,4 @@ var min_scale_numeric = framework.Function1{
 		}
 		return int32(0), nil
 	},
-	Strict: true,
 }

--- a/server/functions/mod.go
+++ b/server/functions/mod.go
@@ -36,54 +36,54 @@ func initMod() {
 var mod_int16_int16 = framework.Function2{
 	Name:       "mod",
 	Return:     pgtypes.Int16,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int16, pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int16) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(int16) % val2.(int16), nil
 	},
-	Strict: true,
 }
 
 // mod_int32_int32 represents the PostgreSQL function of the same name, taking the same parameters.
 var mod_int32_int32 = framework.Function2{
 	Name:       "mod",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int32) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(int32) % val2.(int32), nil
 	},
-	Strict: true,
 }
 
 // mod_int64_int64 represents the PostgreSQL function of the same name, taking the same parameters.
 var mod_int64_int64 = framework.Function2{
 	Name:       "mod",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int64) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(int64) % val2.(int64), nil
 	},
-	Strict: true,
 }
 
 // mod_numeric_numeric represents the PostgreSQL function of the same name, taking the same parameters.
 var mod_numeric_numeric = framework.Function2{
 	Name:       "mod",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(decimal.Decimal).Cmp(decimal.Zero) == 0 {
 			return nil, fmt.Errorf("division by zero")
 		}
 		return val1.(decimal.Decimal).Mod(val2.(decimal.Decimal)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/nextval.go
+++ b/server/functions/nextval.go
@@ -31,9 +31,10 @@ func initNextVal() {
 var nextval_text = framework.Function1{
 	Name:               "nextval",
 	Return:             pgtypes.Int64,
-	Parameters:         []pgtypes.DoltgresType{pgtypes.Text},
+	Parameters:         [1]pgtypes.DoltgresType{pgtypes.Text},
 	IsNonDeterministic: true,
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Strict:             true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		collection, err := core.GetCollectionFromContext(ctx)
 		if err != nil {
 			return nil, err
@@ -45,5 +46,4 @@ var nextval_text = framework.Function1{
 		}
 		return collection.NextVal(schema, val1.(string))
 	},
-	Strict: true,
 }

--- a/server/functions/octet_length.go
+++ b/server/functions/octet_length.go
@@ -30,9 +30,9 @@ func initOctetLength() {
 var octet_length_varchar = framework.Function1{
 	Name:       "octet_length",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return int32(len(val1.(string))), nil
 	},
-	Strict: true,
 }

--- a/server/functions/pi.go
+++ b/server/functions/pi.go
@@ -30,11 +30,10 @@ func initPi() {
 
 // pi represents the PostgreSQL function of the same name, taking the same parameters.
 var pi = framework.Function0{
-	Name:       "pi",
-	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{},
+	Name:   "pi",
+	Return: pgtypes.Float64,
+	Strict: true,
 	Callable: func(ctx *sql.Context) (any, error) {
 		return float64(math.Pi), nil
 	},
-	Strict: true,
 }

--- a/server/functions/power.go
+++ b/server/functions/power.go
@@ -34,19 +34,20 @@ func initPower() {
 var power_float64_float64 = framework.Function2{
 	Name:       "power",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return math.Pow(val1.(float64), val2.(float64)), nil
 	},
-	Strict: true,
 }
 
 // power_numeric_numeric represents the PostgreSQL function of the same name, taking the same parameters.
 var power_numeric_numeric = framework.Function2{
 	Name:       "power",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val1 == nil || val2 == nil {
 			return nil, nil
 		}
@@ -56,5 +57,4 @@ var power_numeric_numeric = framework.Function2{
 		}
 		return val1.(decimal.Decimal).Pow(val2.(decimal.Decimal)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/radians.go
+++ b/server/functions/radians.go
@@ -32,11 +32,11 @@ func initRadians() {
 var radians_float64 = framework.Function1{
 	Name:       "radians",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return toRadians(val1.(float64)), nil
 	},
-	Strict: true,
 }
 
 // toRadians converts the given degrees to radians.

--- a/server/functions/random.go
+++ b/server/functions/random.go
@@ -30,11 +30,11 @@ func initRandom() {
 
 // random represents the PostgreSQL function of the same name, taking the same parameters.
 var random = framework.Function0{
-	Name:       "random",
-	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{},
+	Name:               "random",
+	Return:             pgtypes.Float64,
+	IsNonDeterministic: true,
+	Strict:             true,
 	Callable: func(ctx *sql.Context) (any, error) {
 		return rand.Float64(), nil
 	},
-	Strict: true,
 }

--- a/server/functions/repeat.go
+++ b/server/functions/repeat.go
@@ -32,9 +32,9 @@ func initRepeat() {
 var repeat_varchar_int32 = framework.Function2{
 	Name:       "repeat",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, str any, num any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, str any, num any) (any, error) {
 		return strings.Repeat(str.(string), int(num.(int32))), nil
 	},
-	Strict: true,
 }

--- a/server/functions/replace.go
+++ b/server/functions/replace.go
@@ -32,12 +32,12 @@ func initReplace() {
 var replace_varchar_varchar_varchar = framework.Function3{
 	Name:       "replace",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.VarChar, pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, str any, from any, to any) (any, error) {
+	Parameters: [3]pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.VarChar, pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [4]pgtypes.DoltgresType, str any, from any, to any) (any, error) {
 		if len(from.(string)) == 0 {
 			return str, nil
 		}
 		return strings.ReplaceAll(str.(string), from.(string), to.(string)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/right.go
+++ b/server/functions/right.go
@@ -30,8 +30,9 @@ func initRight() {
 var right_varchar_int32 = framework.Function2{
 	Name:       "right",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, strInt any, nInt any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, strInt any, nInt any) (any, error) {
 		str := strInt.(string)
 		n := nInt.(int32)
 		if n >= 0 {
@@ -46,5 +47,4 @@ var right_varchar_int32 = framework.Function2{
 			return str[int(-n):], nil
 		}
 	},
-	Strict: true,
 }

--- a/server/functions/round.go
+++ b/server/functions/round.go
@@ -35,37 +35,37 @@ func initRound() {
 var round_float64 = framework.Function1{
 	Name:       "round",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		if val1 == nil {
 			return nil, nil
 		}
 		return math.RoundToEven(val1.(float64)), nil
 	},
-	Strict: true,
 }
 
 // round_numeric represents the PostgreSQL function of the same name, taking the same parameters.
 var round_numeric = framework.Function1{
 	Name:       "round",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		if val1 == nil {
 			return nil, nil
 		}
 		return val1.(decimal.Decimal).Round(0), nil
 	},
-	Strict: true,
 }
 
 // round_numeric_int64 represents the PostgreSQL function of the same name, taking the same parameters.
 var round_numeric_int64 = framework.Function2{
 	Name:       "round",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		return val1.(decimal.Decimal).Round(int32(val2.(int64))), nil
 	},
-	Strict: true,
 }

--- a/server/functions/rpad.go
+++ b/server/functions/rpad.go
@@ -31,19 +31,21 @@ func initRpad() {
 var rpad_varchar_int32 = framework.Function2{
 	Name:       "rpad",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
-		return rpad_varchar_int32_varchar.Callable(ctx, val1, val2, " ")
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
+		var unusedTypes [4]pgtypes.DoltgresType
+		return rpad_varchar_int32_varchar.Callable(ctx, unusedTypes, val1, val2, " ")
 	},
-	Strict: true,
 }
 
 // rpad_varchar_int32_varchar represents the PostgreSQL function of the same name, taking the same parameters.
 var rpad_varchar_int32_varchar = framework.Function3{
 	Name:       "rpad",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32, pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, str any, length any, fill any) (any, error) {
+	Parameters: [3]pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32, pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [4]pgtypes.DoltgresType, str any, length any, fill any) (any, error) {
 		if length.(int32) <= 0 {
 			return "", nil
 		}
@@ -54,5 +56,4 @@ var rpad_varchar_int32_varchar = framework.Function3{
 		}
 		return string(runes[:length.(int32)]), nil
 	},
-	Strict: true,
 }

--- a/server/functions/rtrim.go
+++ b/server/functions/rtrim.go
@@ -31,19 +31,21 @@ func initRtrim() {
 var rtrim_varchar = framework.Function1{
 	Name:       "rtrim",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
-		return rtrim_varchar_varchar.Callable(ctx, val1, " ")
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
+		var unusedTypes [3]pgtypes.DoltgresType
+		return rtrim_varchar_varchar.Callable(ctx, unusedTypes, val1, " ")
 	},
-	Strict: true,
 }
 
 // rtrim_varchar_varchar represents the PostgreSQL function of the same name, taking the same parameters.
 var rtrim_varchar_varchar = framework.Function2{
 	Name:       "rtrim",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, str any, characters any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, str any, characters any) (any, error) {
 		runes := []rune(str.(string))
 		trimChars := make(map[rune]struct{})
 		for _, c := range characters.(string) {
@@ -57,5 +59,4 @@ var rtrim_varchar_varchar = framework.Function2{
 		}
 		return string(runes[:trimIdx]), nil
 	},
-	Strict: true,
 }

--- a/server/functions/scale.go
+++ b/server/functions/scale.go
@@ -31,13 +31,13 @@ func initScale() {
 var scale_numeric = framework.Function1{
 	Name:       "scale",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
-		res, err := min_scale_numeric.Callable(ctx, val1)
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, dt [2]pgtypes.DoltgresType, val1 any) (any, error) {
+		res, err := min_scale_numeric.Callable(ctx, dt, val1)
 		if res != nil {
 			return res.(int32), err
 		}
 		return nil, err
 	},
-	Strict: true,
 }

--- a/server/functions/setval.go
+++ b/server/functions/setval.go
@@ -32,21 +32,23 @@ func initSetVal() {
 var setval_text_int64 = framework.Function2{
 	Name:               "setval",
 	Return:             pgtypes.Int64,
-	Parameters:         []pgtypes.DoltgresType{pgtypes.Text, pgtypes.Int64},
+	Parameters:         [2]pgtypes.DoltgresType{pgtypes.Text, pgtypes.Int64},
 	IsNonDeterministic: true,
-	Callable: func(ctx *sql.Context, val1 any, val2 any) (any, error) {
-		return setval_text_int64_boolean.Callable(ctx, val1, val2, true)
+	Strict:             true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
+		var unusedTypes [4]pgtypes.DoltgresType
+		return setval_text_int64_boolean.Callable(ctx, unusedTypes, val1, val2, true)
 	},
-	Strict: true,
 }
 
 // setval_text_int64_boolean represents the PostgreSQL function of the same name, taking the same parameters.
 var setval_text_int64_boolean = framework.Function3{
 	Name:               "setval",
 	Return:             pgtypes.Int64,
-	Parameters:         []pgtypes.DoltgresType{pgtypes.Text, pgtypes.Int64, pgtypes.Bool},
+	Parameters:         [3]pgtypes.DoltgresType{pgtypes.Text, pgtypes.Int64, pgtypes.Bool},
 	IsNonDeterministic: true,
-	Callable: func(ctx *sql.Context, val1 any, val2 any, val3 any) (any, error) {
+	Strict:             true,
+	Callable: func(ctx *sql.Context, _ [4]pgtypes.DoltgresType, val1 any, val2 any, val3 any) (any, error) {
 		collection, err := core.GetCollectionFromContext(ctx)
 		if err != nil {
 			return nil, err
@@ -59,5 +61,4 @@ var setval_text_int64_boolean = framework.Function3{
 
 		return val2.(int64), collection.SetVal(schema, val1.(string), val2.(int64), val3.(bool))
 	},
-	Strict: true,
 }

--- a/server/functions/sign.go
+++ b/server/functions/sign.go
@@ -33,8 +33,9 @@ func initSign() {
 var sign_float64 = framework.Function1{
 	Name:       "sign",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		if val1.(float64) < 0 {
 			return float64(-1), nil
 		} else if val1.(float64) > 0 {
@@ -43,15 +44,15 @@ var sign_float64 = framework.Function1{
 			return float64(0), nil
 		}
 	},
-	Strict: true,
 }
 
 // sign_numeric represents the PostgreSQL function of the same name, taking the same parameters.
 var sign_numeric = framework.Function1{
 	Name:       "sign",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return decimal.NewFromInt(int64(val1.(decimal.Decimal).Cmp(decimal.Zero))), nil
 	},
 }

--- a/server/functions/sin.go
+++ b/server/functions/sin.go
@@ -32,9 +32,9 @@ func initSin() {
 var sin_float64 = framework.Function1{
 	Name:       "sin",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return math.Sin(val1.(float64)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/sind.go
+++ b/server/functions/sind.go
@@ -32,9 +32,9 @@ func initSind() {
 var sind_float64 = framework.Function1{
 	Name:       "sind",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return math.Sin(toRadians(val1.(float64))), nil
 	},
-	Strict: true,
 }

--- a/server/functions/sinh.go
+++ b/server/functions/sinh.go
@@ -32,9 +32,9 @@ func initSinh() {
 var sinh_float64 = framework.Function1{
 	Name:       "sinh",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return math.Sinh(val1.(float64)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/split_part.go
+++ b/server/functions/split_part.go
@@ -34,8 +34,9 @@ func initSplitPart() {
 var split_part_varchar_varchar_int32 = framework.Function3{
 	Name:       "split_part",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.VarChar, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, str any, delimiter any, n any) (any, error) {
+	Parameters: [3]pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.VarChar, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [4]pgtypes.DoltgresType, str any, delimiter any, n any) (any, error) {
 		if n.(int32) == 0 {
 			return nil, fmt.Errorf("field position must not be zero")
 		}
@@ -54,5 +55,4 @@ var split_part_varchar_varchar_int32 = framework.Function3{
 			return parts[int32(len(parts))+n.(int32)], nil
 		}
 	},
-	Strict: true,
 }

--- a/server/functions/sqrt.go
+++ b/server/functions/sqrt.go
@@ -35,8 +35,9 @@ func initSqrt() {
 var sqrt_float64 = framework.Function1{
 	Name:       "sqrt",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		if val1 == nil {
 			return nil, nil
 		}
@@ -45,20 +46,19 @@ var sqrt_float64 = framework.Function1{
 		}
 		return math.Sqrt(val1.(float64)), nil
 	},
-	Strict: true,
 }
 
 // sqrt_numeric represents the PostgreSQL function of the same name, taking the same parameters.
 var sqrt_numeric = framework.Function1{
 	Name:       "sqrt",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		if val1.(decimal.Decimal).Cmp(decimal.Zero) == -1 {
 			return nil, fmt.Errorf("cannot take square root of a negative number")
 		}
 		// TODO: decimal's Pow function does not work correctly using an exponent of 0.5, need to fix
 		return decimal.NewFromFloat(math.Sqrt(val1.(decimal.Decimal).InexactFloat64())), nil
 	},
-	Strict: true,
 }

--- a/server/functions/strpos.go
+++ b/server/functions/strpos.go
@@ -32,13 +32,13 @@ func initStrpos() {
 var strpos_varchar = framework.Function2{
 	Name:       "strpos",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, str any, substring any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, str any, substring any) (any, error) {
 		idx := strings.Index(str.(string), substring.(string))
 		if idx == -1 {
 			return int32(0), nil
 		}
 		return int32(idx + 1), nil
 	},
-	Strict: true,
 }

--- a/server/functions/substr.go
+++ b/server/functions/substr.go
@@ -33,11 +33,9 @@ func initSubstr() {
 var substr_varchar_int32 = framework.Function2{
 	Name:       "substr",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, str any, start any) (any, error) {
-		if str == nil || start == nil {
-			return nil, nil
-		}
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, str any, start any) (any, error) {
 		runes := []rune(str.(string))
 		if start.(int32) < 1 {
 			start = int32(1)
@@ -49,15 +47,15 @@ var substr_varchar_int32 = framework.Function2{
 		}
 		return string(runes[start.(int32):]), nil
 	},
-	Strict: true,
 }
 
 // substr_varchar_int32_int32 represents the PostgreSQL function of the same name, taking the same parameters.
 var substr_varchar_int32_int32 = framework.Function3{
 	Name:       "substr",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, str any, startInt any, countInt any) (any, error) {
+	Parameters: [3]pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.Int32, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [4]pgtypes.DoltgresType, str any, startInt any, countInt any) (any, error) {
 		start := startInt.(int32)
 		count := countInt.(int32)
 		runes := []rune(str.(string))
@@ -80,5 +78,4 @@ var substr_varchar_int32_int32 = framework.Function3{
 		}
 		return string(runes[start : start+count]), nil
 	},
-	Strict: true,
 }

--- a/server/functions/tan.go
+++ b/server/functions/tan.go
@@ -32,9 +32,9 @@ func initTan() {
 var tan_float64 = framework.Function1{
 	Name:       "tan",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return math.Tan(val1.(float64)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/tand.go
+++ b/server/functions/tand.go
@@ -32,9 +32,9 @@ func initTand() {
 var tand_float64 = framework.Function1{
 	Name:       "tand",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return math.Tan(toRadians(val1.(float64))), nil
 	},
-	Strict: true,
 }

--- a/server/functions/tanh.go
+++ b/server/functions/tanh.go
@@ -32,9 +32,9 @@ func initTanh() {
 var tanh_float64 = framework.Function1{
 	Name:       "tanh",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return math.Tanh(val1.(float64)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/to_hex.go
+++ b/server/functions/to_hex.go
@@ -32,9 +32,9 @@ func initToHex() {
 var to_hex_int64 = framework.Function1{
 	Name:       "to_hex",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return fmt.Sprintf("%x", uint64(val1.(int64))), nil
 	},
-	Strict: true,
 }

--- a/server/functions/trim_scale.go
+++ b/server/functions/trim_scale.go
@@ -32,11 +32,11 @@ func initTrimScale() {
 var trim_scale_numeric = framework.Function1{
 	Name:       "trim_scale",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		// We don't store the scale in the value, so I'm not sure if this is functionally correct.
 		// Seems like we'd need to modify the type of the return value (by trimming the scale), rather than the value itself.
 		return val1.(decimal.Decimal), nil
 	},
-	Strict: true,
 }

--- a/server/functions/trunc.go
+++ b/server/functions/trunc.go
@@ -35,38 +35,38 @@ func initTrunc() {
 var trunc_float64 = framework.Function1{
 	Name:       "trunc",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		if val1 == nil {
 			return nil, nil
 		}
 		return math.Trunc(val1.(float64)), nil
 	},
-	Strict: true,
 }
 
 // trunc_numeric represents the PostgreSQL function of the same name, taking the same parameters.
 var trunc_numeric = framework.Function1{
 	Name:       "trunc",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		if val1 == nil {
 			return nil, nil
 		}
 		return decimal.NewFromInt(val1.(decimal.Decimal).IntPart()), nil
 	},
-	Strict: true,
 }
 
 // trunc_numeric_int64 represents the PostgreSQL function of the same name, taking the same parameters.
 var trunc_numeric_int64 = framework.Function2{
 	Name:       "trunc",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, num any, places any) (any, error) {
+	Parameters: [2]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, num any, places any) (any, error) {
 		//TODO: test for negative values in places
 		return num.(decimal.Decimal).Truncate(places.(int32)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/unary/minus.go
+++ b/server/functions/unary/minus.go
@@ -39,64 +39,64 @@ func initUnaryMinus() {
 var float4um = framework.Function1{
 	Name:       "float4um",
 	Return:     pgtypes.Float32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return -(val1.(float32)), nil
 	},
-	Strict: true,
 }
 
 // float8um represents the PostgreSQL function of the same name, taking the same parameters.
 var float8um = framework.Function1{
 	Name:       "float8um",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return -(val1.(float64)), nil
 	},
-	Strict: true,
 }
 
 // int2um represents the PostgreSQL function of the same name, taking the same parameters.
 var int2um = framework.Function1{
 	Name:       "int2um",
 	Return:     pgtypes.Int16,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return -(val1.(int16)), nil
 	},
-	Strict: true,
 }
 
 // int4um represents the PostgreSQL function of the same name, taking the same parameters.
 var int4um = framework.Function1{
 	Name:       "int4um",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return -(val1.(int32)), nil
 	},
-	Strict: true,
 }
 
 // int8um represents the PostgreSQL function of the same name, taking the same parameters.
 var int8um = framework.Function1{
 	Name:       "int8um",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return -(val1.(int64)), nil
 	},
-	Strict: true,
 }
 
 // numeric_uminus represents the PostgreSQL function of the same name, taking the same parameters.
 var numeric_uminus = framework.Function1{
 	Name:       "numeric_uminus",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return val1.(decimal.Decimal).Neg(), nil
 	},
-	Strict: true,
 }

--- a/server/functions/unary/plus.go
+++ b/server/functions/unary/plus.go
@@ -38,64 +38,64 @@ func initUnaryPlus() {
 var float4up = framework.Function1{
 	Name:       "float4up",
 	Return:     pgtypes.Float32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float32},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return val1, nil
 	},
-	Strict: true,
 }
 
 // float8up represents the PostgreSQL function of the same name, taking the same parameters.
 var float8up = framework.Function1{
 	Name:       "float8up",
 	Return:     pgtypes.Float64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Float64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return val1, nil
 	},
-	Strict: true,
 }
 
 // int2up represents the PostgreSQL function of the same name, taking the same parameters.
 var int2up = framework.Function1{
 	Name:       "int2up",
 	Return:     pgtypes.Int16,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int16},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Int16},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return val1, nil
 	},
-	Strict: true,
 }
 
 // int4up represents the PostgreSQL function of the same name, taking the same parameters.
 var int4up = framework.Function1{
 	Name:       "int4up",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int32},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return val1, nil
 	},
-	Strict: true,
 }
 
 // int8up represents the PostgreSQL function of the same name, taking the same parameters.
 var int8up = framework.Function1{
 	Name:       "int8up",
 	Return:     pgtypes.Int64,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Int64},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Int64},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return val1, nil
 	},
-	Strict: true,
 }
 
 // numeric_uplus represents the PostgreSQL function of the same name, taking the same parameters.
 var numeric_uplus = framework.Function1{
 	Name:       "numeric_uplus",
 	Return:     pgtypes.Numeric,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.Numeric},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		return val1, nil
 	},
-	Strict: true,
 }

--- a/server/functions/upper.go
+++ b/server/functions/upper.go
@@ -32,10 +32,10 @@ func initUpper() {
 var upper_varchar = framework.Function1{
 	Name:       "upper",
 	Return:     pgtypes.VarChar,
-	Parameters: []pgtypes.DoltgresType{pgtypes.VarChar},
-	Callable: func(ctx *sql.Context, val1 any) (any, error) {
+	Parameters: [1]pgtypes.DoltgresType{pgtypes.VarChar},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
 		//TODO: this doesn't respect collations
 		return strings.ToUpper(val1.(string)), nil
 	},
-	Strict: true,
 }

--- a/server/functions/width_bucket.go
+++ b/server/functions/width_bucket.go
@@ -35,8 +35,9 @@ func initWidthBucket() {
 var width_bucket_float64_float64_float64_int64 = framework.Function4{
 	Name:       "width_bucket",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64, pgtypes.Float64, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, operandInterface any, lowInterface any, highInterface any, countInterface any) (any, error) {
+	Parameters: [4]pgtypes.DoltgresType{pgtypes.Float64, pgtypes.Float64, pgtypes.Float64, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [5]pgtypes.DoltgresType, operandInterface any, lowInterface any, highInterface any, countInterface any) (any, error) {
 		operand := operandInterface.(float64)
 		low := lowInterface.(float64)
 		high := highInterface.(float64)
@@ -61,15 +62,15 @@ var width_bucket_float64_float64_float64_int64 = framework.Function4{
 		}
 		return int32(result), nil
 	},
-	Strict: true,
 }
 
 // width_bucket_numeric_numeric_numeric_int64 represents the PostgreSQL function of the same name, taking the same parameters.
 var width_bucket_numeric_numeric_numeric_int64 = framework.Function4{
 	Name:       "width_bucket",
 	Return:     pgtypes.Int32,
-	Parameters: []pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric, pgtypes.Numeric, pgtypes.Int32},
-	Callable: func(ctx *sql.Context, operandInterface any, lowInterface any, highInterface any, countInterface any) (any, error) {
+	Parameters: [4]pgtypes.DoltgresType{pgtypes.Numeric, pgtypes.Numeric, pgtypes.Numeric, pgtypes.Int32},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [5]pgtypes.DoltgresType, operandInterface any, lowInterface any, highInterface any, countInterface any) (any, error) {
 		operand := operandInterface.(decimal.Decimal)
 		low := lowInterface.(decimal.Decimal)
 		high := highInterface.(decimal.Decimal)
@@ -95,5 +96,4 @@ var width_bucket_numeric_numeric_numeric_int64 = framework.Function4{
 		i64 := result.IntPart()
 		return int32(i64), nil
 	},
-	Strict: true,
 }

--- a/server/types/any_element.go
+++ b/server/types/any_element.go
@@ -1,0 +1,194 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/dolthub/vitess/go/sqltypes"
+	"github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/lib/pq/oid"
+)
+
+// AnyElement is a pseudo-type that can represent any type.
+var AnyElement = AnyElementType{}
+
+// AnyElementType is the extended type implementation of the PostgreSQL anyelement.
+type AnyElementType struct{}
+
+var _ DoltgresType = AnyElementType{}
+var _ DoltgresPolymorphicType = AnyElementType{}
+
+// Alignment implements the DoltgresType interface.
+func (ae AnyElementType) Alignment() TypeAlignment {
+	return TypeAlignment_Double
+}
+
+// BaseID implements the DoltgresType interface.
+func (ae AnyElementType) BaseID() DoltgresTypeBaseID {
+	return DoltgresTypeBaseID_AnyElement
+}
+
+// BaseName implements the DoltgresType interface.
+func (ae AnyElementType) BaseName() string {
+	return "anyelement"
+}
+
+// Category implements the DoltgresType interface.
+func (ae AnyElementType) Category() TypeCategory {
+	return TypeCategory_PseudoTypes
+}
+
+// CollationCoercibility implements the DoltgresType interface.
+func (ae AnyElementType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
+// Compare implements the DoltgresType interface.
+func (ae AnyElementType) Compare(v1 any, v2 any) (int, error) {
+	return 0, fmt.Errorf("%s cannot compare values", ae.String())
+}
+
+// Convert implements the DoltgresType interface.
+func (ae AnyElementType) Convert(val any) (any, sql.ConvertInRange, error) {
+	return val, sql.InRange, nil
+}
+
+// Equals implements the DoltgresType interface.
+func (ae AnyElementType) Equals(otherType sql.Type) bool {
+	_, ok := otherType.(AnyElementType)
+	return ok
+}
+
+// FormatSerializedValue implements the DoltgresType interface.
+func (ae AnyElementType) FormatSerializedValue(val []byte) (string, error) {
+	return "", fmt.Errorf("%s cannot format serialized values", ae.String())
+}
+
+// FormatValue implements the DoltgresType interface.
+func (ae AnyElementType) FormatValue(val any) (string, error) {
+	return "", fmt.Errorf("%s cannot format values", ae.String())
+}
+
+// GetSerializationID implements the DoltgresType interface.
+func (ae AnyElementType) GetSerializationID() SerializationID {
+	return SerializationID_Invalid
+}
+
+// IoInput implements the DoltgresType interface.
+func (ae AnyElementType) IoInput(input string) (any, error) {
+	return "", fmt.Errorf("%s cannot receive I/O input", ae.String())
+}
+
+// IoOutput implements the DoltgresType interface.
+func (ae AnyElementType) IoOutput(output any) (string, error) {
+	return "", fmt.Errorf("%s cannot produce I/O output", ae.String())
+}
+
+// IsPreferredType implements the DoltgresType interface.
+func (ae AnyElementType) IsPreferredType() bool {
+	return false
+}
+
+// IsUnbounded implements the DoltgresType interface.
+func (ae AnyElementType) IsUnbounded() bool {
+	return true
+}
+
+// IsValid implements the DoltgresPolymorphicType interface.
+func (ae AnyElementType) IsValid(target DoltgresType) bool {
+	return true
+}
+
+// MaxSerializedWidth implements the DoltgresType interface.
+func (ae AnyElementType) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
+	return types.ExtendedTypeSerializedWidth_Unbounded
+}
+
+// MaxTextResponseByteLength implements the DoltgresType interface.
+func (ae AnyElementType) MaxTextResponseByteLength(ctx *sql.Context) uint32 {
+	return math.MaxUint32
+}
+
+// OID implements the DoltgresType interface.
+func (ae AnyElementType) OID() uint32 {
+	return uint32(oid.T_anyelement)
+}
+
+// Promote implements the DoltgresType interface.
+func (ae AnyElementType) Promote() sql.Type {
+	return ae
+}
+
+// SerializedCompare implements the DoltgresType interface.
+func (ae AnyElementType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
+	return 0, fmt.Errorf("%s cannot compare serialized values", ae.String())
+}
+
+// SQL implements the DoltgresType interface.
+func (ae AnyElementType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
+	return sqltypes.Value{}, fmt.Errorf("%s cannot output values in the wire format", ae.String())
+}
+
+// String implements the DoltgresType interface.
+func (ae AnyElementType) String() string {
+	return "anyelement"
+}
+
+// ToArrayType implements the DoltgresType interface.
+func (ae AnyElementType) ToArrayType() DoltgresArrayType {
+	return Unknown
+}
+
+// Type implements the DoltgresType interface.
+func (ae AnyElementType) Type() query.Type {
+	return sqltypes.Text
+}
+
+// ValueType implements the DoltgresType interface.
+func (ae AnyElementType) ValueType() reflect.Type {
+	var val any
+	return reflect.TypeOf(val)
+}
+
+// Zero implements the DoltgresType interface.
+func (ae AnyElementType) Zero() any {
+	var val any
+	return val
+}
+
+// SerializeType implements the DoltgresType interface.
+func (ae AnyElementType) SerializeType() ([]byte, error) {
+	return nil, fmt.Errorf("%s cannot be serialized", ae.String())
+}
+
+// deserializeType implements the DoltgresType interface.
+func (ae AnyElementType) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
+	return nil, fmt.Errorf("%s cannot be deserialized", ae.String())
+}
+
+// SerializeValue implements the DoltgresType interface.
+func (ae AnyElementType) SerializeValue(val any) ([]byte, error) {
+	return nil, fmt.Errorf("%s cannot serialize values", ae.String())
+}
+
+// DeserializeValue implements the DoltgresType interface.
+func (ae AnyElementType) DeserializeValue(val []byte) (any, error) {
+	return nil, fmt.Errorf("%s cannot deserialize values", ae.String())
+}

--- a/server/types/any_nonarray.go
+++ b/server/types/any_nonarray.go
@@ -1,0 +1,200 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/dolthub/vitess/go/sqltypes"
+	"github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/lib/pq/oid"
+)
+
+// AnyNonArray is a pseudo-type that can represent any type that isn't an array type.
+var AnyNonArray = AnyNonArrayType{}
+
+// AnyNonArrayType is the extended type implementation of the PostgreSQL anynonarray.
+type AnyNonArrayType struct{}
+
+var _ DoltgresType = AnyNonArrayType{}
+var _ DoltgresPolymorphicType = AnyNonArrayType{}
+
+// Alignment implements the DoltgresType interface.
+func (ana AnyNonArrayType) Alignment() TypeAlignment {
+	return TypeAlignment_Double
+}
+
+// BaseID implements the DoltgresType interface.
+func (ana AnyNonArrayType) BaseID() DoltgresTypeBaseID {
+	return DoltgresTypeBaseID_AnyNonArray
+}
+
+// BaseName implements the DoltgresType interface.
+func (ana AnyNonArrayType) BaseName() string {
+	return "anynonarray"
+}
+
+// Category implements the DoltgresType interface.
+func (ana AnyNonArrayType) Category() TypeCategory {
+	return TypeCategory_PseudoTypes
+}
+
+// CollationCoercibility implements the DoltgresType interface.
+func (ana AnyNonArrayType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
+// Compare implements the DoltgresType interface.
+func (ana AnyNonArrayType) Compare(v1 any, v2 any) (int, error) {
+	return 0, fmt.Errorf("%s cannot compare values", ana.String())
+}
+
+// Convert implements the DoltgresType interface.
+func (ana AnyNonArrayType) Convert(val any) (any, sql.ConvertInRange, error) {
+	switch val := val.(type) {
+	case []any:
+		return nil, sql.OutOfRange, fmt.Errorf("%s: unhandled type: %T", ana.String(), val)
+	default:
+		return val, sql.InRange, nil
+	}
+}
+
+// Equals implements the DoltgresType interface.
+func (ana AnyNonArrayType) Equals(otherType sql.Type) bool {
+	_, ok := otherType.(AnyNonArrayType)
+	return ok
+}
+
+// FormatSerializedValue implements the DoltgresType interface.
+func (ana AnyNonArrayType) FormatSerializedValue(val []byte) (string, error) {
+	return "", fmt.Errorf("%s cannot format serialized values", ana.String())
+}
+
+// FormatValue implements the DoltgresType interface.
+func (ana AnyNonArrayType) FormatValue(val any) (string, error) {
+	return "", fmt.Errorf("%s cannot format values", ana.String())
+}
+
+// GetSerializationID implements the DoltgresType interface.
+func (ana AnyNonArrayType) GetSerializationID() SerializationID {
+	return SerializationID_Invalid
+}
+
+// IoInput implements the DoltgresType interface.
+func (ana AnyNonArrayType) IoInput(input string) (any, error) {
+	return "", fmt.Errorf("%s cannot receive I/O input", ana.String())
+}
+
+// IoOutput implements the DoltgresType interface.
+func (ana AnyNonArrayType) IoOutput(output any) (string, error) {
+	return "", fmt.Errorf("%s cannot produce I/O output", ana.String())
+}
+
+// IsPreferredType implements the DoltgresType interface.
+func (ana AnyNonArrayType) IsPreferredType() bool {
+	return false
+}
+
+// IsUnbounded implements the DoltgresType interface.
+func (ana AnyNonArrayType) IsUnbounded() bool {
+	return true
+}
+
+// IsValid implements the DoltgresPolymorphicType interface.
+func (ana AnyNonArrayType) IsValid(target DoltgresType) bool {
+	_, ok := target.(DoltgresArrayType)
+	return !ok
+}
+
+// MaxSerializedWidth implements the DoltgresType interface.
+func (ana AnyNonArrayType) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
+	return types.ExtendedTypeSerializedWidth_Unbounded
+}
+
+// MaxTextResponseByteLength implements the DoltgresType interface.
+func (ana AnyNonArrayType) MaxTextResponseByteLength(ctx *sql.Context) uint32 {
+	return math.MaxUint32
+}
+
+// OID implements the DoltgresType interface.
+func (ana AnyNonArrayType) OID() uint32 {
+	return uint32(oid.T_anynonarray)
+}
+
+// Promote implements the DoltgresType interface.
+func (ana AnyNonArrayType) Promote() sql.Type {
+	return ana
+}
+
+// SerializedCompare implements the DoltgresType interface.
+func (ana AnyNonArrayType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
+	return 0, fmt.Errorf("%s cannot compare serialized values", ana.String())
+}
+
+// SQL implements the DoltgresType interface.
+func (ana AnyNonArrayType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
+	return sqltypes.Value{}, fmt.Errorf("%s cannot output values in the wire format", ana.String())
+}
+
+// String implements the DoltgresType interface.
+func (ana AnyNonArrayType) String() string {
+	return "anynonarray"
+}
+
+// ToArrayType implements the DoltgresType interface.
+func (ana AnyNonArrayType) ToArrayType() DoltgresArrayType {
+	return Unknown
+}
+
+// Type implements the DoltgresType interface.
+func (ana AnyNonArrayType) Type() query.Type {
+	return sqltypes.Text
+}
+
+// ValueType implements the DoltgresType interface.
+func (ana AnyNonArrayType) ValueType() reflect.Type {
+	var val any
+	return reflect.TypeOf(val)
+}
+
+// Zero implements the DoltgresType interface.
+func (ana AnyNonArrayType) Zero() any {
+	var val any
+	return val
+}
+
+// SerializeType implements the DoltgresType interface.
+func (ana AnyNonArrayType) SerializeType() ([]byte, error) {
+	return nil, fmt.Errorf("%s cannot be serialized", ana.String())
+}
+
+// deserializeType implements the DoltgresType interface.
+func (ana AnyNonArrayType) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
+	return nil, fmt.Errorf("%s cannot be deserialized", ana.String())
+}
+
+// SerializeValue implements the DoltgresType interface.
+func (ana AnyNonArrayType) SerializeValue(val any) ([]byte, error) {
+	return nil, fmt.Errorf("%s cannot serialize values", ana.String())
+}
+
+// DeserializeValue implements the DoltgresType interface.
+func (ana AnyNonArrayType) DeserializeValue(val []byte) (any, error) {
+	return nil, fmt.Errorf("%s cannot deserialize values", ana.String())
+}

--- a/testing/go/types_test.go
+++ b/testing/go/types_test.go
@@ -1957,6 +1957,35 @@ var typesTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "Polymorphic types",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT array_append(ARRAY[1], 2);",
+				Expected: []sql.Row{
+					{"{1,2}"},
+				},
+			},
+			{
+				Query: "SELECT array_append(ARRAY['abc','def'], 'ghi');",
+				Expected: []sql.Row{
+					{"{abc,def,ghi}"},
+				},
+			},
+			{
+				Query:       "SELECT array_append(1, 2);",
+				ExpectedErr: "does not exist",
+			},
+			{
+				Query:       "SELECT array_append(1, ARRAY[2]);",
+				ExpectedErr: "does not exist",
+			},
+			{
+				Query:       "SELECT array_append(ARRAY[1], ARRAY[2]);",
+				ExpectedErr: "does not exist",
+			},
+		},
+	},
 }
 
 func TestSameTypes(t *testing.T) {


### PR DESCRIPTION
This adds the types `anyelement` and `anynonarray`, in addition to adding support for defining functions that use polymorphic types.
https://www.postgresql.org/docs/15/extend-type-system.html#EXTEND-TYPES-POLYMORPHIC
Besides the changes to function resolution, this also adds a new parameter so that functions can see which types are passed in.
In addition, this cleans up the function interface, so that function definitions are a little more consistent and slightly less prone to typos (such as changing function parameters to an array from a slice, so that the length must be defined).