### PR TITLE
Fix `version` function so that it returns Postgres version

### DIFF
--- a/server/functions/init.go
+++ b/server/functions/init.go
@@ -94,5 +94,6 @@ func Init() {
 	initTrimScale()
 	initTrunc()
 	initUpper()
+	initVersion()
 	initWidthBucket()
 }

--- a/server/functions/version.go
+++ b/server/functions/version.go
@@ -17,9 +17,10 @@ package functions
 import (
 	"fmt"
 
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
-	"github.com/dolthub/go-mysql-server/sql"
 )
 
 const postgresVersion = "15.5"

--- a/server/functions/version.go
+++ b/server/functions/version.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+import (
+	"fmt"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+const postgresVersion = "15.5"
+
+// initVersion registers the functions to the catalog.
+func initVersion() {
+	framework.RegisterFunction(version)
+}
+
+// version represents the PostgreSQL system information function of the same name, taking no parameters.
+var version = framework.Function0{
+	Name:   "version",
+	Return: pgtypes.Text,
+	Strict: true,
+	Callable: func(ctx *sql.Context) (any, error) {
+		return fmt.Sprintf("PostgreSQL %s", postgresVersion), nil
+	},
+}

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -321,5 +321,16 @@ func TestSystemInformationFunctions(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "version",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `SELECT version();`,
+					Expected: []sql.Row{
+						{"PostgreSQL 15.5"},
+					},
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
Relies on GMS PR: https://github.com/dolthub/go-mysql-server/pull/2588