### PR TITLE
Added regclass and regproc

### DIFF
--- a/server/analyzer/type_sanitizer.go
+++ b/server/analyzer/type_sanitizer.go
@@ -94,6 +94,10 @@ func TypeSanitizer(ctx *sql.Context, a *analyzer.Analyzer, node sql.Node, scope 
 
 // typeSanitizerLiterals handles literal expressions for TypeSanitizer.
 func typeSanitizerLiterals(gmsLiteral *expression.Literal) (sql.Expression, transform.TreeIdentity, error) {
+	// GMS may resolve Doltgres literals and then stick them in GMS literals, so we have to account for that here
+	if doltgresType, ok := gmsLiteral.Type().(pgtypes.DoltgresType); ok {
+		return pgexprs.NewUnsafeLiteral(gmsLiteral.Value(), doltgresType), transform.NewTree, nil
+	}
 	switch gmsLiteral.Type().Type() {
 	case query.Type_INT8, query.Type_INT16, query.Type_INT24, query.Type_INT32, query.Type_INT64, query.Type_YEAR, query.Type_ENUM:
 		newVal, _, err := types.Int64.Convert(gmsLiteral.Value())

--- a/server/ast/resolvable_type_reference.go
+++ b/server/ast/resolvable_type_reference.go
@@ -110,6 +110,10 @@ func nodeResolvableTypeReference(typ tree.ResolvableTypeReference) (*vitess.Conv
 				}
 			case oid.T_oid:
 				resolvedType = pgtypes.Oid
+			case oid.T_regclass:
+				resolvedType = pgtypes.Regclass
+			case oid.T_regproc:
+				resolvedType = pgtypes.Regproc
 			case oid.T_text:
 				resolvedType = pgtypes.Text
 			case oid.T_time:

--- a/server/cast/char.go
+++ b/server/cast/char.go
@@ -55,7 +55,7 @@ func charImplicit() {
 		FromType: pgtypes.BpChar,
 		ToType:   pgtypes.BpChar,
 		Function: func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
-			return targetType.IoInput(val.(string))
+			return targetType.IoInput(ctx, val.(string))
 		},
 	})
 	framework.MustAddImplicitTypeCast(framework.TypeCast{

--- a/server/cast/int16.go
+++ b/server/cast/int16.go
@@ -71,4 +71,18 @@ func int16Implicit() {
 			return uint32(val.(int16)), nil
 		},
 	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.Regclass,
+		Function: func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return uint32(val.(int16)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int16,
+		ToType:   pgtypes.Regproc,
+		Function: func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return uint32(val.(int16)), nil
+		},
+	})
 }

--- a/server/cast/int32.go
+++ b/server/cast/int32.go
@@ -93,4 +93,18 @@ func int32Implicit() {
 			return uint32(val.(int32)), nil
 		},
 	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.Regclass,
+		Function: func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return uint32(val.(int32)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int32,
+		ToType:   pgtypes.Regproc,
+		Function: func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			return uint32(val.(int32)), nil
+		},
+	})
 }

--- a/server/cast/int64.go
+++ b/server/cast/int64.go
@@ -87,4 +87,24 @@ func int64Implicit() {
 			return uint32(val.(int64)), nil
 		},
 	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.Regclass,
+		Function: func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			if val.(int64) > pgtypes.MaxUint32 || val.(int64) < 0 {
+				return nil, errOutOfRange.New(targetType.String())
+			}
+			return uint32(val.(int64)), nil
+		},
+	})
+	framework.MustAddImplicitTypeCast(framework.TypeCast{
+		FromType: pgtypes.Int64,
+		ToType:   pgtypes.Regproc,
+		Function: func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
+			if val.(int64) > pgtypes.MaxUint32 || val.(int64) < 0 {
+				return nil, errOutOfRange.New(targetType.String())
+			}
+			return uint32(val.(int64)), nil
+		},
+	})
 }

--- a/server/cast/json.go
+++ b/server/cast/json.go
@@ -32,7 +32,7 @@ func jsonAssignment() {
 		FromType: pgtypes.Json,
 		ToType:   pgtypes.JsonB,
 		Function: func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
-			return targetType.IoInput(val.(string))
+			return targetType.IoInput(ctx, val.(string))
 		},
 	})
 }

--- a/server/cast/jsonb.go
+++ b/server/cast/jsonb.go
@@ -208,7 +208,7 @@ func jsonbAssignment() {
 		FromType: pgtypes.JsonB,
 		ToType:   pgtypes.Json,
 		Function: func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
-			return pgtypes.JsonB.IoOutput(val)
+			return pgtypes.JsonB.IoOutput(ctx, val)
 		},
 	})
 }

--- a/server/cast/regclass.go
+++ b/server/cast/regclass.go
@@ -21,23 +21,23 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// initOid handles all casts that are built-in. This comprises only the "From" types.
-func initOid() {
-	oidAssignment()
-	oidImplicit()
+// initRegclass handles all casts that are built-in. This comprises only the "From" types.
+func initRegclass() {
+	regclassAssignment()
+	regclassImplicit()
 }
 
-// oidAssignment registers all assignment casts. This comprises only the "From" types.
-func oidAssignment() {
+// regclassAssignment registers all assignment casts. This comprises only the "From" types.
+func regclassAssignment() {
 	framework.MustAddAssignmentTypeCast(framework.TypeCast{
-		FromType: pgtypes.Oid,
+		FromType: pgtypes.Regclass,
 		ToType:   pgtypes.Int32,
 		Function: func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
 			return int32(val.(uint32)), nil
 		},
 	})
 	framework.MustAddAssignmentTypeCast(framework.TypeCast{
-		FromType: pgtypes.Oid,
+		FromType: pgtypes.Regclass,
 		ToType:   pgtypes.Int64,
 		Function: func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
 			return int64(val.(uint32)), nil
@@ -45,18 +45,11 @@ func oidAssignment() {
 	})
 }
 
-// oidImplicit registers all implicit casts. This comprises only the "From" types.
-func oidImplicit() {
+// regclassImplicit registers all implicit casts. This comprises only the "From" types.
+func regclassImplicit() {
 	framework.MustAddImplicitTypeCast(framework.TypeCast{
-		FromType: pgtypes.Oid,
-		ToType:   pgtypes.Regclass,
-		Function: func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
-			return val, nil
-		},
-	})
-	framework.MustAddImplicitTypeCast(framework.TypeCast{
-		FromType: pgtypes.Oid,
-		ToType:   pgtypes.Regproc,
+		FromType: pgtypes.Regclass,
+		ToType:   pgtypes.Oid,
 		Function: func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
 			return val, nil
 		},

--- a/server/cast/regproc.go
+++ b/server/cast/regproc.go
@@ -21,23 +21,23 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// initOid handles all casts that are built-in. This comprises only the "From" types.
-func initOid() {
-	oidAssignment()
-	oidImplicit()
+// initRegproc handles all casts that are built-in. This comprises only the "From" types.
+func initRegproc() {
+	regprocAssignment()
+	regprocImplicit()
 }
 
-// oidAssignment registers all assignment casts. This comprises only the "From" types.
-func oidAssignment() {
+// regprocAssignment registers all assignment casts. This comprises only the "From" types.
+func regprocAssignment() {
 	framework.MustAddAssignmentTypeCast(framework.TypeCast{
-		FromType: pgtypes.Oid,
+		FromType: pgtypes.Regproc,
 		ToType:   pgtypes.Int32,
 		Function: func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
 			return int32(val.(uint32)), nil
 		},
 	})
 	framework.MustAddAssignmentTypeCast(framework.TypeCast{
-		FromType: pgtypes.Oid,
+		FromType: pgtypes.Regproc,
 		ToType:   pgtypes.Int64,
 		Function: func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
 			return int64(val.(uint32)), nil
@@ -45,18 +45,11 @@ func oidAssignment() {
 	})
 }
 
-// oidImplicit registers all implicit casts. This comprises only the "From" types.
-func oidImplicit() {
+// regprocImplicit registers all implicit casts. This comprises only the "From" types.
+func regprocImplicit() {
 	framework.MustAddImplicitTypeCast(framework.TypeCast{
-		FromType: pgtypes.Oid,
-		ToType:   pgtypes.Regclass,
-		Function: func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
-			return val, nil
-		},
-	})
-	framework.MustAddImplicitTypeCast(framework.TypeCast{
-		FromType: pgtypes.Oid,
-		ToType:   pgtypes.Regproc,
+		FromType: pgtypes.Regproc,
+		ToType:   pgtypes.Oid,
 		Function: func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
 			return val, nil
 		},

--- a/server/expression/literal.go
+++ b/server/expression/literal.go
@@ -136,6 +136,16 @@ func NewRawLiteralTimestamp(val time.Time) *Literal {
 	}
 }
 
+// NewUnsafeLiteral returns a new *Literal containing the given value and type. This should almost never be used, as
+// it does not perform any checking and circumvents type safety, which may lead to hard-to-debug errors. This is
+// currently only used within the analyzer, and will likely be removed in the future.
+func NewUnsafeLiteral(val any, t pgtypes.DoltgresType) *Literal {
+	return &Literal{
+		value: val,
+		typ:   t,
+	}
+}
+
 // Children implements the sql.Expression interface.
 func (l *Literal) Children() []sql.Expression {
 	return nil

--- a/server/functions/binary/json.go
+++ b/server/functions/binary/json.go
@@ -62,7 +62,7 @@ var json_array_element = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		// TODO: make a bespoke implementation that preserves whitespace
-		newVal, err := pgtypes.JsonB.IoInput(val1.(string))
+		newVal, err := pgtypes.JsonB.IoInput(ctx, val1.(string))
 		if err != nil {
 			return nil, err
 		}
@@ -71,7 +71,10 @@ var json_array_element = framework.Function2{
 		if err != nil {
 			return nil, err
 		}
-		return pgtypes.JsonB.FormatValue(retVal)
+		if retVal == nil {
+			return "", nil
+		}
+		return pgtypes.JsonB.IoOutput(ctx, retVal)
 	},
 }
 
@@ -105,7 +108,7 @@ var json_object_field = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		// TODO: make a bespoke implementation that preserves whitespace
-		newVal, err := pgtypes.JsonB.IoInput(val1.(string))
+		newVal, err := pgtypes.JsonB.IoInput(ctx, val1.(string))
 		if err != nil {
 			return nil, err
 		}
@@ -114,7 +117,10 @@ var json_object_field = framework.Function2{
 		if err != nil {
 			return nil, err
 		}
-		return pgtypes.JsonB.FormatValue(retVal)
+		if retVal == nil {
+			return "", nil
+		}
+		return pgtypes.JsonB.IoOutput(ctx, retVal)
 	},
 }
 
@@ -145,7 +151,7 @@ var json_array_element_text = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		// TODO: make a bespoke implementation that preserves whitespace
-		newVal, err := pgtypes.JsonB.IoInput(val1.(string))
+		newVal, err := pgtypes.JsonB.IoInput(ctx, val1.(string))
 		if err != nil {
 			return nil, err
 		}
@@ -169,7 +175,7 @@ var jsonb_array_element_text = framework.Function2{
 		case pgtypes.JsonValueString:
 			return string(value), nil
 		default:
-			return pgtypes.JsonB.FormatValue(pgtypes.JsonDocument{Value: value})
+			return pgtypes.JsonB.IoOutput(ctx, pgtypes.JsonDocument{Value: value})
 		}
 	},
 }
@@ -182,7 +188,7 @@ var json_object_field_text = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		// TODO: make a bespoke implementation that preserves whitespace
-		newVal, err := pgtypes.JsonB.IoInput(val1.(string))
+		newVal, err := pgtypes.JsonB.IoInput(ctx, val1.(string))
 		if err != nil {
 			return nil, err
 		}
@@ -206,7 +212,7 @@ var jsonb_object_field_text = framework.Function2{
 		case pgtypes.JsonValueString:
 			return string(value), nil
 		default:
-			return pgtypes.JsonB.FormatValue(pgtypes.JsonDocument{Value: value})
+			return pgtypes.JsonB.IoOutput(ctx, pgtypes.JsonDocument{Value: value})
 		}
 	},
 }
@@ -219,7 +225,7 @@ var json_extract_path = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		// TODO: make a bespoke implementation that preserves whitespace
-		newVal, err := pgtypes.JsonB.IoInput(val1.(string))
+		newVal, err := pgtypes.JsonB.IoInput(ctx, val1.(string))
 		if err != nil {
 			return nil, err
 		}
@@ -228,7 +234,10 @@ var json_extract_path = framework.Function2{
 		if err != nil {
 			return nil, err
 		}
-		return pgtypes.JsonB.FormatValue(retVal)
+		if retVal == nil {
+			return "", nil
+		}
+		return pgtypes.JsonB.IoOutput(ctx, retVal)
 	},
 }
 
@@ -276,7 +285,7 @@ var json_extract_path_text = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		// TODO: make a bespoke implementation that preserves whitespace
-		newVal, err := pgtypes.JsonB.IoInput(val1.(string))
+		newVal, err := pgtypes.JsonB.IoInput(ctx, val1.(string))
 		if err != nil {
 			return nil, err
 		}
@@ -300,7 +309,7 @@ var jsonb_extract_path_text = framework.Function2{
 		case pgtypes.JsonValueString:
 			return string(value), nil
 		default:
-			return pgtypes.JsonB.FormatValue(pgtypes.JsonDocument{Value: value})
+			return pgtypes.JsonB.IoOutput(ctx, pgtypes.JsonDocument{Value: value})
 		}
 	},
 }

--- a/server/functions/framework/cast.go
+++ b/server/functions/framework/cast.go
@@ -145,11 +145,11 @@ func GetExplicitCast(fromType pgtypes.DoltgresTypeBaseID, toType pgtypes.Doltgre
 			if val == nil {
 				return nil, nil
 			}
-			str, err := fromType.GetRepresentativeType().IoOutput(val)
+			str, err := fromType.GetRepresentativeType().IoOutput(ctx, val)
 			if err != nil {
 				return nil, err
 			}
-			return targetType.IoInput(str)
+			return targetType.IoInput(ctx, str)
 		}
 	} else if fromType.GetTypeCategory() == pgtypes.TypeCategory_StringTypes {
 		// All types have a built-in assignment cast from string types, which we can reference in an explicit cast
@@ -157,11 +157,11 @@ func GetExplicitCast(fromType pgtypes.DoltgresTypeBaseID, toType pgtypes.Doltgre
 			if val == nil {
 				return nil, nil
 			}
-			str, err := fromType.GetRepresentativeType().IoOutput(val)
+			str, err := fromType.GetRepresentativeType().IoOutput(ctx, val)
 			if err != nil {
 				return nil, err
 			}
-			return targetType.IoInput(str)
+			return targetType.IoInput(ctx, str)
 		}
 	}
 	return nil
@@ -186,11 +186,11 @@ func GetAssignmentCast(fromType pgtypes.DoltgresTypeBaseID, toType pgtypes.Doltg
 			if val == nil {
 				return nil, nil
 			}
-			str, err := fromType.GetRepresentativeType().IoOutput(val)
+			str, err := fromType.GetRepresentativeType().IoOutput(ctx, val)
 			if err != nil {
 				return nil, err
 			}
-			return targetType.IoInput(str)
+			return targetType.IoInput(ctx, str)
 		}
 	}
 	return nil
@@ -298,5 +298,5 @@ func stringLiteralCast(ctx *sql.Context, val any, targetType pgtypes.DoltgresTyp
 	if !ok {
 		return nil, fmt.Errorf("string literal was expected in I/O cast, but received: `%T`", val)
 	}
-	return targetType.IoInput(str)
+	return targetType.IoInput(ctx, str)
 }

--- a/server/functions/init.go
+++ b/server/functions/init.go
@@ -91,6 +91,8 @@ func Init() {
 	initTand()
 	initTanh()
 	initToHex()
+	initToRegclass()
+	initToRegproc()
 	initTrimScale()
 	initTrunc()
 	initUpper()

--- a/server/functions/to_regclass.go
+++ b/server/functions/to_regclass.go
@@ -1,0 +1,55 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// initToRegclass registers the functions to the catalog.
+func initToRegclass() {
+	framework.RegisterFunction(to_regclass_text)
+}
+
+// to_regclass_text represents the PostgreSQL function of the same name, taking the same parameters.
+var to_regclass_text = framework.Function1{
+	Name:               "to_regclass",
+	Return:             pgtypes.Regclass,
+	Parameters:         [1]pgtypes.DoltgresType{pgtypes.Text},
+	IsNonDeterministic: true,
+	Strict:             true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
+		// If the string just represents a number, then we return nil.
+		if _, err := strconv.ParseUint(val1.(string), 10, 32); err == nil {
+			return nil, nil
+		}
+		oid, err := pgtypes.Regclass.IoInput(ctx, val1.(string))
+		if err != nil {
+			// Specifically for the "does not exist" error, we return nil instead of the error.
+			// https://www.postgresql.org/docs/15/functions-info.html#FUNCTIONS-INFO-CATALOG-TABLE
+			if strings.Contains(err.Error(), "does not exist") {
+				return nil, nil
+			}
+			return nil, err
+		}
+		return oid, nil
+	},
+}

--- a/server/functions/to_regproc.go
+++ b/server/functions/to_regproc.go
@@ -1,0 +1,56 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// initToRegproc registers the functions to the catalog.
+func initToRegproc() {
+	framework.RegisterFunction(to_regproc_text)
+}
+
+// to_regproc_text represents the PostgreSQL function of the same name, taking the same parameters.
+var to_regproc_text = framework.Function1{
+	Name:               "to_regproc",
+	Return:             pgtypes.Regproc,
+	Parameters:         [1]pgtypes.DoltgresType{pgtypes.Text},
+	IsNonDeterministic: true,
+	Strict:             true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val1 any) (any, error) {
+		// If the string just represents a number, then we return nil.
+		if _, err := strconv.ParseUint(val1.(string), 10, 32); err == nil {
+			return nil, nil
+		}
+		oid, err := pgtypes.Regproc.IoInput(ctx, val1.(string))
+		if err != nil {
+			// Specifically for the "does not exist" and "more than one function" errors, we return nil instead of the error.
+			// https://www.postgresql.org/docs/15/functions-info.html#FUNCTIONS-INFO-CATALOG-TABLE
+			errStr := err.Error()
+			if strings.Contains(errStr, "does not exist") || strings.Contains(errStr, "more than one function") {
+				return nil, nil
+			}
+			return nil, err
+		}
+		return oid, nil
+	},
+}

--- a/server/initialization/initialization.go
+++ b/server/initialization/initialization.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dolthub/doltgresql/server/tables"
 	"github.com/dolthub/doltgresql/server/tables/pgcatalog"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
+	"github.com/dolthub/doltgresql/server/types/oid"
 )
 
 var once = &sync.Once{}
@@ -42,6 +43,7 @@ func Initialize() {
 		analyzer.Init()
 		config.Init()
 		pgtypes.InitBaseIDs()
+		oid.Init()
 		binary.Init()
 		unary.Init()
 		functions.Init()

--- a/server/tables/pgcatalog/iters.go
+++ b/server/tables/pgcatalog/iters.go
@@ -20,33 +20,3 @@ import "github.com/dolthub/go-mysql-server/sql"
 func emptyRowIter() (sql.RowIter, error) {
 	return sql.RowsToRowIter(), nil
 }
-
-// currentDatabaseSchemaIter iterates over all schemas in the current database, calling cb
-// for each schema. Once all schemas have been processed or the callback returns
-// false or an error, the iteration stops.
-func currentDatabaseSchemaIter(ctx *sql.Context, c sql.Catalog, cb func(schema sql.DatabaseSchema) (bool, error)) (sql.Database, error) {
-	currentDB := ctx.GetCurrentDatabase()
-	db, err := c.Database(ctx, currentDB)
-	if err != nil {
-		return nil, err
-	}
-
-	if schDB, ok := db.(sql.SchemaDatabase); ok {
-		schemas, err := schDB.AllSchemas(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, schema := range schemas {
-			cont, err := cb(schema)
-			if err != nil {
-				return nil, err
-			}
-			if !cont {
-				break
-			}
-		}
-	}
-
-	return db, nil
-}

--- a/server/tables/pgcatalog/pg_attribute.go
+++ b/server/tables/pgcatalog/pg_attribute.go
@@ -17,12 +17,11 @@ package pgcatalog
 import (
 	"io"
 
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
-	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/tables"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
+	"github.com/dolthub/doltgresql/server/types/oid"
 )
 
 // PgAttributeName is a constant to the pg_attribute name.
@@ -45,35 +44,26 @@ func (p PgAttributeHandler) Name() string {
 
 // RowIter implements the interface tables.Handler.
 func (p PgAttributeHandler) RowIter(ctx *sql.Context) (sql.RowIter, error) {
-	doltSession := dsess.DSessFromSess(ctx.Session)
-	c := sqle.NewDefault(doltSession.Provider()).Analyzer.Catalog
-
 	var cols []*sql.Column
-	var schemas []string
+	var tableOIDs []uint32
 
-	_, err := currentDatabaseSchemaIter(ctx, c, func(db sql.DatabaseSchema) (bool, error) {
-		err := sql.DBTableIter(ctx, db, func(t sql.Table) (cont bool, err error) {
-			for _, col := range t.Schema() {
+	err := oid.IterateCurrentDatabase(ctx, oid.Callbacks{
+		Table: func(ctx *sql.Context, _ oid.ItemSchema, table oid.ItemTable) (cont bool, err error) {
+			for _, col := range table.Item.Schema() {
 				cols = append(cols, col)
-				schemas = append(schemas, db.SchemaName())
+				tableOIDs = append(tableOIDs, table.OID)
 			}
 			return true, nil
-		})
-		if err != nil {
-			return false, err
-		}
-
-		return true, nil
+		},
 	})
-
 	if err != nil {
 		return nil, err
 	}
 
 	return &pgAttributeRowIter{
-		cols:    cols,
-		schemas: schemas,
-		idx:     0,
+		cols:      cols,
+		tableOIDs: tableOIDs,
+		idx:       0,
 	}, nil
 }
 
@@ -117,9 +107,9 @@ var pgAttributeSchema = sql.Schema{
 
 // pgAttributeRowIter is the sql.RowIter for the pg_attribute table.
 type pgAttributeRowIter struct {
-	cols    []*sql.Column
-	schemas []string
-	idx     int
+	cols      []*sql.Column
+	tableOIDs []uint32
+	idx       int
 }
 
 var _ sql.RowIter = (*pgAttributeRowIter)(nil)
@@ -131,9 +121,7 @@ func (iter *pgAttributeRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 	}
 	iter.idx++
 	col := iter.cols[iter.idx-1]
-	schema := iter.schemas[iter.idx-1]
-
-	tableOid := genOid(col.DatabaseSource, schema, col.Source)
+	tableOid := iter.tableOIDs[iter.idx-1]
 
 	generated := ""
 	if col.Generated != nil {
@@ -141,8 +129,7 @@ func (iter *pgAttributeRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 	}
 
 	dimensions := 0
-	s, ok := col.Type.(sql.SetType)
-	if ok {
+	if s, ok := col.Type.(sql.SetType); ok {
 		dimensions = int(s.NumberOfElements())
 	}
 
@@ -150,7 +137,7 @@ func (iter *pgAttributeRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 
 	typeOid := uint32(0)
 	if doltgresType, ok := col.Type.(pgtypes.DoltgresType); ok {
-		typeOid = uint32(doltgresType.OID())
+		typeOid = doltgresType.OID()
 	}
 
 	// TODO: Fill in the rest of the pg_attribute columns

--- a/server/tables/pgcatalog/pg_database.go
+++ b/server/tables/pgcatalog/pg_database.go
@@ -16,6 +16,7 @@ package pgcatalog
 
 import (
 	"io"
+	"sort"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	sqle "github.com/dolthub/go-mysql-server"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/dolthub/doltgresql/server/tables"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
+	"github.com/dolthub/doltgresql/server/types/oid"
 )
 
 // PgDatabaseName is a constant to the pg_database name.
@@ -58,6 +60,9 @@ func (p PgDatabaseHandler) RowIter(ctx *sql.Context) (sql.RowIter, error) {
 		}
 		dbs = append(dbs, db)
 	}
+	sort.Slice(dbs, func(i, j int) bool {
+		return dbs[i].Name() < dbs[j].Name()
+	})
 
 	return &pgDatabaseRowIter{
 		dbs: dbs,
@@ -109,12 +114,11 @@ func (iter *pgDatabaseRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 	}
 	iter.idx++
 	db := iter.dbs[iter.idx-1]
-
-	oid := genOid(db.Name())
+	dbOid := oid.CreateOID(oid.Section_Database, 0, iter.idx-1)
 
 	// TODO: Add the rest of the pg_database columns
 	return sql.Row{
-		oid,       // oid
+		dbOid,     // oid
 		db.Name(), // datname
 		uint32(0), // datdba
 		int32(0),  // encoding

--- a/server/types/any_array.go
+++ b/server/types/any_array.go
@@ -89,11 +89,6 @@ func (aa AnyArrayType) Equals(otherType sql.Type) bool {
 	return ok
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (aa AnyArrayType) FormatSerializedValue(val []byte) (string, error) {
-	return "", fmt.Errorf("%s cannot format serialized values", aa.String())
-}
-
 // FormatValue implements the DoltgresType interface.
 func (aa AnyArrayType) FormatValue(val any) (string, error) {
 	return "", fmt.Errorf("%s cannot format values", aa.String())
@@ -105,12 +100,12 @@ func (aa AnyArrayType) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (aa AnyArrayType) IoInput(input string) (any, error) {
+func (aa AnyArrayType) IoInput(ctx *sql.Context, input string) (any, error) {
 	return "", fmt.Errorf("%s cannot receive I/O input", aa.String())
 }
 
 // IoOutput implements the DoltgresType interface.
-func (aa AnyArrayType) IoOutput(output any) (string, error) {
+func (aa AnyArrayType) IoOutput(ctx *sql.Context, output any) (string, error) {
 	return "", fmt.Errorf("%s cannot produce I/O output", aa.String())
 }
 

--- a/server/types/any_element.go
+++ b/server/types/any_element.go
@@ -76,11 +76,6 @@ func (ae AnyElementType) Equals(otherType sql.Type) bool {
 	return ok
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (ae AnyElementType) FormatSerializedValue(val []byte) (string, error) {
-	return "", fmt.Errorf("%s cannot format serialized values", ae.String())
-}
-
 // FormatValue implements the DoltgresType interface.
 func (ae AnyElementType) FormatValue(val any) (string, error) {
 	return "", fmt.Errorf("%s cannot format values", ae.String())
@@ -92,12 +87,12 @@ func (ae AnyElementType) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (ae AnyElementType) IoInput(input string) (any, error) {
+func (ae AnyElementType) IoInput(ctx *sql.Context, input string) (any, error) {
 	return "", fmt.Errorf("%s cannot receive I/O input", ae.String())
 }
 
 // IoOutput implements the DoltgresType interface.
-func (ae AnyElementType) IoOutput(output any) (string, error) {
+func (ae AnyElementType) IoOutput(ctx *sql.Context, output any) (string, error) {
 	return "", fmt.Errorf("%s cannot produce I/O output", ae.String())
 }
 

--- a/server/types/any_nonarray.go
+++ b/server/types/any_nonarray.go
@@ -81,11 +81,6 @@ func (ana AnyNonArrayType) Equals(otherType sql.Type) bool {
 	return ok
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (ana AnyNonArrayType) FormatSerializedValue(val []byte) (string, error) {
-	return "", fmt.Errorf("%s cannot format serialized values", ana.String())
-}
-
 // FormatValue implements the DoltgresType interface.
 func (ana AnyNonArrayType) FormatValue(val any) (string, error) {
 	return "", fmt.Errorf("%s cannot format values", ana.String())
@@ -97,12 +92,12 @@ func (ana AnyNonArrayType) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (ana AnyNonArrayType) IoInput(input string) (any, error) {
+func (ana AnyNonArrayType) IoInput(ctx *sql.Context, input string) (any, error) {
 	return "", fmt.Errorf("%s cannot receive I/O input", ana.String())
 }
 
 // IoOutput implements the DoltgresType interface.
-func (ana AnyNonArrayType) IoOutput(output any) (string, error) {
+func (ana AnyNonArrayType) IoOutput(ctx *sql.Context, output any) (string, error) {
 	return "", fmt.Errorf("%s cannot produce I/O output", ana.String())
 }
 

--- a/server/types/base_ids.go
+++ b/server/types/base_ids.go
@@ -22,7 +22,7 @@ package types
 type DoltgresTypeBaseID uint32
 
 const (
-	DoltgresTypeBaseID_Any DoltgresTypeBaseID = iota + 2147483648
+	DoltgresTypeBaseID_Any DoltgresTypeBaseID = iota + 8192
 	DoltgresTypeBaseID_AnyElement
 	DoltgresTypeBaseID_AnyArray
 	DoltgresTypeBaseID_AnyNonArray
@@ -50,6 +50,17 @@ const (
 	DoltgresTypeBaseID_Int16Serial
 	DoltgresTypeBaseID_Int32Serial
 	DoltgresTypeBaseID_Int64Serial
+	DoltgresTypeBaseID_Regclass
+	DoltgresTypeBaseID_Regcollation
+	DoltgresTypeBaseID_Regconfig
+	DoltgresTypeBaseID_Regdictionary
+	DoltgresTypeBaseID_Regnamespace
+	DoltgresTypeBaseID_Regoper
+	DoltgresTypeBaseID_Regoperator
+	DoltgresTypeBaseID_Regproc
+	DoltgresTypeBaseID_Regprocedure
+	DoltgresTypeBaseID_Regrole
+	DoltgresTypeBaseID_Regtype
 )
 
 const (

--- a/server/types/bool.go
+++ b/server/types/bool.go
@@ -111,21 +111,12 @@ func (b BoolType) Equals(otherType sql.Type) bool {
 	return false
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (b BoolType) FormatSerializedValue(val []byte) (string, error) {
-	deserialized, err := b.DeserializeValue(val)
-	if err != nil {
-		return "", err
-	}
-	return b.FormatValue(deserialized)
-}
-
 // FormatValue implements the DoltgresType interface.
 func (b BoolType) FormatValue(val any) (string, error) {
 	if val == nil {
 		return "", nil
 	}
-	return b.IoOutput(val)
+	return b.IoOutput(sql.NewEmptyContext(), val)
 }
 
 // GetSerializationID implements the DoltgresType interface.
@@ -134,7 +125,7 @@ func (b BoolType) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (b BoolType) IoInput(input string) (any, error) {
+func (b BoolType) IoInput(ctx *sql.Context, input string) (any, error) {
 	input = strings.TrimSpace(strings.ToLower(input))
 	if input == "true" || input == "t" || input == "yes" || input == "on" || input == "1" {
 		return true, nil
@@ -146,7 +137,7 @@ func (b BoolType) IoInput(input string) (any, error) {
 }
 
 // IoOutput implements the DoltgresType interface.
-func (b BoolType) IoOutput(output any) (string, error) {
+func (b BoolType) IoOutput(ctx *sql.Context, output any) (string, error) {
 	converted, _, err := b.Convert(output)
 	if err != nil {
 		return "", err

--- a/server/types/char.go
+++ b/server/types/char.go
@@ -135,21 +135,12 @@ func (b CharType) Equals(otherType sql.Type) bool {
 	return false
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (b CharType) FormatSerializedValue(val []byte) (string, error) {
-	deserialized, err := b.DeserializeValue(val)
-	if err != nil {
-		return "", err
-	}
-	return b.FormatValue(deserialized)
-}
-
 // FormatValue implements the DoltgresType interface.
 func (b CharType) FormatValue(val any) (string, error) {
 	if val == nil {
 		return "", nil
 	}
-	return b.IoOutput(val)
+	return b.IoOutput(sql.NewEmptyContext(), val)
 }
 
 // GetSerializationID implements the DoltgresType interface.
@@ -158,7 +149,7 @@ func (b CharType) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (b CharType) IoInput(input string) (any, error) {
+func (b CharType) IoInput(ctx *sql.Context, input string) (any, error) {
 	if b.IsUnbounded() {
 		return input, nil
 	} else {
@@ -174,7 +165,7 @@ func (b CharType) IoInput(input string) (any, error) {
 }
 
 // IoOutput implements the DoltgresType interface.
-func (b CharType) IoOutput(output any) (string, error) {
+func (b CharType) IoOutput(ctx *sql.Context, output any) (string, error) {
 	converted, _, err := b.Convert(output)
 	if err != nil {
 		return "", err
@@ -249,7 +240,7 @@ func (b CharType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, err
 	if v == nil {
 		return sqltypes.NULL, nil
 	}
-	value, err := b.FormatValue(v)
+	value, err := b.IoOutput(ctx, v)
 	if err != nil {
 		return sqltypes.Value{}, err
 	}

--- a/server/types/date.go
+++ b/server/types/date.go
@@ -104,21 +104,12 @@ func (b DateType) Equals(otherType sql.Type) bool {
 	return false
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (b DateType) FormatSerializedValue(val []byte) (string, error) {
-	deserialized, err := b.DeserializeValue(val)
-	if err != nil {
-		return "", err
-	}
-	return b.FormatValue(deserialized)
-}
-
 // FormatValue implements the DoltgresType interface.
 func (b DateType) FormatValue(val any) (string, error) {
 	if val == nil {
 		return "", nil
 	}
-	return b.IoOutput(val)
+	return b.IoOutput(sql.NewEmptyContext(), val)
 }
 
 // GetSerializationID implements the DoltgresType interface.
@@ -127,7 +118,7 @@ func (b DateType) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (b DateType) IoInput(input string) (any, error) {
+func (b DateType) IoInput(ctx *sql.Context, input string) (any, error) {
 	if t, err := time.Parse("2006-01-02", input); err == nil {
 		return t.UTC(), nil
 	} else if t, err = time.Parse("January 02, 2006", input); err == nil {
@@ -139,7 +130,7 @@ func (b DateType) IoInput(input string) (any, error) {
 }
 
 // IoOutput implements the DoltgresType interface.
-func (b DateType) IoOutput(output any) (string, error) {
+func (b DateType) IoOutput(ctx *sql.Context, output any) (string, error) {
 	converted, _, err := b.Convert(output)
 	if err != nil {
 		return "", err
@@ -196,7 +187,7 @@ func (b DateType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, err
 	if v == nil {
 		return sqltypes.NULL, nil
 	}
-	value, err := b.FormatValue(v)
+	value, err := b.IoOutput(ctx, v)
 	if err != nil {
 		return sqltypes.Value{}, err
 	}

--- a/server/types/float32.go
+++ b/server/types/float32.go
@@ -114,15 +114,6 @@ func (b Float32Type) Equals(otherType sql.Type) bool {
 	return false
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (b Float32Type) FormatSerializedValue(val []byte) (string, error) {
-	deserialized, err := b.DeserializeValue(val)
-	if err != nil {
-		return "", err
-	}
-	return b.FormatValue(deserialized)
-}
-
 // FormatValue implements the DoltgresType interface.
 func (b Float32Type) FormatValue(val any) (string, error) {
 	if val == nil {
@@ -141,7 +132,7 @@ func (b Float32Type) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (b Float32Type) IoInput(input string) (any, error) {
+func (b Float32Type) IoInput(ctx *sql.Context, input string) (any, error) {
 	val, err := strconv.ParseFloat(strings.TrimSpace(input), 32)
 	if err != nil {
 		return nil, fmt.Errorf("invalid input syntax for type %s: %q", b.String(), input)
@@ -150,7 +141,7 @@ func (b Float32Type) IoInput(input string) (any, error) {
 }
 
 // IoOutput implements the DoltgresType interface.
-func (b Float32Type) IoOutput(output any) (string, error) {
+func (b Float32Type) IoOutput(ctx *sql.Context, output any) (string, error) {
 	converted, _, err := b.Convert(output)
 	if err != nil {
 		return "", err

--- a/server/types/float64.go
+++ b/server/types/float64.go
@@ -113,15 +113,6 @@ func (b Float64Type) Equals(otherType sql.Type) bool {
 	return false
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (b Float64Type) FormatSerializedValue(val []byte) (string, error) {
-	deserialized, err := b.DeserializeValue(val)
-	if err != nil {
-		return "", err
-	}
-	return b.FormatValue(deserialized)
-}
-
 // FormatValue implements the DoltgresType interface.
 func (b Float64Type) FormatValue(val any) (string, error) {
 	if val == nil {
@@ -140,7 +131,7 @@ func (b Float64Type) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (b Float64Type) IoInput(input string) (any, error) {
+func (b Float64Type) IoInput(ctx *sql.Context, input string) (any, error) {
 	val, err := strconv.ParseFloat(strings.TrimSpace(input), 64)
 	if err != nil {
 		return nil, fmt.Errorf("invalid input syntax for type %s: %q", b.String(), input)
@@ -149,7 +140,7 @@ func (b Float64Type) IoInput(input string) (any, error) {
 }
 
 // IoOutput implements the DoltgresType interface.
-func (b Float64Type) IoOutput(output any) (string, error) {
+func (b Float64Type) IoOutput(ctx *sql.Context, output any) (string, error) {
 	converted, _, err := b.Convert(output)
 	if err != nil {
 		return "", err

--- a/server/types/int16.go
+++ b/server/types/int16.go
@@ -112,21 +112,12 @@ func (b Int16Type) Equals(otherType sql.Type) bool {
 	return false
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (b Int16Type) FormatSerializedValue(val []byte) (string, error) {
-	deserialized, err := b.DeserializeValue(val)
-	if err != nil {
-		return "", err
-	}
-	return b.FormatValue(deserialized)
-}
-
 // FormatValue implements the DoltgresType interface.
 func (b Int16Type) FormatValue(val any) (string, error) {
 	if val == nil {
 		return "", nil
 	}
-	return b.IoOutput(val)
+	return b.IoOutput(sql.NewEmptyContext(), val)
 }
 
 // GetSerializationID implements the DoltgresType interface.
@@ -135,7 +126,7 @@ func (b Int16Type) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (b Int16Type) IoInput(input string) (any, error) {
+func (b Int16Type) IoInput(ctx *sql.Context, input string) (any, error) {
 	val, err := strconv.ParseInt(strings.TrimSpace(input), 10, 16)
 	if err != nil {
 		return nil, fmt.Errorf("invalid input syntax for type %s: %q", b.String(), input)
@@ -147,7 +138,7 @@ func (b Int16Type) IoInput(input string) (any, error) {
 }
 
 // IoOutput implements the DoltgresType interface.
-func (b Int16Type) IoOutput(output any) (string, error) {
+func (b Int16Type) IoOutput(ctx *sql.Context, output any) (string, error) {
 	converted, _, err := b.Convert(output)
 	if err != nil {
 		return "", err
@@ -203,7 +194,7 @@ func (b Int16Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, er
 	if v == nil {
 		return sqltypes.NULL, nil
 	}
-	value, err := b.FormatValue(v)
+	value, err := b.IoOutput(ctx, v)
 	if err != nil {
 		return sqltypes.Value{}, err
 	}

--- a/server/types/int16_serial.go
+++ b/server/types/int16_serial.go
@@ -74,11 +74,6 @@ func (b Int16TypeSerial) Equals(otherType sql.Type) bool {
 	return ok
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (b Int16TypeSerial) FormatSerializedValue(val []byte) (string, error) {
-	return "", fmt.Errorf("SERIAL types are not formattable")
-}
-
 // FormatValue implements the DoltgresType interface.
 func (b Int16TypeSerial) FormatValue(val any) (string, error) {
 	return "", fmt.Errorf("SERIAL types are not formattable")
@@ -90,12 +85,12 @@ func (b Int16TypeSerial) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (b Int16TypeSerial) IoInput(input string) (any, error) {
+func (b Int16TypeSerial) IoInput(ctx *sql.Context, input string) (any, error) {
 	return "", fmt.Errorf("SERIAL types cannot receive I/O input")
 }
 
 // IoOutput implements the DoltgresType interface.
-func (b Int16TypeSerial) IoOutput(output any) (string, error) {
+func (b Int16TypeSerial) IoOutput(ctx *sql.Context, output any) (string, error) {
 	return "", fmt.Errorf("SERIAL types cannot produce I/O output")
 }
 

--- a/server/types/int32.go
+++ b/server/types/int32.go
@@ -112,21 +112,12 @@ func (b Int32Type) Equals(otherType sql.Type) bool {
 	return false
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (b Int32Type) FormatSerializedValue(val []byte) (string, error) {
-	deserialized, err := b.DeserializeValue(val)
-	if err != nil {
-		return "", err
-	}
-	return b.FormatValue(deserialized)
-}
-
 // FormatValue implements the DoltgresType interface.
 func (b Int32Type) FormatValue(val any) (string, error) {
 	if val == nil {
 		return "", nil
 	}
-	return b.IoOutput(val)
+	return b.IoOutput(sql.NewEmptyContext(), val)
 }
 
 // GetSerializationID implements the DoltgresType interface.
@@ -135,7 +126,7 @@ func (b Int32Type) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (b Int32Type) IoInput(input string) (any, error) {
+func (b Int32Type) IoInput(ctx *sql.Context, input string) (any, error) {
 	val, err := strconv.ParseInt(strings.TrimSpace(input), 10, 32)
 	if err != nil {
 		return nil, fmt.Errorf("invalid input syntax for type %s: %q", b.String(), input)
@@ -147,7 +138,7 @@ func (b Int32Type) IoInput(input string) (any, error) {
 }
 
 // IoOutput implements the DoltgresType interface.
-func (b Int32Type) IoOutput(output any) (string, error) {
+func (b Int32Type) IoOutput(ctx *sql.Context, output any) (string, error) {
 	converted, _, err := b.Convert(output)
 	if err != nil {
 		return "", err
@@ -203,7 +194,7 @@ func (b Int32Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, er
 	if v == nil {
 		return sqltypes.NULL, nil
 	}
-	value, err := b.FormatValue(v)
+	value, err := b.IoOutput(ctx, v)
 	if err != nil {
 		return sqltypes.Value{}, err
 	}

--- a/server/types/int32_serial.go
+++ b/server/types/int32_serial.go
@@ -74,11 +74,6 @@ func (b Int32TypeSerial) Equals(otherType sql.Type) bool {
 	return ok
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (b Int32TypeSerial) FormatSerializedValue(val []byte) (string, error) {
-	return "", fmt.Errorf("SERIAL types are not formattable")
-}
-
 // FormatValue implements the DoltgresType interface.
 func (b Int32TypeSerial) FormatValue(val any) (string, error) {
 	return "", fmt.Errorf("SERIAL types are not formattable")
@@ -90,12 +85,12 @@ func (b Int32TypeSerial) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (b Int32TypeSerial) IoInput(input string) (any, error) {
+func (b Int32TypeSerial) IoInput(ctx *sql.Context, input string) (any, error) {
 	return "", fmt.Errorf("SERIAL types cannot receive I/O input")
 }
 
 // IoOutput implements the DoltgresType interface.
-func (b Int32TypeSerial) IoOutput(output any) (string, error) {
+func (b Int32TypeSerial) IoOutput(ctx *sql.Context, output any) (string, error) {
 	return "", fmt.Errorf("SERIAL types cannot produce I/O output")
 }
 

--- a/server/types/int64.go
+++ b/server/types/int64.go
@@ -112,21 +112,12 @@ func (b Int64Type) Equals(otherType sql.Type) bool {
 	return false
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (b Int64Type) FormatSerializedValue(val []byte) (string, error) {
-	deserialized, err := b.DeserializeValue(val)
-	if err != nil {
-		return "", err
-	}
-	return b.FormatValue(deserialized)
-}
-
 // FormatValue implements the DoltgresType interface.
 func (b Int64Type) FormatValue(val any) (string, error) {
 	if val == nil {
 		return "", nil
 	}
-	return b.IoOutput(val)
+	return b.IoOutput(sql.NewEmptyContext(), val)
 }
 
 // GetSerializationID implements the DoltgresType interface.
@@ -135,7 +126,7 @@ func (b Int64Type) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (b Int64Type) IoInput(input string) (any, error) {
+func (b Int64Type) IoInput(ctx *sql.Context, input string) (any, error) {
 	val, err := strconv.ParseInt(strings.TrimSpace(input), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("invalid input syntax for type %s: %q", b.String(), input)
@@ -144,7 +135,7 @@ func (b Int64Type) IoInput(input string) (any, error) {
 }
 
 // IoOutput implements the DoltgresType interface.
-func (b Int64Type) IoOutput(output any) (string, error) {
+func (b Int64Type) IoOutput(ctx *sql.Context, output any) (string, error) {
 	converted, _, err := b.Convert(output)
 	if err != nil {
 		return "", err
@@ -200,7 +191,7 @@ func (b Int64Type) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, er
 	if v == nil {
 		return sqltypes.NULL, nil
 	}
-	value, err := b.FormatValue(v)
+	value, err := b.IoOutput(ctx, v)
 	if err != nil {
 		return sqltypes.Value{}, err
 	}

--- a/server/types/int64_serial.go
+++ b/server/types/int64_serial.go
@@ -74,11 +74,6 @@ func (b Int64TypeSerial) Equals(otherType sql.Type) bool {
 	return ok
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (b Int64TypeSerial) FormatSerializedValue(val []byte) (string, error) {
-	return "", fmt.Errorf("SERIAL types are not formattable")
-}
-
 // FormatValue implements the DoltgresType interface.
 func (b Int64TypeSerial) FormatValue(val any) (string, error) {
 	return "", fmt.Errorf("SERIAL types are not formattable")
@@ -90,12 +85,12 @@ func (b Int64TypeSerial) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (b Int64TypeSerial) IoInput(input string) (any, error) {
+func (b Int64TypeSerial) IoInput(ctx *sql.Context, input string) (any, error) {
 	return "", fmt.Errorf("SERIAL types cannot receive I/O input")
 }
 
 // IoOutput implements the DoltgresType interface.
-func (b Int64TypeSerial) IoOutput(output any) (string, error) {
+func (b Int64TypeSerial) IoOutput(ctx *sql.Context, output any) (string, error) {
 	return "", fmt.Errorf("SERIAL types cannot produce I/O output")
 }
 

--- a/server/types/interface.go
+++ b/server/types/interface.go
@@ -17,6 +17,8 @@ package types
 import (
 	"sort"
 
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
@@ -36,11 +38,11 @@ type DoltgresType interface {
 	// IoInput returns a value from the given input string. This function mirrors Postgres' I/O input function. Such
 	// strings are intended for serialization and automatic cross-type conversion. An input string will never represent
 	// NULL.
-	IoInput(input string) (any, error)
+	IoInput(ctx *sql.Context, input string) (any, error)
 	// IoOutput returns a string from the given output value. This function mirrors Postgres' I/O output function. These
 	// strings are not intended for output, but are instead intended for serialization and cross-type conversion. Output
 	// values will always be non-NULL.
-	IoOutput(output any) (string, error)
+	IoOutput(ctx *sql.Context, output any) (string, error)
 	// IsPreferredType returns true if the type is preferred type.
 	IsPreferredType() bool
 	// IsUnbounded returns whether the type is unbounded. Unbounded types do not enforce a length, precision, etc. on
@@ -119,6 +121,10 @@ var typesFromBaseID = map[DoltgresTypeBaseID]DoltgresType{
 	NumericArray.BaseID():     NumericArray,
 	Oid.BaseID():              Oid,
 	OidArray.BaseID():         OidArray,
+	Regclass.BaseID():         Regclass,
+	RegclassArray.BaseID():    RegclassArray,
+	Regproc.BaseID():          Regproc,
+	RegprocArray.BaseID():     RegprocArray,
 	Text.BaseID():             Text,
 	TextArray.BaseID():        TextArray,
 	Time.BaseID():             Time,

--- a/server/types/null.go
+++ b/server/types/null.go
@@ -81,15 +81,6 @@ func (b NullType) Equals(otherType sql.Type) bool {
 	return false
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (b NullType) FormatSerializedValue(val []byte) (string, error) {
-	deserialized, err := b.DeserializeValue(val)
-	if err != nil {
-		return "", err
-	}
-	return b.FormatValue(deserialized)
-}
-
 // FormatValue implements the DoltgresType interface.
 func (b NullType) FormatValue(val any) (string, error) {
 	return "NULL", nil
@@ -101,12 +92,12 @@ func (b NullType) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (b NullType) IoInput(input string) (any, error) {
+func (b NullType) IoInput(ctx *sql.Context, input string) (any, error) {
 	return "", fmt.Errorf("%s cannot receive I/O input", b.String())
 }
 
 // IoOutput implements the DoltgresType interface.
-func (b NullType) IoOutput(output any) (string, error) {
+func (b NullType) IoOutput(ctx *sql.Context, output any) (string, error) {
 	return "", fmt.Errorf("%s cannot produce I/O output", b.String())
 }
 

--- a/server/types/oid/init.go
+++ b/server/types/oid/init.go
@@ -12,25 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package pgcatalog
+package oid
 
-import (
-	"strings"
+import pgtypes "github.com/dolthub/doltgresql/server/types"
 
-	"github.com/cespare/xxhash/v2"
-)
-
-// hashStringToUint32 hashes a string to a uint32 using the FNV-1a hash function.
-func hashStringToUint32(s string) uint32 {
-	hash := xxhash.Sum64String(s)
-	// Convert the hash to uint32
-	hash32 := uint32(hash & 0xFFFFFFFF)
-	// Ensure the hash is in the top half of the key space (>= 2^31) using XOR
-	return hash32 | 0x80000000
-}
-
-// genOid generates an OID from a list of names.
-func genOid(names ...string) uint32 {
-	id := strings.Join(names, ".")
-	return hashStringToUint32(id)
+// Init handles the assignment of the Io functions for the "reg" types.
+func Init() {
+	pgtypes.Regclass_IoInput = regclass_IoInput
+	pgtypes.Regclass_IoOutput = regclass_IoOutput
+	pgtypes.Regproc_IoInput = regproc_IoInput
+	pgtypes.Regproc_IoOutput = regproc_IoOutput
 }

--- a/server/types/oid/io_input.go
+++ b/server/types/oid/io_input.go
@@ -1,0 +1,82 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oid
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// ioInputSections converts the input string for IoInput into a sectioned form according to the rules defined by Postgres:
+// https://www.postgresql.org/docs/15/datatype-oid.html
+func ioInputSections(input string) ([]string, error) {
+	if len(input) == 0 {
+		return nil, fmt.Errorf("invalid name syntax")
+	}
+	runeInput := []rune(strings.TrimSpace(input))
+	var sections []string
+	var sectionBuilder strings.Builder
+	var inQuotes bool
+	for i := 0; i < len(runeInput); i++ {
+		char := runeInput[i]
+		switch char {
+		case '"':
+			if inQuotes {
+				if i < len(runeInput)-1 && runeInput[i+1] == '"' {
+					sectionBuilder.WriteRune(char)
+					i++
+				} else {
+					inQuotes = false
+					section := sectionBuilder.String()
+					sectionBuilder.Reset()
+					if len(section) == 0 || section == `"` {
+						return nil, fmt.Errorf("invalid name syntax")
+					}
+					sections = append(sections, section)
+				}
+			} else {
+				inQuotes = true
+			}
+		default:
+			if inQuotes {
+				sectionBuilder.WriteRune(char)
+			} else if char != ' ' {
+				if char == '.' {
+					section := sectionBuilder.String()
+					sectionBuilder.Reset()
+					if len(section) > 0 {
+						sections = append(sections, section)
+					}
+					sections = append(sections, string(char))
+				} else {
+					sectionBuilder.WriteRune(unicode.ToLower(char))
+				}
+			}
+		}
+	}
+	if sectionBuilder.Len() > 0 {
+		section := sectionBuilder.String()
+		if inQuotes {
+			// For some reason, you can have an unmatched double quote at the end, so we're duplicating that behavior
+			if input[len(input)-1] != '"' {
+				return nil, fmt.Errorf("invalid name syntax")
+			}
+			section += `"`
+		}
+		sections = append(sections, section)
+	}
+	return sections, nil
+}

--- a/server/types/oid/iterate.go
+++ b/server/types/oid/iterate.go
@@ -1,0 +1,739 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oid
+
+import (
+	"sort"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	sqle "github.com/dolthub/go-mysql-server"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression/function"
+
+	"github.com/dolthub/doltgresql/core"
+	"github.com/dolthub/doltgresql/core/sequences"
+)
+
+// Callbacks are a set of callbacks that are used to simplify and coalesce all iteration involving database elements and
+// their OIDs. All callbacks should be left nil except for the ones that are desired. Search paths are also supported
+// through SearchSchemas.
+type Callbacks struct {
+	// Check is the callback for check constraints.
+	Check func(ctx *sql.Context, schema ItemSchema, table ItemTable, check ItemCheck) (cont bool, err error)
+	// ForeignKey is the callback for foreign keys.
+	ForeignKey func(ctx *sql.Context, schema ItemSchema, table ItemTable, foreignKey ItemForeignKey) (cont bool, err error)
+	// Function is the callback for functions.
+	Function func(ctx *sql.Context, function ItemFunction) (cont bool, err error)
+	// Index is the callback for indexes.
+	Index func(ctx *sql.Context, schema ItemSchema, table ItemTable, index ItemIndex) (cont bool, err error)
+	// Schema is the callback for schemas/namespaces.
+	Schema func(ctx *sql.Context, schema ItemSchema) (cont bool, err error)
+	// Sequence is the callback for sequences.
+	Sequence func(ctx *sql.Context, schema ItemSchema, sequence ItemSequence) (cont bool, err error)
+	// Table is the callback for tables.
+	Table func(ctx *sql.Context, schema ItemSchema, table ItemTable) (cont bool, err error)
+	// View is the callback for views.
+	View func(ctx *sql.Context, schema ItemSchema, view ItemView) (cont bool, err error)
+	// SearchSchemas represents the search path. If left empty, then all schemas are iterated over. If supplied, then
+	// schemas are iterated by their given order.
+	SearchSchemas []string
+}
+
+// ItemCheck contains the relevant information to pass to the Check callback.
+type ItemCheck struct {
+	Index int
+	OID   uint32
+	Item  sql.CheckDefinition
+}
+
+// ItemForeignKey contains the relevant information to pass to the ForeignKey callback.
+type ItemForeignKey struct {
+	Index int
+	OID   uint32
+	Item  sql.ForeignKeyConstraint
+}
+
+// ItemFunction contains the relevant information to pass to the Function callback.
+type ItemFunction struct {
+	Index int
+	OID   uint32
+	Item  sql.Function
+}
+
+// ItemIndex contains the relevant information to pass to the Index callback.
+type ItemIndex struct {
+	Index int
+	OID   uint32
+	Item  sql.Index
+}
+
+// ItemSchema contains the relevant information to pass to the Schema callback.
+type ItemSchema struct {
+	Index int
+	OID   uint32
+	Item  sql.DatabaseSchema
+}
+
+// ItemSequence contains the relevant information to pass to the Sequence callback.
+type ItemSequence struct {
+	Index int
+	OID   uint32
+	Item  *sequences.Sequence
+}
+
+// ItemTable contains the relevant information to pass to the Table callback.
+type ItemTable struct {
+	Index int
+	OID   uint32
+	Item  sql.Table
+}
+
+// ItemView contains the relevant information to pass to the View callback.
+type ItemView struct {
+	Index int
+	OID   uint32
+	Item  sql.ViewDefinition
+}
+
+// IterateCurrentDatabase iterates over the current database, calling each callback as the relevant items are iterated
+// over. This is a central function that homogenizes all iteration, since OIDs depend on a deterministic iteration over
+// items. This function should be expanded as we add more items to iterate over.
+func IterateCurrentDatabase(ctx *sql.Context, callbacks Callbacks) error {
+	// Functions aren't contained within a schema for now, so we'll iterate over those separately
+	if callbacks.Function != nil {
+		for functionIndex, f := range function.BuiltIns {
+			itemFunction := ItemFunction{
+				Index: functionIndex,
+				OID:   CreateOID(Section_Function, 0, functionIndex),
+				Item:  f,
+			}
+			if cont, err := callbacks.Function(ctx, itemFunction); err != nil {
+				return err
+			} else if !cont {
+				return nil
+			}
+		}
+	}
+	// Everything else is within a schema, so we grab the current database
+	doltSession := dsess.DSessFromSess(ctx.Session)
+	currentDatabase, err := sqle.NewDefault(doltSession.Provider()).Analyzer.Catalog.Database(ctx, ctx.GetCurrentDatabase())
+	if err != nil {
+		return err
+	}
+	// Then we'll iterate over everything that is contained within a schema
+	if currentSchemaDatabase, ok := currentDatabase.(sql.SchemaDatabase); ok && callbacks.iteratesOverSchemas() {
+		// Load and sort all of the schemas by name ascending
+		schemas, err := currentSchemaDatabase.AllSchemas(ctx)
+		if err != nil {
+			return err
+		}
+		sort.Slice(schemas, func(i, j int) bool {
+			return schemas[i].SchemaName() < schemas[j].SchemaName()
+		})
+		// We'll load the sequences early (if the callback exists) since they're stored on the root.
+		// Within the schema iteration, we can simply
+		var sequenceMap map[string][]*sequences.Sequence
+		if callbacks.Sequence != nil {
+			collection, err := core.GetCollectionFromContext(ctx)
+			if err != nil {
+				return err
+			}
+			sequenceMap, _, _ = collection.GetAllSequences()
+		}
+		if err = iterateSchemas(ctx, callbacks, schemas, sequenceMap); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// iterateSchemas is called by IterateCurrentDatabase to handle schemas and elements contained within schemas.
+func iterateSchemas(ctx *sql.Context, callbacks Callbacks, sortedSchemas []sql.DatabaseSchema, sequenceMap map[string][]*sequences.Sequence) error {
+	// Iterate over the sorted schemas by the iteration order
+	for _, schemaIndex := range callbacks.schemaIterationOrder(sortedSchemas) {
+		schema := sortedSchemas[schemaIndex]
+		itemSchema := ItemSchema{
+			Index: schemaIndex,
+			OID:   CreateOID(Section_Namespace, 0, schemaIndex),
+			Item:  schema,
+		}
+		// Check for a schema callback
+		if callbacks.Schema != nil {
+			if cont, err := callbacks.Schema(ctx, itemSchema); err != nil {
+				return err
+			} else if !cont {
+				return nil
+			}
+		}
+		// Check for a view callback
+		if callbacks.View != nil {
+			if err := iterateViews(ctx, callbacks, itemSchema); err != nil {
+				return err
+			}
+		}
+		// Iterate over sequences. The map will only be populated if the sequence callback exists.
+		for sequenceIndex, sequence := range sequenceMap[schema.SchemaName()] {
+			itemSequence := ItemSequence{
+				Index: sequenceIndex,
+				OID:   CreateOID(Section_Sequence, schemaIndex, sequenceIndex),
+				Item:  sequence,
+			}
+			if cont, err := callbacks.Sequence(ctx, itemSchema, itemSequence); err != nil {
+				return err
+			} else if !cont {
+				return nil
+			}
+		}
+		// Check if we need to iterate over tables
+		if callbacks.iteratesOverTables() {
+			tableNames, err := schema.GetTableNames(ctx)
+			if err != nil {
+				return err
+			}
+			sort.Slice(tableNames, func(i, j int) bool {
+				return tableNames[i] < tableNames[j]
+			})
+			if err = iterateTables(ctx, callbacks, itemSchema, tableNames); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// iterateViews is called by iterateSchemas to handle views.
+func iterateViews(ctx *sql.Context, callbacks Callbacks, itemSchema ItemSchema) error {
+	if viewDatabase, ok := itemSchema.Item.(sql.ViewDatabase); ok {
+		views, err := viewDatabase.AllViews(ctx)
+		if err != nil {
+			return err
+		}
+		sort.Slice(views, func(i, j int) bool {
+			return views[i].Name < views[j].Name
+		})
+		for viewIndex, view := range views {
+			itemView := ItemView{
+				Index: viewIndex,
+				OID:   CreateOID(Section_View, itemSchema.Index, viewIndex),
+				Item:  view,
+			}
+			if cont, err := callbacks.View(ctx, itemSchema, itemView); err != nil {
+				return err
+			} else if !cont {
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+// iterateTables is called by iterateSchemas to handle tables and elements contained within tables.
+func iterateTables(ctx *sql.Context, callbacks Callbacks, itemSchema ItemSchema, sortedTableNames []string) error {
+	// Start all of the counts at -1, since we always increment before using the count.
+	checkCount := -1
+	foreignKeyCount := -1
+	indexCount := -1
+
+	// Iterate over the sorted table names
+	for tableIndex, tableName := range sortedTableNames {
+		table, ok, err := itemSchema.Item.GetTableInsensitive(ctx, tableName)
+		if err != nil {
+			return err
+		} else if !ok {
+			return sql.ErrTableNotFound.New(tableName)
+		}
+		itemTable := ItemTable{
+			Index: tableIndex,
+			OID:   CreateOID(Section_Table, itemSchema.Index, tableIndex),
+			Item:  table,
+		}
+
+		// Check for a check constraint callback
+		if callbacks.Check != nil {
+			if err = iterateChecks(ctx, callbacks, itemSchema, itemTable, &checkCount); err != nil {
+				return err
+			}
+		}
+		// Check for a foreign key callback
+		if callbacks.ForeignKey != nil {
+			if err = iterateForeignKeys(ctx, callbacks, itemSchema, itemTable, &foreignKeyCount); err != nil {
+				return err
+			}
+		}
+		// Check for an index callback
+		if callbacks.Index != nil {
+			if err = iterateIndexes(ctx, callbacks, itemSchema, itemTable, &indexCount); err != nil {
+				return err
+			}
+		}
+		// Check for a table callback
+		if callbacks.Table != nil {
+			if cont, err := callbacks.Table(ctx, itemSchema, itemTable); err != nil {
+				return err
+			} else if !cont {
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+// iterateChecks is called by iterateTables to handle check constraints.
+func iterateChecks(ctx *sql.Context, callbacks Callbacks, itemSchema ItemSchema, itemTable ItemTable, checkCount *int) error {
+	if checkTable, ok := itemTable.Item.(sql.CheckTable); ok {
+		checks, err := checkTable.GetChecks(ctx)
+		if err != nil {
+			return err
+		}
+		sort.Slice(checks, func(i, j int) bool {
+			return checks[i].Name < checks[j].Name
+		})
+		for _, check := range checks {
+			*checkCount++
+			itemCheck := ItemCheck{
+				Index: *checkCount,
+				OID:   CreateOID(Section_Check, itemSchema.Index, *checkCount),
+				Item:  check,
+			}
+			if cont, err := callbacks.Check(ctx, itemSchema, itemTable, itemCheck); err != nil {
+				return err
+			} else if !cont {
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+// iterateForeignKeys is called by iterateTables to handle foreign keys.
+func iterateForeignKeys(ctx *sql.Context, callbacks Callbacks, itemSchema ItemSchema, itemTable ItemTable, foreignKeyCount *int) error {
+	if fkTable, ok := itemTable.Item.(sql.ForeignKeyTable); ok {
+		foreignKeys, err := fkTable.GetDeclaredForeignKeys(ctx)
+		if err != nil {
+			return err
+		}
+		sort.Slice(foreignKeys, func(i, j int) bool {
+			return foreignKeys[i].Name < foreignKeys[j].Name
+		})
+		for _, foreignKey := range foreignKeys {
+			*foreignKeyCount++
+			itemForeignKey := ItemForeignKey{
+				Index: *foreignKeyCount,
+				OID:   CreateOID(Section_ForeignKey, itemSchema.Index, *foreignKeyCount),
+				Item:  foreignKey,
+			}
+			if cont, err := callbacks.ForeignKey(ctx, itemSchema, itemTable, itemForeignKey); err != nil {
+				return err
+			} else if !cont {
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+// iterateIndexes is called by iterateTables to handle indexes.
+func iterateIndexes(ctx *sql.Context, callbacks Callbacks, itemSchema ItemSchema, itemTable ItemTable, indexCount *int) error {
+	if indexedTable, ok := itemTable.Item.(sql.IndexAddressable); ok {
+		indexes, err := indexedTable.GetIndexes(ctx)
+		if err != nil {
+			return err
+		}
+		sort.Slice(indexes, func(i, j int) bool {
+			return indexes[i].ID() < indexes[j].ID()
+		})
+		for _, index := range indexes {
+			*indexCount++
+			itemIndex := ItemIndex{
+				Index: *indexCount,
+				OID:   CreateOID(Section_Index, itemSchema.Index, *indexCount),
+				Item:  index,
+			}
+			if cont, err := callbacks.Index(ctx, itemSchema, itemTable, itemIndex); err != nil {
+				return err
+			} else if !cont {
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+// RunCallback iterates over schemas, etc. to find the item that the given oid points to. Once the item has been found,
+// the relevant callback is called with the item. This means that, at most, only one callback will be called. If the
+// item cannot be found, then no callbacks are called.
+func RunCallback(ctx *sql.Context, oid uint32, callbacks Callbacks) error {
+	section, schemaIndex, dataIndex := ParseOID(oid)
+	if ok := runCallbackValidation(ctx, oid, callbacks); !ok {
+		return nil
+	}
+	// Functions aren't contained within a schema for now, so we'll iterate over those here
+	if section == Section_Function {
+		return runFunction(ctx, oid, callbacks)
+	}
+	// We know we have the relevant callback for the given section, so we'll grab the schema
+	doltSession := dsess.DSessFromSess(ctx.Session)
+	currentDatabase, err := sqle.NewDefault(doltSession.Provider()).Analyzer.Catalog.Database(ctx, ctx.GetCurrentDatabase())
+	if err != nil {
+		return err
+	}
+	if currentSchemaDatabase, ok := currentDatabase.(sql.SchemaDatabase); ok {
+		schemas, err := currentSchemaDatabase.AllSchemas(ctx)
+		if err != nil {
+			return err
+		}
+		sort.Slice(schemas, func(i, j int) bool {
+			return schemas[i].SchemaName() < schemas[j].SchemaName()
+		})
+		// First check if we're only looking for the schema
+		if section == Section_Namespace {
+			return runNamespace(ctx, oid, callbacks, schemas)
+		}
+		// We're not looking for the schema, so we'll just select the target schema containing what we're looking for
+		if schemaIndex >= len(schemas) {
+			return nil
+		}
+		itemSchema := ItemSchema{
+			Index: schemaIndex,
+			OID:   oid,
+			Item:  schemas[schemaIndex],
+		}
+		// Check if we're looking for a sequence
+		if section == Section_Sequence {
+			return runSequence(ctx, oid, callbacks, itemSchema)
+		}
+		// Check if we're looking for a view
+		if section == Section_View {
+			return runView(ctx, oid, callbacks, itemSchema)
+		}
+		// Before diving inside of tables, we'll check if we're looking for a table
+		tableNames, err := itemSchema.Item.GetTableNames(ctx)
+		if err != nil {
+			return err
+		}
+		sort.Slice(tableNames, func(i, j int) bool {
+			return tableNames[i] < tableNames[j]
+		})
+		if section == Section_Table {
+			return runTable(ctx, oid, callbacks, itemSchema, tableNames)
+		}
+		// All other sections are items on tables, so we'll iterate over those now.
+		// We hold the count here since it increments across tables.
+		countedIndex := 0
+		for _, tableName := range tableNames {
+			table, ok, err := itemSchema.Item.GetTableInsensitive(ctx, tableName)
+			if err != nil {
+				return err
+			} else if !ok {
+				return sql.ErrTableNotFound.New(tableName)
+			}
+			itemTable := ItemTable{
+				Index: dataIndex,
+				OID:   oid,
+				Item:  table,
+			}
+			switch section {
+			case Section_Check:
+				if ok, err := runCheck(ctx, oid, callbacks, itemSchema, itemTable, &countedIndex); err != nil {
+					return err
+				} else if ok {
+					continue
+				}
+				return nil
+			case Section_ForeignKey:
+				if ok, err := runForeignKey(ctx, oid, callbacks, itemSchema, itemTable, &countedIndex); err != nil {
+					return err
+				} else if ok {
+					continue
+				}
+				return nil
+			case Section_Index:
+				if ok, err := runIndex(ctx, oid, callbacks, itemSchema, itemTable, &countedIndex); err != nil {
+					return err
+				} else if ok {
+					continue
+				}
+				return nil
+			default: // This is unnecessary, but the linter complains without it
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+// runCheck is called by RunCallback to handle Section_Check.
+func runCheck(ctx *sql.Context, oid uint32, callbacks Callbacks, itemSchema ItemSchema, itemTable ItemTable, countedIndex *int) (cont bool, err error) {
+	_, _, dataIndex := ParseOID(oid)
+	if checkTable, ok := itemTable.Item.(sql.CheckTable); ok {
+		checks, err := checkTable.GetChecks(ctx)
+		if err != nil {
+			return false, err
+		}
+		if len(checks) <= dataIndex {
+			*countedIndex += len(checks)
+			return true, nil
+		}
+		sort.Slice(checks, func(i, j int) bool {
+			return checks[i].Name < checks[j].Name
+		})
+		itemCheck := ItemCheck{
+			Index: dataIndex,
+			OID:   oid,
+			Item:  checks[dataIndex-(*countedIndex)],
+		}
+		_, err = callbacks.Check(ctx, itemSchema, itemTable, itemCheck)
+		return false, err
+	}
+	return true, nil
+}
+
+// runForeignKey is called by RunCallback to handle Section_ForeignKey.
+func runForeignKey(ctx *sql.Context, oid uint32, callbacks Callbacks, itemSchema ItemSchema, itemTable ItemTable, countedIndex *int) (cont bool, err error) {
+	_, _, dataIndex := ParseOID(oid)
+	if fkTable, ok := itemTable.Item.(sql.ForeignKeyTable); ok {
+		foreignKeys, err := fkTable.GetDeclaredForeignKeys(ctx)
+		if err != nil {
+			return false, err
+		}
+		if len(foreignKeys) <= dataIndex {
+			*countedIndex += len(foreignKeys)
+			return true, nil
+		}
+		sort.Slice(foreignKeys, func(i, j int) bool {
+			return foreignKeys[i].Name < foreignKeys[j].Name
+		})
+		itemForeignKey := ItemForeignKey{
+			Index: dataIndex,
+			OID:   oid,
+			Item:  foreignKeys[dataIndex-(*countedIndex)],
+		}
+		_, err = callbacks.ForeignKey(ctx, itemSchema, itemTable, itemForeignKey)
+		return false, err
+	}
+	return true, nil
+}
+
+// runFunction is called by RunCallback to handle Section_Function.
+func runFunction(ctx *sql.Context, oid uint32, callbacks Callbacks) error {
+	_, _, dataIndex := ParseOID(oid)
+	if dataIndex >= len(function.BuiltIns) {
+		return nil
+	}
+	itemFunction := ItemFunction{
+		Index: dataIndex,
+		OID:   oid,
+		Item:  function.BuiltIns[dataIndex],
+	}
+	_, err := callbacks.Function(ctx, itemFunction)
+	return err
+}
+
+// runIndex is called by RunCallback to handle Section_Index.
+func runIndex(ctx *sql.Context, oid uint32, callbacks Callbacks, itemSchema ItemSchema, itemTable ItemTable, countedIndex *int) (cont bool, err error) {
+	_, _, dataIndex := ParseOID(oid)
+	if indexedTable, ok := itemTable.Item.(sql.IndexAddressable); ok {
+		indexes, err := indexedTable.GetIndexes(ctx)
+		if err != nil {
+			return false, err
+		}
+		if len(indexes) <= dataIndex {
+			*countedIndex += len(indexes)
+			return true, nil
+		}
+		sort.Slice(indexes, func(i, j int) bool {
+			return indexes[i].ID() < indexes[j].ID()
+		})
+		itemIndex := ItemIndex{
+			Index: dataIndex,
+			OID:   oid,
+			Item:  indexes[dataIndex-(*countedIndex)],
+		}
+		_, err = callbacks.Index(ctx, itemSchema, itemTable, itemIndex)
+		return false, err
+	}
+	return true, nil
+}
+
+// runNamespace is called by RunCallback to handle Section_Namespace.
+func runNamespace(ctx *sql.Context, oid uint32, callbacks Callbacks, sortedSchemas []sql.DatabaseSchema) error {
+	_, _, dataIndex := ParseOID(oid)
+	if dataIndex >= len(sortedSchemas) {
+		return nil
+	}
+	itemSchema := ItemSchema{
+		Index: dataIndex,
+		OID:   oid,
+		Item:  sortedSchemas[dataIndex],
+	}
+	_, err := callbacks.Schema(ctx, itemSchema)
+	return err
+}
+
+// runSequence is called by RunCallback to handle Section_Sequence.
+func runSequence(ctx *sql.Context, oid uint32, callbacks Callbacks, itemSchema ItemSchema) error {
+	_, _, dataIndex := ParseOID(oid)
+	collection, err := core.GetCollectionFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	sequenceMap, _, _ := collection.GetAllSequences()
+	sequencesInSchema, ok := sequenceMap[itemSchema.Item.SchemaName()]
+	if !ok || dataIndex >= len(sequencesInSchema) {
+		return nil
+	}
+	itemSequence := ItemSequence{
+		Index: dataIndex,
+		OID:   oid,
+		Item:  sequencesInSchema[dataIndex],
+	}
+	_, err = callbacks.Sequence(ctx, itemSchema, itemSequence)
+	return err
+}
+
+// runTable is called by RunCallback to handle Section_Table.
+func runTable(ctx *sql.Context, oid uint32, callbacks Callbacks, itemSchema ItemSchema, sortedTableNames []string) error {
+	_, _, dataIndex := ParseOID(oid)
+	if dataIndex >= len(sortedTableNames) {
+		return nil
+	}
+	table, ok, err := itemSchema.Item.GetTableInsensitive(ctx, sortedTableNames[dataIndex])
+	if err != nil {
+		return err
+	} else if !ok {
+		return sql.ErrTableNotFound.New(sortedTableNames[dataIndex])
+	}
+	itemTable := ItemTable{
+		Index: dataIndex,
+		OID:   oid,
+		Item:  table,
+	}
+	_, err = callbacks.Table(ctx, itemSchema, itemTable)
+	return err
+}
+
+// runView is called by RunCallback to handle Section_View.
+func runView(ctx *sql.Context, oid uint32, callbacks Callbacks, itemSchema ItemSchema) error {
+	_, _, dataIndex := ParseOID(oid)
+	if viewDatabase, ok := itemSchema.Item.(sql.ViewDatabase); ok {
+		views, err := viewDatabase.AllViews(ctx)
+		if err != nil {
+			return err
+		}
+		sort.Slice(views, func(i, j int) bool {
+			return views[i].Name < views[j].Name
+		})
+		if dataIndex >= len(views) {
+			return nil
+		}
+		itemView := ItemView{
+			Index: dataIndex,
+			OID:   oid,
+			Item:  views[dataIndex],
+		}
+		_, err = callbacks.View(ctx, itemSchema, itemView)
+		return err
+	}
+	return nil
+}
+
+// runCallbackValidation ensures that the callbacks match the given oid.
+func runCallbackValidation(ctx *sql.Context, oid uint32, callbacks Callbacks) bool {
+	section, _, _ := ParseOID(oid)
+	// Check that we have the relevant callback, and return early if we do not
+	switch section {
+	case Section_Check:
+		if callbacks.Check == nil {
+			return false
+		}
+	case Section_Database:
+		// TODO: we inject information_schema, so we need to figure out how to model that here
+		return false
+	case Section_ForeignKey:
+		if callbacks.ForeignKey == nil {
+			return false
+		}
+	case Section_Function:
+		if callbacks.Function == nil {
+			return false
+		}
+	case Section_Index:
+		if callbacks.Index == nil {
+			return false
+		}
+	case Section_Namespace:
+		if callbacks.Schema == nil {
+			return false
+		}
+	case Section_Sequence:
+		if callbacks.Sequence == nil {
+			return false
+		}
+	case Section_Table:
+		if callbacks.Table == nil {
+			return false
+		}
+	case Section_View:
+		if callbacks.View == nil {
+			return false
+		}
+	default:
+		return false
+	}
+	return true
+}
+
+// iteratesOverSchemas returns whether we need to iterate over schemas based on the given callbacks.
+func (iter Callbacks) iteratesOverSchemas() bool {
+	return iter.Check != nil ||
+		iter.ForeignKey != nil ||
+		iter.Index != nil ||
+		iter.Schema != nil ||
+		iter.Sequence != nil ||
+		iter.Table != nil ||
+		iter.View != nil
+}
+
+// iteratesOverTables returns whether we need to iterate over tables based on the given callbacks.
+func (iter Callbacks) iteratesOverTables() bool {
+	return iter.Check != nil ||
+		iter.ForeignKey != nil ||
+		iter.Index != nil ||
+		iter.Table != nil
+}
+
+// schemaIterationOrder returns the order that the given schemas should be iterated over.
+func (iter Callbacks) schemaIterationOrder(sortedSchemas []sql.DatabaseSchema) []int {
+	// If no search schemas are set, then we'll iterate over all of the schemas in sorted order
+	if len(iter.SearchSchemas) == 0 {
+		order := make([]int, len(sortedSchemas))
+		for i := range sortedSchemas {
+			order[i] = i
+		}
+		return order
+	}
+	sortedSchemasMap := make(map[string]int)
+	for i, schema := range sortedSchemas {
+		sortedSchemasMap[schema.SchemaName()] = i
+	}
+	// We only add the schemas that we can find
+	order := make([]int, 0, len(iter.SearchSchemas))
+	for _, searchSchema := range iter.SearchSchemas {
+		if schemaPosition, ok := sortedSchemasMap[searchSchema]; ok {
+			order = append(order, schemaPosition)
+		}
+	}
+	return order
+}

--- a/server/types/oid/oid.go
+++ b/server/types/oid/oid.go
@@ -1,0 +1,89 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oid
+
+// Section represents a specific space that an OID subset resides in. This makes it relatively simple to find the target
+// of an OID, since each searchable space has its own section.
+type Section uint8
+
+const (
+	Section_BuiltIn    Section = iota // Contains all of the OIDs that are defined when creating a Postgres database
+	Section_Check                     // Refers to checks on tables (the dataIndex is obtained by incrementing through all tables' checks)
+	Section_Collation                 // Refers to collations
+	Section_Database                  // Refers to the database (schemaIndex does not apply, so only dataIndex should be used)
+	Section_ForeignKey                // Refers to foreign keys on tables (the dataIndex is obtained by incrementing through all tables' foreign keys)
+	Section_Function                  // Refers to functions only (no stored procedures, etc.)
+	Section_Index                     // Refers to indexes on tables (the dataIndex is obtained by incrementing through all tables' indexes)
+	Section_Namespace                 // Namespaces are the underlying structure of a schema, so these only use the dataIndex
+	Section_Operator                  // Refers to operators (+, -, *, etc.)
+	Section_Sequence                  // Refers to sequences
+	Section_Table                     // Refers to tables
+	Section_View                      // Refers to views
+	Section_Invalid                   // Represents an invalid OID
+)
+
+const (
+	dataBitCount    = 20 // The size, in bits, of the dataIndex. 2^20 allows for 1048576 elements.
+	schemaBitCount  = 8  // The size, in bits, of the schemaIndex. 2^8 allows for 256 schemas.
+	sectionBitCount = 4  // The size, in bits, of the section. 2^4 allows for 16 sections.
+)
+
+const (
+	dataMask   = uint32(1<<dataBitCount) - 1                       // Contains the mask for the dataIndex portion of an OID.
+	schemaMask = (uint32(1<<(schemaBitCount)) - 1) << dataBitCount // Contains the mask for the schemaIndex portion of an OID.
+)
+
+// CreateOID returns an OID with the given contents. If any index is larger than the allotted bit size, then this
+// returns an OID with the section set to Section_Invalid.
+//
+// The layout of an OID is as follows:
+//
+// [Section][SchemaIndex][DataIndex]
+//
+// The schemaIndex represents the schema position that the OID is referencing (for all sections except for
+// Section_Namespace) when sorting all schemas in ascending order by name. The dataIndex represents the index of the
+// data according to the Section given (which will use some deterministic algorithm for the index).
+func CreateOID(section Section, schemaIndex int, dataIndex int) uint32 {
+	if schemaIndex < 0 || dataIndex < 0 || schemaIndex >= (1<<schemaBitCount) || dataIndex >= (1<<dataBitCount) {
+		return uint32(Section_Invalid) << (dataBitCount + schemaBitCount)
+	}
+	if (section == Section_Namespace || section == Section_Database) && schemaIndex != 0 {
+		// Go doesn't allow for compile-time checks, so we'll panic here.
+		// This shouldn't happen at run-time, as this should be caught by tests.
+		panic("The Database and Namespace sections should only use the dataIndex, not the schemaIndex")
+	}
+	return (uint32(section) << (dataBitCount + schemaBitCount)) +
+		(uint32(schemaIndex) << (dataBitCount)) +
+		uint32(dataIndex)
+}
+
+// ParseOID deconstructs an OID that was previously created using CreateOID.
+func ParseOID(oid uint32) (section Section, schemaIndex int, dataIndex int) {
+	section = Section(oid >> (dataBitCount + schemaBitCount))
+	if section >= Section_Invalid {
+		return Section_Invalid, 0, 0
+	}
+	return section, int((oid & schemaMask) >> dataBitCount), int(oid & dataMask)
+}
+
+// init validates the bit field lengths for the OID
+func init() {
+	if dataBitCount+schemaBitCount+sectionBitCount != 32 {
+		panic("OID bit counts do not cover the OID range")
+	}
+	if Section_Invalid >= (1 << sectionBitCount) {
+		panic("There are more sections than the bit allocation allows")
+	}
+}

--- a/server/types/oid/regclass.go
+++ b/server/types/oid/regclass.go
@@ -1,0 +1,151 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oid
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/resolve"
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// regclass_IoInput is the implementation for IoInput that avoids circular dependencies by being declared in a separate
+// package.
+func regclass_IoInput(ctx *sql.Context, input string) (uint32, error) {
+	// If the string just represents a number, then we return it.
+	if parsedOid, err := strconv.ParseUint(input, 10, 32); err == nil {
+		return uint32(parsedOid), nil
+	}
+	sections, err := ioInputSections(input)
+	if err != nil {
+		return 0, err
+	}
+	if err = regclass_IoInputValidation(ctx, input, sections); err != nil {
+		return 0, err
+	}
+	var searchSchemas []string
+	var relationName string
+	switch len(sections) {
+	case 1:
+		searchSchemas, err = resolve.SearchPath(ctx)
+		if err != nil {
+			return 0, err
+		}
+		relationName = sections[0]
+	case 3:
+		searchSchemas = []string{sections[0]}
+		relationName = sections[2]
+	default:
+		return 0, fmt.Errorf("regclass failed validation")
+	}
+	// Iterate over all of the items to find which relation matches.
+	// Postgres does not need to worry about name conflicts since everything is created in the same naming space, but
+	// GMS and Dolt use different naming spaces, so for now we just ignore potential name conflicts and return the first
+	// match found.
+	resultOid := uint32(0)
+	err = IterateCurrentDatabase(ctx, Callbacks{
+		Index: func(ctx *sql.Context, schema ItemSchema, table ItemTable, index ItemIndex) (cont bool, err error) {
+			idxName := index.Item.ID()
+			if idxName == "PRIMARY" {
+				idxName = fmt.Sprintf("%s_pkey", index.Item.Table())
+			}
+			if relationName == idxName {
+				resultOid = index.OID
+				return false, nil
+			}
+			return true, nil
+		},
+		Sequence: func(ctx *sql.Context, schema ItemSchema, sequence ItemSequence) (cont bool, err error) {
+			if sequence.Item.Name == relationName {
+				resultOid = sequence.OID
+				return false, nil
+			}
+			return true, nil
+		},
+		Table: func(ctx *sql.Context, schema ItemSchema, table ItemTable) (cont bool, err error) {
+			if table.Item.Name() == relationName {
+				resultOid = table.OID
+				return false, nil
+			}
+			return true, nil
+		},
+		View: func(ctx *sql.Context, schema ItemSchema, view ItemView) (cont bool, err error) {
+			if view.Item.Name == relationName {
+				resultOid = view.OID
+				return false, nil
+			}
+			return true, nil
+		},
+		SearchSchemas: searchSchemas,
+	})
+	if err != nil || resultOid != 0 {
+		return resultOid, err
+	}
+	return 0, fmt.Errorf(`relation "%s" does not exist`, input)
+}
+
+// regclass_IoOutput is the implementation for IoOutput that avoids circular dependencies by being declared in a separate
+// package.
+func regclass_IoOutput(ctx *sql.Context, oid uint32) (string, error) {
+	output := strconv.FormatUint(uint64(oid), 10)
+	err := RunCallback(ctx, oid, Callbacks{
+		Index: func(ctx *sql.Context, schema ItemSchema, table ItemTable, index ItemIndex) (cont bool, err error) {
+			output = index.Item.ID()
+			if output == "PRIMARY" {
+				output = fmt.Sprintf("%s_pkey", index.Item.Table())
+			}
+			return false, nil
+		},
+		Sequence: func(ctx *sql.Context, schema ItemSchema, sequence ItemSequence) (cont bool, err error) {
+			output = sequence.Item.Name
+			return false, nil
+		},
+		Table: func(ctx *sql.Context, schema ItemSchema, table ItemTable) (cont bool, err error) {
+			output = table.Item.Name()
+			return false, nil
+		},
+		View: func(ctx *sql.Context, schema ItemSchema, view ItemView) (cont bool, err error) {
+			output = view.Item.Name
+			return false, nil
+		},
+	})
+	return output, err
+}
+
+// regclass_IoInputValidation handles the validation for the parsed sections in regclass_IoInput.
+func regclass_IoInputValidation(ctx *sql.Context, input string, sections []string) error {
+	switch len(sections) {
+	case 1:
+		return nil
+	case 3:
+		if sections[1] != "." {
+			return fmt.Errorf("invalid name syntax")
+		}
+		return nil
+	case 5:
+		if sections[1] != "." || sections[3] != "." {
+			return fmt.Errorf("invalid name syntax")
+		}
+		return fmt.Errorf("cross-database references are not implemented: %s", input)
+	case 7:
+		if sections[1] != "." || sections[3] != "." || sections[5] != "." {
+			return fmt.Errorf("invalid name syntax")
+		}
+		return fmt.Errorf("improper qualified name (too many dotted names): %s", input)
+	default:
+		return fmt.Errorf("invalid name syntax")
+	}
+}

--- a/server/types/oid/regproc.go
+++ b/server/types/oid/regproc.go
@@ -1,0 +1,98 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oid
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// regproc_IoInput is the implementation for IoInput that avoids circular dependencies by being declared in a separate
+// package.
+func regproc_IoInput(ctx *sql.Context, input string) (uint32, error) {
+	// If the string just represents a number, then we return it.
+	if parsedOid, err := strconv.ParseUint(input, 10, 32); err == nil {
+		return uint32(parsedOid), nil
+	}
+	sections, err := ioInputSections(input)
+	if err != nil {
+		return 0, err
+	}
+	if err = regproc_IoInputValidation(ctx, input, sections); err != nil {
+		return 0, err
+	}
+	switch len(sections) {
+	case 1:
+		// TODO: handle procedures, aggregate functions, and window functions
+		name := sections[0]
+		oid := uint32(0)
+		err = IterateCurrentDatabase(ctx, Callbacks{
+			Function: func(ctx *sql.Context, function ItemFunction) (cont bool, err error) {
+				if function.Item.FunctionName() == name {
+					// TODO: this should error for overloaded functions
+					oid = function.OID
+					return false, nil
+				}
+				return true, nil
+			},
+		})
+		if err != nil || oid != 0 {
+			return oid, err
+		}
+		return 0, fmt.Errorf(`"function "%s" does not exist"`, input)
+	default:
+		return 0, fmt.Errorf("regproc failed validation")
+	}
+}
+
+// regproc_IoOutput is the implementation for IoOutput that avoids circular dependencies by being declared in a separate
+// package.
+func regproc_IoOutput(ctx *sql.Context, oid uint32) (string, error) {
+	output := strconv.FormatUint(uint64(oid), 10)
+	err := RunCallback(ctx, oid, Callbacks{
+		Function: func(ctx *sql.Context, function ItemFunction) (cont bool, err error) {
+			output = function.Item.FunctionName()
+			return false, nil
+		},
+	})
+	return output, err
+}
+
+// regproc_IoInputValidation handles the validation for the parsed sections in regproc_IoInput.
+func regproc_IoInputValidation(ctx *sql.Context, input string, sections []string) error {
+	switch len(sections) {
+	case 1:
+		return nil
+	case 3:
+		if sections[1] != "." {
+			return fmt.Errorf("invalid name syntax")
+		}
+		return fmt.Errorf("functions are not yet implemented in terms of the schema")
+	case 5:
+		if sections[1] != "." || sections[3] != "." {
+			return fmt.Errorf("invalid name syntax")
+		}
+		return fmt.Errorf("cross-database references are not implemented: %s", input)
+	case 7:
+		if sections[1] != "." || sections[3] != "." || sections[5] != "." {
+			return fmt.Errorf("invalid name syntax")
+		}
+		return fmt.Errorf("improper qualified name (too many dotted names): %s", input)
+	default:
+		return fmt.Errorf("invalid name syntax")
+	}
+}

--- a/server/types/regclass.go
+++ b/server/types/regclass.go
@@ -16,11 +16,8 @@ package types
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"reflect"
-	"strconv"
-	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
@@ -29,46 +26,46 @@ import (
 	"github.com/lib/pq/oid"
 )
 
-// Xid is a data type used for internal transaction IDs. It is implemented as an unsigned 32 bit integer.
-var Xid = XidType{}
+// Regclass is the OID type for finding items in pg_class.
+var Regclass = RegclassType{}
 
-// XidType is the extended type implementation of the PostgreSQL xid.
-type XidType struct{}
+// RegclassType is the extended type implementation of the PostgreSQL regclass.
+type RegclassType struct{}
 
-var _ DoltgresType = XidType{}
+var _ DoltgresType = RegclassType{}
 
 // Alignment implements the DoltgresType interface.
-func (b XidType) Alignment() TypeAlignment {
+func (b RegclassType) Alignment() TypeAlignment {
 	return TypeAlignment_Int
 }
 
 // BaseID implements the DoltgresType interface.
-func (b XidType) BaseID() DoltgresTypeBaseID {
-	return DoltgresTypeBaseID_Xid
+func (b RegclassType) BaseID() DoltgresTypeBaseID {
+	return DoltgresTypeBaseID_Regclass
 }
 
 // BaseName implements the DoltgresType interface.
-func (b XidType) BaseName() string {
-	return "xid"
+func (b RegclassType) BaseName() string {
+	return "regclass"
 }
 
 // Category implements the DoltgresType interface.
-func (b XidType) Category() TypeCategory {
-	return TypeCategory_UserDefinedTypes
+func (b RegclassType) Category() TypeCategory {
+	return TypeCategory_NumericTypes
 }
 
 // CollationCoercibility implements the DoltgresType interface.
-func (b XidType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+func (b RegclassType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
 	return sql.Collation_binary, 5
 }
 
 // Compare implements the DoltgresType interface.
-func (b XidType) Compare(v1 any, v2 any) (int, error) {
-	return compareUint32(b, v1, v2)
+func (b RegclassType) Compare(v1 any, v2 any) (int, error) {
+	return OidType{}.Compare(v1, v2)
 }
 
 // Convert implements the DoltgresType interface.
-func (b XidType) Convert(val any) (any, sql.ConvertInRange, error) {
+func (b RegclassType) Convert(val any) (any, sql.ConvertInRange, error) {
 	switch val := val.(type) {
 	case uint32:
 		return val, sql.InRange, nil
@@ -80,7 +77,7 @@ func (b XidType) Convert(val any) (any, sql.ConvertInRange, error) {
 }
 
 // Equals implements the DoltgresType interface.
-func (b XidType) Equals(otherType sql.Type) bool {
+func (b RegclassType) Equals(otherType sql.Type) bool {
 	if otherExtendedType, ok := otherType.(types.ExtendedType); ok {
 		return bytes.Equal(MustSerializeType(b), MustSerializeType(otherExtendedType))
 	}
@@ -88,7 +85,7 @@ func (b XidType) Equals(otherType sql.Type) bool {
 }
 
 // FormatValue implements the DoltgresType interface.
-func (b XidType) FormatValue(val any) (string, error) {
+func (b RegclassType) FormatValue(val any) (string, error) {
 	if val == nil {
 		return "", nil
 	}
@@ -96,60 +93,62 @@ func (b XidType) FormatValue(val any) (string, error) {
 }
 
 // GetSerializationID implements the DoltgresType interface.
-func (b XidType) GetSerializationID() SerializationID {
-	return SerializationID_Xid
+func (b RegclassType) GetSerializationID() SerializationID {
+	return SerializationID_Invalid
 }
+
+// Regclass_IoInput is the implementation for IoInput that is being set from another package to avoid circular dependencies.
+var Regclass_IoInput func(ctx *sql.Context, input string) (uint32, error)
 
 // IoInput implements the DoltgresType interface.
-func (b XidType) IoInput(ctx *sql.Context, input string) (any, error) {
-	val, err := strconv.ParseInt(strings.TrimSpace(input), 10, 64)
-	if err != nil {
-		return uint32(0), nil
-	}
-	return uint32(val), nil
+func (b RegclassType) IoInput(ctx *sql.Context, input string) (any, error) {
+	return Regclass_IoInput(ctx, input)
 }
 
+// Regclass_IoOutput is the implementation for IoOutput that is being set from another package to avoid circular dependencies.
+var Regclass_IoOutput func(ctx *sql.Context, oid uint32) (string, error)
+
 // IoOutput implements the DoltgresType interface.
-func (b XidType) IoOutput(ctx *sql.Context, output any) (string, error) {
+func (b RegclassType) IoOutput(ctx *sql.Context, output any) (string, error) {
 	converted, _, err := b.Convert(output)
 	if err != nil {
 		return "", err
 	}
-	return strconv.FormatUint(uint64(converted.(uint32)), 10), nil
+	return Regclass_IoOutput(ctx, converted.(uint32))
 }
 
 // IsPreferredType implements the DoltgresType interface.
-func (b XidType) IsPreferredType() bool {
+func (b RegclassType) IsPreferredType() bool {
 	return false
 }
 
 // IsUnbounded implements the DoltgresType interface.
-func (b XidType) IsUnbounded() bool {
+func (b RegclassType) IsUnbounded() bool {
 	return false
 }
 
 // MaxSerializedWidth implements the DoltgresType interface.
-func (b XidType) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
+func (b RegclassType) MaxSerializedWidth() types.ExtendedTypeSerializedWidth {
 	return types.ExtendedTypeSerializedWidth_64K
 }
 
 // MaxTextResponseByteLength implements the DoltgresType interface.
-func (b XidType) MaxTextResponseByteLength(ctx *sql.Context) uint32 {
+func (b RegclassType) MaxTextResponseByteLength(ctx *sql.Context) uint32 {
 	return 4
 }
 
 // OID implements the DoltgresType interface.
-func (b XidType) OID() uint32 {
-	return uint32(oid.T_xid)
+func (b RegclassType) OID() uint32 {
+	return uint32(oid.T_regclass)
 }
 
 // Promote implements the DoltgresType interface.
-func (b XidType) Promote() sql.Type {
+func (b RegclassType) Promote() sql.Type {
 	return b
 }
 
 // SerializedCompare implements the DoltgresType interface.
-func (b XidType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
+func (b RegclassType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 	if len(v1) == 0 && len(v2) == 0 {
 		return 0, nil
 	} else if len(v1) > 0 && len(v2) == 0 {
@@ -162,7 +161,7 @@ func (b XidType) SerializedCompare(v1 []byte, v2 []byte) (int, error) {
 }
 
 // SQL implements the DoltgresType interface.
-func (b XidType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
+func (b RegclassType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}
@@ -174,63 +173,46 @@ func (b XidType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, erro
 }
 
 // String implements the DoltgresType interface.
-func (b XidType) String() string {
-	return "xid"
+func (b RegclassType) String() string {
+	return "regclass"
 }
 
 // ToArrayType implements the DoltgresType interface.
-func (b XidType) ToArrayType() DoltgresArrayType {
-	return XidArray
+func (b RegclassType) ToArrayType() DoltgresArrayType {
+	return RegclassArray
 }
 
 // Type implements the DoltgresType interface.
-func (b XidType) Type() query.Type {
-	return sqltypes.Uint32
+func (b RegclassType) Type() query.Type {
+	return sqltypes.Text
 }
 
 // ValueType implements the DoltgresType interface.
-func (b XidType) ValueType() reflect.Type {
+func (b RegclassType) ValueType() reflect.Type {
 	return reflect.TypeOf(uint32(0))
 }
 
 // Zero implements the DoltgresType interface.
-func (b XidType) Zero() any {
+func (b RegclassType) Zero() any {
 	return uint32(0)
 }
 
 // SerializeType implements the DoltgresType interface.
-func (b XidType) SerializeType() ([]byte, error) {
-	return SerializationID_Xid.ToByteSlice(0), nil
+func (b RegclassType) SerializeType() ([]byte, error) {
+	return nil, fmt.Errorf("%s cannot be serialized", b.String())
 }
 
 // deserializeType implements the DoltgresType interface.
-func (b XidType) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
-	switch version {
-	case 0:
-		return Xid, nil
-	default:
-		return nil, fmt.Errorf("version %d is not yet supported for %s", version, b.String())
-	}
+func (b RegclassType) deserializeType(version uint16, metadata []byte) (DoltgresType, error) {
+	return nil, fmt.Errorf("%s cannot be deserialized", b.String())
 }
 
 // SerializeValue implements the DoltgresType interface.
-func (b XidType) SerializeValue(val any) ([]byte, error) {
-	if val == nil {
-		return nil, nil
-	}
-	converted, _, err := b.Convert(val)
-	if err != nil {
-		return nil, err
-	}
-	retVal := make([]byte, 4)
-	binary.BigEndian.PutUint32(retVal, uint32(converted.(uint32)))
-	return retVal, nil
+func (b RegclassType) SerializeValue(val any) ([]byte, error) {
+	return nil, fmt.Errorf("%s cannot serialize values", b.String())
 }
 
 // DeserializeValue implements the DoltgresType interface.
-func (b XidType) DeserializeValue(val []byte) (any, error) {
-	if len(val) == 0 {
-		return nil, nil
-	}
-	return uint32(binary.BigEndian.Uint32(val)), nil
+func (b RegclassType) DeserializeValue(val []byte) (any, error) {
+	return nil, fmt.Errorf("%s cannot deserialize values", b.String())
 }

--- a/server/types/regclass_array.go
+++ b/server/types/regclass_array.go
@@ -12,24 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cast
+package types
 
-// Init initializes all casts in this package.
-func Init() {
-	initBool()
-	initChar()
-	initFloat32()
-	initFloat64()
-	initInt16()
-	initInt32()
-	initInt64()
-	initJson()
-	initJsonB()
-	initName()
-	initNumeric()
-	initOid()
-	initRegclass()
-	initRegproc()
-	initText()
-	initVarChar()
-}
+import "github.com/lib/pq/oid"
+
+// RegclassArray is the array variant of Regclass.
+var RegclassArray = createArrayType(Regclass, SerializationID_Invalid, oid.T__regclass)

--- a/server/types/regproc_array.go
+++ b/server/types/regproc_array.go
@@ -12,24 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cast
+package types
 
-// Init initializes all casts in this package.
-func Init() {
-	initBool()
-	initChar()
-	initFloat32()
-	initFloat64()
-	initInt16()
-	initInt32()
-	initInt64()
-	initJson()
-	initJsonB()
-	initName()
-	initNumeric()
-	initOid()
-	initRegclass()
-	initRegproc()
-	initText()
-	initVarChar()
-}
+import "github.com/lib/pq/oid"
+
+// RegprocArray is the array variant of Regproc.
+var RegprocArray = createArrayType(Regproc, SerializationID_Invalid, oid.T__regproc)

--- a/server/types/text.go
+++ b/server/types/text.go
@@ -112,21 +112,12 @@ func (b TextType) Equals(otherType sql.Type) bool {
 	return false
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (b TextType) FormatSerializedValue(val []byte) (string, error) {
-	deserialized, err := b.DeserializeValue(val)
-	if err != nil {
-		return "", err
-	}
-	return b.FormatValue(deserialized)
-}
-
 // FormatValue implements the DoltgresType interface.
 func (b TextType) FormatValue(val any) (string, error) {
 	if val == nil {
 		return "", nil
 	}
-	return b.IoOutput(val)
+	return b.IoOutput(sql.NewEmptyContext(), val)
 }
 
 // GetSerializationID implements the DoltgresType interface.
@@ -135,12 +126,12 @@ func (b TextType) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (b TextType) IoInput(input string) (any, error) {
+func (b TextType) IoInput(ctx *sql.Context, input string) (any, error) {
 	return input, nil
 }
 
 // IoOutput implements the DoltgresType interface.
-func (b TextType) IoOutput(output any) (string, error) {
+func (b TextType) IoOutput(ctx *sql.Context, output any) (string, error) {
 	converted, _, err := b.Convert(output)
 	if err != nil {
 		return "", err
@@ -195,7 +186,7 @@ func (b TextType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, err
 	if v == nil {
 		return sqltypes.NULL, nil
 	}
-	value, err := b.FormatValue(v)
+	value, err := b.IoOutput(ctx, v)
 	if err != nil {
 		return sqltypes.Value{}, err
 	}

--- a/server/types/timestamp.go
+++ b/server/types/timestamp.go
@@ -107,21 +107,12 @@ func (b TimestampType) Equals(otherType sql.Type) bool {
 	return false
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (b TimestampType) FormatSerializedValue(val []byte) (string, error) {
-	deserialized, err := b.DeserializeValue(val)
-	if err != nil {
-		return "", err
-	}
-	return b.FormatValue(deserialized)
-}
-
 // FormatValue implements the DoltgresType interface.
 func (b TimestampType) FormatValue(val any) (string, error) {
 	if val == nil {
 		return "", nil
 	}
-	return b.IoOutput(val)
+	return b.IoOutput(sql.NewEmptyContext(), val)
 }
 
 // GetSerializationID implements the DoltgresType interface.
@@ -130,7 +121,7 @@ func (b TimestampType) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (b TimestampType) IoInput(input string) (any, error) {
+func (b TimestampType) IoInput(ctx *sql.Context, input string) (any, error) {
 	if t, err := time.Parse("2006-01-02 15:04:05", input); err == nil {
 		return t.UTC(), nil
 	} else if t, err = time.Parse("January 01 15:04:05 2006", input); err == nil {
@@ -140,7 +131,7 @@ func (b TimestampType) IoInput(input string) (any, error) {
 }
 
 // IoOutput implements the DoltgresType interface.
-func (b TimestampType) IoOutput(output any) (string, error) {
+func (b TimestampType) IoOutput(ctx *sql.Context, output any) (string, error) {
 	converted, _, err := b.Convert(output)
 	if err != nil {
 		return "", err
@@ -197,7 +188,7 @@ func (b TimestampType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value
 	if v == nil {
 		return sqltypes.NULL, nil
 	}
-	value, err := b.FormatValue(v)
+	value, err := b.IoOutput(ctx, v)
 	if err != nil {
 		return sqltypes.Value{}, err
 	}

--- a/server/types/timetz.go
+++ b/server/types/timetz.go
@@ -107,26 +107,12 @@ func (b TimeTZType) Equals(otherType sql.Type) bool {
 	return false
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (b TimeTZType) FormatSerializedValue(val []byte) (string, error) {
-	deserialized, err := b.DeserializeValue(val)
-	if err != nil {
-		return "", err
-	}
-	return b.FormatValue(deserialized)
-}
-
 // FormatValue implements the DoltgresType interface.
 func (b TimeTZType) FormatValue(val any) (string, error) {
 	if val == nil {
 		return "", nil
 	}
-	converted, _, err := b.Convert(val)
-	if err != nil {
-		return "", err
-	}
-	// TODO: this always displays the time with an offset relevant to the server location
-	return converted.(time.Time).Format("15:04:05-07"), nil
+	return b.IoOutput(sql.NewEmptyContext(), val)
 }
 
 // GetSerializationID implements the DoltgresType interface.
@@ -135,7 +121,7 @@ func (b TimeTZType) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (b TimeTZType) IoInput(input string) (any, error) {
+func (b TimeTZType) IoInput(ctx *sql.Context, input string) (any, error) {
 	if t, err := time.Parse("15:04:05-0700", input); err == nil {
 		return t, nil
 	} else if t, err = time.Parse("15:04:05-07:00", input); err == nil {
@@ -147,11 +133,12 @@ func (b TimeTZType) IoInput(input string) (any, error) {
 }
 
 // IoOutput implements the DoltgresType interface.
-func (b TimeTZType) IoOutput(output any) (string, error) {
+func (b TimeTZType) IoOutput(ctx *sql.Context, output any) (string, error) {
 	converted, _, err := b.Convert(output)
 	if err != nil {
 		return "", err
 	}
+	// TODO: this always displays the time with an offset relevant to the server location
 	return converted.(time.Time).Format("15:04:05-07"), nil
 }
 
@@ -204,7 +191,7 @@ func (b TimeTZType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, e
 	if v == nil {
 		return sqltypes.NULL, nil
 	}
-	value, err := b.FormatValue(v)
+	value, err := b.IoOutput(ctx, v)
 	if err != nil {
 		return sqltypes.Value{}, err
 	}

--- a/server/types/unknown.go
+++ b/server/types/unknown.go
@@ -81,11 +81,6 @@ func (u UnknownType) Equals(otherType sql.Type) bool {
 	return ok
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (u UnknownType) FormatSerializedValue(val []byte) (string, error) {
-	return "", fmt.Errorf("%s cannot format serialized values", u.String())
-}
-
 // FormatValue implements the DoltgresType interface.
 func (u UnknownType) FormatValue(val any) (string, error) {
 	return "", fmt.Errorf("%s cannot format values", u.String())
@@ -97,12 +92,12 @@ func (u UnknownType) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (u UnknownType) IoInput(input string) (any, error) {
+func (u UnknownType) IoInput(ctx *sql.Context, input string) (any, error) {
 	return "", fmt.Errorf("%s cannot receive I/O input", u.String())
 }
 
 // IoOutput implements the DoltgresType interface.
-func (u UnknownType) IoOutput(output any) (string, error) {
+func (u UnknownType) IoOutput(ctx *sql.Context, output any) (string, error) {
 	return "", fmt.Errorf("%s cannot produce I/O output", u.String())
 }
 

--- a/server/types/uuid.go
+++ b/server/types/uuid.go
@@ -105,21 +105,12 @@ func (b UuidType) Equals(otherType sql.Type) bool {
 	return false
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (b UuidType) FormatSerializedValue(val []byte) (string, error) {
-	deserialized, err := b.DeserializeValue(val)
-	if err != nil {
-		return "", err
-	}
-	return b.FormatValue(deserialized)
-}
-
 // FormatValue implements the DoltgresType interface.
 func (b UuidType) FormatValue(val any) (string, error) {
 	if val == nil {
 		return "", nil
 	}
-	return b.IoOutput(val)
+	return b.IoOutput(sql.NewEmptyContext(), val)
 }
 
 // GetSerializationID implements the DoltgresType interface.
@@ -128,12 +119,12 @@ func (b UuidType) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (b UuidType) IoInput(input string) (any, error) {
+func (b UuidType) IoInput(ctx *sql.Context, input string) (any, error) {
 	return uuid.FromString(input)
 }
 
 // IoOutput implements the DoltgresType interface.
-func (b UuidType) IoOutput(output any) (string, error) {
+func (b UuidType) IoOutput(ctx *sql.Context, output any) (string, error) {
 	converted, _, err := b.Convert(output)
 	if err != nil {
 		return "", err

--- a/server/types/varchar.go
+++ b/server/types/varchar.go
@@ -131,21 +131,12 @@ func (b VarCharType) Equals(otherType sql.Type) bool {
 	return false
 }
 
-// FormatSerializedValue implements the DoltgresType interface.
-func (b VarCharType) FormatSerializedValue(val []byte) (string, error) {
-	deserialized, err := b.DeserializeValue(val)
-	if err != nil {
-		return "", err
-	}
-	return b.FormatValue(deserialized)
-}
-
 // FormatValue implements the DoltgresType interface.
 func (b VarCharType) FormatValue(val any) (string, error) {
 	if val == nil {
 		return "", nil
 	}
-	return b.IoOutput(val)
+	return b.IoOutput(sql.NewEmptyContext(), val)
 }
 
 // GetSerializationID implements the DoltgresType interface.
@@ -154,7 +145,7 @@ func (b VarCharType) GetSerializationID() SerializationID {
 }
 
 // IoInput implements the DoltgresType interface.
-func (b VarCharType) IoInput(input string) (any, error) {
+func (b VarCharType) IoInput(ctx *sql.Context, input string) (any, error) {
 	if b.IsUnbounded() {
 		return input, nil
 	}
@@ -167,7 +158,7 @@ func (b VarCharType) IoInput(input string) (any, error) {
 }
 
 // IoOutput implements the DoltgresType interface.
-func (b VarCharType) IoOutput(output any) (string, error) {
+func (b VarCharType) IoOutput(ctx *sql.Context, output any) (string, error) {
 	converted, _, err := b.Convert(output)
 	if err != nil {
 		return "", err
@@ -234,7 +225,7 @@ func (b VarCharType) SQL(ctx *sql.Context, dest []byte, v any) (sqltypes.Value, 
 	if v == nil {
 		return sqltypes.NULL, nil
 	}
-	value, err := b.FormatValue(v)
+	value, err := b.IoOutput(ctx, v)
 	if err != nil {
 		return sqltypes.Value{}, err
 	}

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -154,6 +154,79 @@ func TestFunctionsMath(t *testing.T) {
 	})
 }
 
+func TestFunctionsOID(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "to_regclass",
+			SetUpScript: []string{
+				`CREATE TABLE testing (pk INT primary key, v1 INT UNIQUE);`,
+				`CREATE TABLE "Testing2" (pk INT primary key, v1 INT);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `SELECT to_regclass('testing');`,
+					Expected: []sql.Row{
+						{"testing"},
+					},
+				},
+				{
+					Query: `SELECT to_regclass('Testing2');`,
+					Expected: []sql.Row{
+						{nil},
+					},
+				},
+				{
+					Query: `SELECT to_regclass('"Testing2"');`,
+					Expected: []sql.Row{
+						{"Testing2"},
+					},
+				},
+				{
+					Query: `SELECT to_regclass(('testing'::regclass)::text);`,
+					Expected: []sql.Row{
+						{"testing"},
+					},
+				},
+				{
+					Query: `SELECT to_regclass((('testing'::regclass)::oid)::text);`,
+					Expected: []sql.Row{
+						{nil},
+					},
+				},
+			},
+		},
+		{
+			Name: "to_regproc",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `SELECT to_regproc('acos');`,
+					Expected: []sql.Row{
+						{"acos"},
+					},
+				},
+				{
+					Query: `SELECT to_regproc('acos"');`,
+					Expected: []sql.Row{
+						{nil},
+					},
+				},
+				{
+					Query: `SELECT to_regproc(('acos'::regproc)::text);`,
+					Expected: []sql.Row{
+						{"acos"},
+					},
+				},
+				{
+					Query: `SELECT to_regproc((('acos'::regproc)::oid)::text);`,
+					Expected: []sql.Row{
+						{nil},
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestSystemInformationFunctions(t *testing.T) {
 	RunScripts(t, []ScriptTest{
 		{

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -126,11 +126,11 @@ func TestPgAttribute(t *testing.T) {
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT * FROM "pg_catalog"."pg_attribute" WHERE attname='pk';`,
-					Expected: []sql.Row{{2650014423, "pk", 23, 0, 1331, -1, -1, 0, "f", "i", "p", "", "t", "f", "f", "", "", "f", "t", 0, -1, 0, nil, nil, nil, nil}},
+					Expected: []sql.Row{{2686451712, "pk", 23, 0, 1331, -1, -1, 0, "f", "i", "p", "", "t", "f", "f", "", "", "f", "t", 0, -1, 0, nil, nil, nil, nil}},
 				},
 				{
 					Query:    `SELECT * FROM "pg_catalog"."pg_attribute" WHERE attname='v1';`,
-					Expected: []sql.Row{{2650014423, "v1", 25, 0, 1332, -1, -1, 0, "f", "i", "p", "", "f", "t", "f", "", "", "f", "t", 0, -1, 0, nil, nil, nil, nil}},
+					Expected: []sql.Row{{2686451712, "v1", 25, 0, 1332, -1, -1, 0, "f", "i", "p", "", "f", "t", "f", "", "", "f", "t", 0, -1, 0, nil, nil, nil, nil}},
 				},
 				{ // Different cases and quoted, so it fails
 					Query:       `SELECT * FROM "PG_catalog"."pg_attribute";`,
@@ -361,18 +361,22 @@ func TestPgClass(t *testing.T) {
 				{
 					Query: `SELECT * FROM "pg_catalog"."pg_class" WHERE relname='testing';`,
 					Expected: []sql.Row{
-						{3421834825, "testing", 3874471750, 0, 0, 0, 0, 0, 0, 0, float32(0), 0, 0, "t", "f", "p", "r", 0, 0, "f", "f", "f", "f", "f", "t", "d", "f", 0, 0, 0, nil, nil, nil},
+						{2686451712, "testing", 1879048194, 0, 0, 0, 0, 0, 0, 0, float32(0), 0, 0, "t", "f", "p", "r", 0, 0, "f", "f", "f", "f", "f", "t", "d", "f", 0, 0, 0, nil, nil, nil},
 					},
 				},
 				// Index
 				{
-					Query:    `SELECT * FROM "pg_catalog"."pg_class" WHERE relname='testing_pkey';`,
-					Expected: []sql.Row{{2755706564, "testing_pkey", 3874471750, 0, 0, 0, 0, 0, 0, 0, float32(0), 0, 0, "f", "f", "p", "i", 0, 0, "f", "f", "f", "f", "f", "t", "d", "f", 0, 0, 0, nil, nil, nil}},
+					Query: `SELECT * FROM "pg_catalog"."pg_class" WHERE relname='testing_pkey';`,
+					Expected: []sql.Row{
+						{1612709888, "testing_pkey", 1879048194, 0, 0, 0, 0, 0, 0, 0, float32(0), 0, 0, "f", "f", "p", "i", 0, 0, "f", "f", "f", "f", "f", "t", "d", "f", 0, 0, 0, nil, nil, nil},
+					},
 				},
 				// View
 				{
-					Query:    `SELECT * FROM "pg_catalog"."pg_class" WHERE relname='testview';`,
-					Expected: []sql.Row{{3365776452, "testview", 3874471750, 0, 0, 0, 0, 0, 0, 0, float32(0), 0, 0, "f", "f", "p", "v", 0, 0, "f", "f", "f", "f", "f", "t", "d", "f", 0, 0, 0, nil, nil, nil}},
+					Query: `SELECT * FROM "pg_catalog"."pg_class" WHERE relname='testview';`,
+					Expected: []sql.Row{
+						{2954887168, "testview", 1879048194, 0, 0, 0, 0, 0, 0, 0, float32(0), 0, 0, "f", "f", "p", "v", 0, 0, "f", "f", "f", "f", "f", "t", "d", "f", 0, 0, 0, nil, nil, nil},
+					},
 				},
 				{ // Different cases and quoted, so it fails
 					Query:       `SELECT * FROM "PG_catalog"."pg_class";`,
@@ -391,12 +395,12 @@ func TestPgClass(t *testing.T) {
 					},
 				},
 				{
-					Query: "SELECT relname from pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid  WHERE n.nspname = 'testschema';",
+					Query: "SELECT relname from pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid  WHERE n.nspname = 'testschema' ORDER BY relname;",
 					Expected: []sql.Row{
-						{"testing_pkey"},
-						{"v1"},
 						{"testing"},
+						{"testing_pkey"},
 						{"testview"},
+						{"v1"},
 					},
 				},
 				{
@@ -405,6 +409,41 @@ func TestPgClass(t *testing.T) {
 						{"pg_aggregate"},
 						{"pg_am"},
 						{"pg_amop"},
+					},
+				},
+			},
+		},
+		{
+			Name: "pg_class with regclass",
+			SetUpScript: []string{
+				`CREATE SCHEMA testschema;`,
+				`SET search_path TO testschema;`,
+				`CREATE TABLE testing (pk INT primary key, v1 INT UNIQUE);`,
+				`CREATE VIEW testview AS SELECT * FROM testing LIMIT 1;`,
+				`CREATE SCHEMA testschema2;`,
+				`SET search_path TO testschema2;`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:       `SELECT * FROM "pg_catalog"."pg_class" WHERE oid='testing'::regclass;`,
+					ExpectedErr: "does not exist",
+				},
+				{
+					Query: `SELECT * FROM "pg_catalog"."pg_class" WHERE oid='testschema.testing'::regclass;`,
+					Expected: []sql.Row{
+						{2686451712, "testing", 1879048194, 0, 0, 0, 0, 0, 0, 0, float32(0), 0, 0, "t", "f", "p", "r", 0, 0, "f", "f", "f", "f", "f", "t", "d", "f", 0, 0, 0, nil, nil, nil},
+					},
+				},
+				{
+					Query: `SELECT * FROM "pg_catalog"."pg_class" WHERE oid='testschema.testing_pkey'::regclass;`,
+					Expected: []sql.Row{
+						{1612709888, "testing_pkey", 1879048194, 0, 0, 0, 0, 0, 0, 0, float32(0), 0, 0, "f", "f", "p", "i", 0, 0, "f", "f", "f", "f", "f", "t", "d", "f", 0, 0, 0, nil, nil, nil},
+					},
+				},
+				{
+					Query: `SELECT * FROM "pg_catalog"."pg_class" WHERE oid='testschema.testview'::regclass;`,
+					Expected: []sql.Row{
+						{2954887168, "testview", 1879048194, 0, 0, 0, 0, 0, 0, 0, float32(0), 0, 0, "f", "f", "p", "v", 0, 0, "f", "f", "f", "f", "f", "t", "d", "f", 0, 0, 0, nil, nil, nil},
 					},
 				},
 			},
@@ -478,11 +517,11 @@ func TestPgConstraint(t *testing.T) {
 				{
 					Query: `SELECT * FROM "pg_catalog"."pg_constraint";`,
 					Expected: []sql.Row{
-						{2417240761, "testing_pkey", 3313866986, "p", "f", "f", "t", 2965627175, 0, 2417240761, 0, 0, "", "", "", "t", 0, "t", nil, nil, nil, nil, nil, nil, nil, nil},
-						{2372902490, "v1", 3313866986, "u", "f", "f", "t", 2965627175, 0, 2372902490, 0, 0, "", "", "", "t", 0, "t", nil, nil, nil, nil, nil, nil, nil, nil},
-						{2205885068, "testing2_pkey", 3313866986, "p", "f", "f", "t", 4009776262, 0, 2205885068, 0, 0, "", "", "", "t", 0, "t", nil, nil, nil, nil, nil, nil, nil, nil},
+						{1611661312, "testing_pkey", 1879048193, "p", "f", "f", "t", 2685403136, 0, 1611661312, 0, 0, "", "", "", "t", 0, "t", nil, nil, nil, nil, nil, nil, nil, nil},
+						{1611661313, "v1", 1879048193, "u", "f", "f", "t", 2685403136, 0, 1611661313, 0, 0, "", "", "", "t", 0, "t", nil, nil, nil, nil, nil, nil, nil, nil},
+						{1611661314, "testing2_pkey", 1879048193, "p", "f", "f", "t", 2685403137, 0, 1611661314, 0, 0, "", "", "", "t", 0, "t", nil, nil, nil, nil, nil, nil, nil, nil},
 						// TODO: Uncomment when foreign keys work
-						// {2205885068, "testing2_pktesting_fkey", 3313866986, "f", "f", "t", 4009776262, 0, 2205885068, 0, 0, "", "", "", "t", 0, "t", nil, nil, nil, nil, nil, nil, nil, nil}},
+						// {1611661314, "testing2_pktesting_fkey", 1879048193, "f", "f", "t", 2685403137, 0, 1611661314, 0, 0, "", "", "", "t", 0, "t", nil, nil, nil, nil, nil, nil, nil, nil}},
 					},
 				},
 				{ // Different cases and quoted, so it fails
@@ -504,7 +543,7 @@ func TestPgConstraint(t *testing.T) {
 				{
 					Query: "SELECT co.oid, co.conname, co.conrelid, cl.relname FROM pg_catalog.pg_constraint co JOIN pg_catalog.pg_class cl ON co.conrelid = cl.oid WHERE cl.relname = 'testing2';",
 					Expected: []sql.Row{
-						{2205885068, "testing2_pkey", 4009776262, "testing2"},
+						{1611661314, "testing2_pkey", 2685403137, "testing2"},
 					},
 				},
 			},
@@ -582,11 +621,11 @@ func TestPgDatabase(t *testing.T) {
 					},
 				},
 				{
-					Query: `SELECT oid, datname FROM "pg_catalog"."pg_database" ORDER BY oid DESC;`,
+					Query: `SELECT oid, datname FROM "pg_catalog"."pg_database" ORDER BY datname DESC;`,
 					Expected: []sql.Row{
-						{3906608034, "postgres"},
-						{3680993593, "test"},
-						{2414594895, "doltgres"},
+						{805306370, "test"},
+						{805306369, "postgres"},
+						{805306368, "doltgres"},
 					},
 				},
 				{ // Different cases and quoted, so it fails
@@ -600,15 +639,15 @@ func TestPgDatabase(t *testing.T) {
 				{ // Different cases but non-quoted, so it works
 					Query: "SELECT oid, datname FROM PG_catalog.pg_DATABASE ORDER BY datname ASC;",
 					Expected: []sql.Row{
-						{2414594895, "doltgres"},
-						{3906608034, "postgres"},
-						{3680993593, "test"},
+						{805306368, "doltgres"},
+						{805306369, "postgres"},
+						{805306370, "test"},
 					},
 				},
 				{
 					Query: "SELECT * FROM pg_catalog.pg_database WHERE datname='test';",
 					Expected: []sql.Row{
-						{3680993593, "test", 0, 0, "i", "f", "t", -1, 0, 0, 0, "", "", nil, "", nil, nil},
+						{805306370, "test", 0, 0, "i", "f", "t", -1, 0, 0, 0, "", "", nil, "", nil, nil},
 					},
 				},
 			},
@@ -994,9 +1033,9 @@ func TestPgIndex(t *testing.T) {
 				{
 					Query: `SELECT * FROM "pg_catalog"."pg_index";`,
 					Expected: []sql.Row{
-						{2755706564, 3421834825, 1, 0, "t", "f", "t", "f", "f", "f", "t", "f", "t", "t", "f", "{}", "{}", "{}", "{}", nil, nil},
-						{3477907979, 3421834825, 1, 0, "t", "f", "f", "f", "f", "f", "t", "f", "t", "t", "f", "{}", "{}", "{}", "{}", nil, nil},
-						{3966643545, 2794008446, 2, 0, "t", "f", "t", "f", "f", "f", "t", "f", "t", "t", "f", "{}", "{}", "{}", "{}", nil, nil},
+						{1612709888, 2686451712, 1, 0, "t", "f", "t", "f", "f", "f", "t", "f", "t", "t", "f", "{}", "{}", "{}", "{}", nil, nil},
+						{1612709889, 2686451712, 1, 0, "t", "f", "f", "f", "f", "f", "t", "f", "t", "t", "f", "{}", "{}", "{}", "{}", nil, nil},
+						{1612709890, 2686451713, 2, 0, "t", "f", "t", "f", "f", "f", "t", "f", "t", "t", "f", "{}", "{}", "{}", "{}", nil, nil},
 					},
 				},
 				{ // Different cases and quoted, so it fails
@@ -1009,14 +1048,14 @@ func TestPgIndex(t *testing.T) {
 				},
 				{ // Different cases but non-quoted, so it works
 					Query:    "SELECT indexrelid FROM PG_catalog.pg_INDEX ORDER BY indexrelid ASC;",
-					Expected: []sql.Row{{2755706564}, {3477907979}, {3966643545}},
+					Expected: []sql.Row{{1612709888}, {1612709889}, {1612709890}},
 				},
 				{
 					Query: "SELECT i.indexrelid, i.indrelid, c.relname, t.relname  FROM pg_catalog.pg_index i JOIN pg_catalog.pg_class c ON i.indexrelid = c.oid JOIN pg_catalog.pg_class t ON i.indrelid = t.oid;",
 					Expected: []sql.Row{
-						{2755706564, 3421834825, "testing_pkey", "testing"},
-						{3477907979, 3421834825, "v1", "testing"},
-						{3966643545, 2794008446, "testing2_pkey", "testing2"},
+						{1612709888, 2686451712, "testing_pkey", "testing"},
+						{1612709889, 2686451712, "v1", "testing"},
+						{1612709890, 2686451713, "testing2_pkey", "testing2"},
 					},
 				},
 			},
@@ -1250,11 +1289,11 @@ func TestPgNamespace(t *testing.T) {
 			Name: "pg_namespace",
 			Assertions: []ScriptTestAssertion{
 				{
-					Query: `SELECT * FROM "pg_catalog"."pg_namespace";`,
+					Query: `SELECT * FROM "pg_catalog"."pg_namespace" ORDER BY nspname;`,
 					Expected: []sql.Row{
-						{2401452148, "pg_catalog", 0, nil},
-						{3313866986, "public", 0, nil},
-						{3662935674, "information_schema", 0, nil},
+						{1879048194, "information_schema", 0, nil},
+						{1879048192, "pg_catalog", 0, nil},
+						{1879048193, "public", 0, nil},
 					},
 				},
 				{ // Different cases and quoted, so it fails
@@ -1278,12 +1317,12 @@ func TestPgNamespace(t *testing.T) {
 					Expected: []sql.Row{},
 				},
 				{
-					Query: `SELECT * FROM "pg_catalog"."pg_namespace";`,
+					Query: `SELECT * FROM "pg_catalog"."pg_namespace" ORDER BY nspname;`,
 					Expected: []sql.Row{
-						{2401452148, "pg_catalog", 0, nil},
-						{3313866986, "public", 0, nil},
-						{3874471750, "testschema", 0, nil},
-						{3662935674, "information_schema", 0, nil},
+						{1879048195, "information_schema", 0, nil},
+						{1879048192, "pg_catalog", 0, nil},
+						{1879048193, "public", 0, nil},
+						{1879048194, "testschema", 0, nil},
 					},
 				},
 			},

--- a/testing/go/prepared_statement_test.go
+++ b/testing/go/prepared_statement_test.go
@@ -338,13 +338,13 @@ var pgCatalogTests = []ScriptTest{
 			{
 				Query:    `SELECT * FROM "pg_catalog"."pg_namespace" WHERE nspname=$1;`,
 				BindVars: []any{"testschema"},
-				Expected: []sql.Row{{3874471750, "testschema", 0, nil}},
+				Expected: []sql.Row{{1879048194, "testschema", 0, nil}},
 			},
 			{
 				Skip:     true, // TODO: Getting ERROR: cannot scan oid (OID 26) in binary format into *string
 				Query:    `SELECT * FROM "pg_catalog"."pg_namespace" WHERE oid=$1;`,
-				BindVars: []any{3874471750},
-				Expected: []sql.Row{{3874471750, "testschema", 0, nil}},
+				BindVars: []any{1879048194},
+				Expected: []sql.Row{{1879048194, "testschema", 0, nil}},
 			},
 		},
 	},

--- a/testing/go/sequences_test.go
+++ b/testing/go/sequences_test.go
@@ -653,15 +653,27 @@ func TestSequences(t *testing.T) {
 				{
 					Query: "SELECT * FROM pg_catalog.pg_sequence ORDER BY seqrelid;",
 					Expected: []sql.Row{
-						{1, 20, 1, 3, 9223372036854775807, 1, 1, "t"},
-						{2, 20, 1, 1, 9223372036854775807, 1, 1, "f"},
+						{2416967680, 20, 1, 3, 9223372036854775807, 1, 1, "t"},
+						{2416967681, 20, 1, 1, 9223372036854775807, 1, 1, "f"},
 					},
 				},
 				{ // Different cases but non-quoted, so it works
 					Query: "SELECT * FROM PG_catalog.pg_SEQUENCE ORDER BY seqrelid;",
 					Expected: []sql.Row{
-						{1, 20, 1, 3, 9223372036854775807, 1, 1, "t"},
-						{2, 20, 1, 1, 9223372036854775807, 1, 1, "f"},
+						{2416967680, 20, 1, 3, 9223372036854775807, 1, 1, "t"},
+						{2416967681, 20, 1, 1, 9223372036854775807, 1, 1, "f"},
+					},
+				},
+				{
+					Query: "SELECT * FROM pg_catalog.pg_sequence WHERE seqrelid = 'some_sequence'::regclass;",
+					Expected: []sql.Row{
+						{2416967681, 20, 1, 1, 9223372036854775807, 1, 1, "f"},
+					},
+				},
+				{
+					Query: "SELECT * FROM pg_catalog.pg_sequence WHERE seqrelid = 'another_sequence'::regclass;",
+					Expected: []sql.Row{
+						{2416967680, 20, 1, 3, 9223372036854775807, 1, 1, "t"},
 					},
 				},
 				{

--- a/testing/go/types_test.go
+++ b/testing/go/types_test.go
@@ -1481,6 +1481,113 @@ var typesTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "Regclass type",
+		SetUpScript: []string{
+			`CREATE TABLE testing (pk INT primary key, v1 INT UNIQUE);`,
+			`CREATE TABLE "Testing2" (pk INT primary key, v1 INT);`,
+			`CREATE VIEW testview AS SELECT * FROM testing LIMIT 1;`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `SELECT 'testing'::regclass;`,
+				Expected: []sql.Row{
+					{"testing"},
+				},
+			},
+			{
+				Query: `SELECT 'testview'::regclass;`,
+				Expected: []sql.Row{
+					{"testview"},
+				},
+			},
+			{
+				Query: `SELECT ' testing'::regclass;`,
+				Expected: []sql.Row{
+					{"testing"},
+				},
+			},
+			{
+				Query:       `SELECT 'Testing2'::regclass;`,
+				ExpectedErr: "does not exist",
+			},
+			{
+				Query: `SELECT '"Testing2"'::regclass;`,
+				Expected: []sql.Row{
+					{"Testing2"},
+				},
+			},
+			{ // This tests that an invalid OID returns itself in string form
+				Query: `SELECT 4294967295::regclass;`,
+				Expected: []sql.Row{
+					{"4294967295"},
+				},
+			},
+			{
+				Query: "SELECT relname FROM pg_catalog.pg_class WHERE oid = 'testing'::regclass;",
+				Expected: []sql.Row{
+					{"testing"},
+				},
+			},
+		},
+	},
+	{
+		Name: "Regproc type",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `SELECT 'acos'::regproc;`,
+				Expected: []sql.Row{
+					{"acos"},
+				},
+			},
+			{
+				Query: `SELECT ' acos'::regproc;`,
+				Expected: []sql.Row{
+					{"acos"},
+				},
+			},
+			{
+				Query: `SELECT '"acos"'::regproc;`,
+				Expected: []sql.Row{
+					{"acos"},
+				},
+			},
+			{ // This tests that a raw OID properly converts
+				Query: `SELECT (('acos'::regproc)::oid)::regproc;`,
+				Expected: []sql.Row{
+					{"acos"},
+				},
+			},
+			{ // This tests that a string representing a raw OID converts the same as a raw OID
+				Query: `SELECT ((('acos'::regproc)::oid)::text)::regproc;`,
+				Expected: []sql.Row{
+					{"acos"},
+				},
+			},
+			{ // This tests that an invalid OID returns itself in string form
+				Query: `SELECT 4294967295::regproc;`,
+				Expected: []sql.Row{
+					{"4294967295"},
+				},
+			},
+			{
+				Query:       `SELECT '"Abs"'::regproc;`,
+				ExpectedErr: "does not exist",
+			},
+			{
+				Query:       `SELECT '"acos'::regproc;`,
+				ExpectedErr: "invalid name syntax",
+			},
+			{
+				Query:       `SELECT 'acos"'::regproc;`,
+				ExpectedErr: "does not exist",
+			},
+			{
+				Query:       `SELECT '""acos'::regproc;`,
+				ExpectedErr: "invalid name syntax",
+			},
+		},
+	},
+	{
 		Name: "Smallint type",
 		SetUpScript: []string{
 			"CREATE TABLE t_smallint (id INTEGER primary key, v1 SMALLINT);",


### PR DESCRIPTION
This adds `regclass` and `regproc`, in addition to everything needed to support their full functionality. The hashing approach we previously used for OIDs were not compatible as-is, and reverse hashing would require extensive modifications to track all side-effects (table renames, etc.) in addition to needing some way to resolve hash collisions, so an approach similar to the one I proposed in the OID document was used.

OIDs are now treated as indexes into arrays, and all database elements (tables, views, etc.) are iterated in a deterministic way, such that we can imagine that all tables are just a single large array containing every table from every schema, all views are a single large array, etc. This let's us get a definitive OID for any database element, and also when given any OID, we are able to grab the relevant database element.

This is done by splitting an OID's bits into three sections.
* Section: This is a header that specifies the search space. For example, tables have their own search space since we can iterate over all of them using `database.GetTableNames` and `database.GetTableInsensitive`. Each item has its own section, since they all have their own search spaces.
* SchemaIndex: This is the index of the relevant schema. We order schemas by sorting them by their names (ascending), so the index gives us exactly the schema to use.
* DataIndex: This is the index of whatever data the section represents. Some elements exist across multiple elements, such as the set of all indexes. To represent an index for those, we sort all tables by their name (ascending) and iterate over each table's indexes as though it were a single contiguous array.

The size of each bit section is malleable, so I've made some guesses at what sensible starting values may be. In addition, I've disabled the ability to save tables with `regclass` and `regproc`, even though Postgres officially supports them. Since we do not yet have a permanent OID solution, I felt that it wouldn't be wise to allow persisting such values to disk, since changing the OID algorithm would break all such databases.