### PR TITLE
[no-release-notes] Fixed literal casting, added more "char" tests

### DIFF
--- a/server/functions/framework/cast.go
+++ b/server/functions/framework/cast.go
@@ -139,8 +139,8 @@ func GetExplicitCast(fromType pgtypes.DoltgresTypeBaseID, toType pgtypes.Doltgre
 	if fromType == toType && toType.GetTypeCategory() != pgtypes.TypeCategory_StringTypes && fromType.GetTypeCategory() != pgtypes.TypeCategory_StringTypes {
 		return identityCast
 	}
-	// All types have a built-in explicit cast to string types: https://www.postgresql.org/docs/15/sql-createcast.html
-	if toType.GetTypeCategory() == pgtypes.TypeCategory_StringTypes {
+	// All types have a built-in explicit cast from string types: https://www.postgresql.org/docs/15/sql-createcast.html
+	if fromType.GetTypeCategory() == pgtypes.TypeCategory_StringTypes {
 		return func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
 			if val == nil {
 				return nil, nil
@@ -151,8 +151,8 @@ func GetExplicitCast(fromType pgtypes.DoltgresTypeBaseID, toType pgtypes.Doltgre
 			}
 			return targetType.IoInput(ctx, str)
 		}
-	} else if fromType.GetTypeCategory() == pgtypes.TypeCategory_StringTypes {
-		// All types have a built-in assignment cast from string types, which we can reference in an explicit cast
+	} else if toType.GetTypeCategory() == pgtypes.TypeCategory_StringTypes {
+		// All types have a built-in assignment cast to string types, which we can reference in an explicit cast
 		return func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
 			if val == nil {
 				return nil, nil
@@ -180,8 +180,8 @@ func GetAssignmentCast(fromType pgtypes.DoltgresTypeBaseID, toType pgtypes.Doltg
 	if fromType == toType && fromType.GetTypeCategory() != pgtypes.TypeCategory_StringTypes {
 		return identityCast
 	}
-	// All types have a built-in assignment cast from string types: https://www.postgresql.org/docs/15/sql-createcast.html
-	if fromType.GetTypeCategory() == pgtypes.TypeCategory_StringTypes {
+	// All types have a built-in assignment cast to string types: https://www.postgresql.org/docs/15/sql-createcast.html
+	if toType.GetTypeCategory() == pgtypes.TypeCategory_StringTypes {
 		return func(ctx *sql.Context, val any, targetType pgtypes.DoltgresType) (any, error) {
 			if val == nil {
 				return nil, nil

--- a/server/types/internal_char.go
+++ b/server/types/internal_char.go
@@ -132,9 +132,7 @@ func (b InternalCharType) GetSerializationID() SerializationID {
 // IoInput implements the DoltgresType interface.
 func (b InternalCharType) IoInput(ctx *sql.Context, input string) (any, error) {
 	input, runeLength := truncateString(input, InternalCharLength)
-	if runeLength > InternalCharLength {
-		return input, fmt.Errorf("value too long for type %s", b.String())
-	} else if runeLength < InternalCharLength {
+	if runeLength < InternalCharLength {
 		return input + strings.Repeat(" ", int(InternalCharLength-runeLength)), nil
 	} else {
 		return input, nil

--- a/testing/go/operators_test.go
+++ b/testing/go/operators_test.go
@@ -793,6 +793,10 @@ func TestOperators(t *testing.T) {
 					Expected: []sql.Row{{"t"}},
 				},
 				{
+					Query:    `SELECT 'abc'::"char" < 'aef';`,
+					Expected: []sql.Row{{"f"}},
+				},
+				{
 					Query:    `SELECT E'\\x01'::bytea < E'\\x02'::bytea;`,
 					Expected: []sql.Row{{"t"}},
 				},
@@ -1079,6 +1083,14 @@ func TestOperators(t *testing.T) {
 				},
 				{
 					Query:    `SELECT 'abc'::"char" > 'def'::"char";`,
+					Expected: []sql.Row{{"f"}},
+				},
+				{
+					Query:    `SELECT 'def'::"char" > 'abc'::"char";`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    `SELECT 'aef' > 'abc'::"char";`,
 					Expected: []sql.Row{{"f"}},
 				},
 				{
@@ -1376,6 +1388,14 @@ func TestOperators(t *testing.T) {
 				},
 				{
 					Query:    `SELECT 'abc'::"char" <= 'def'::"char";`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    `SELECT 'def'::"char" <= 'abc'::"char";`,
+					Expected: []sql.Row{{"f"}},
+				},
+				{
+					Query:    `SELECT 'abc' <= 'aef'::"char";`,
 					Expected: []sql.Row{{"t"}},
 				},
 				{
@@ -1808,6 +1828,14 @@ func TestOperators(t *testing.T) {
 					Expected: []sql.Row{{"f"}},
 				},
 				{
+					Query:    `SELECT 'def'::"char" >= 'abc'::"char";`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    `SELECT 'aef'::"char" >= 'abc';`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
 					Query:    `SELECT E'\\x01'::bytea >= E'\\x02'::bytea;`,
 					Expected: []sql.Row{{"f"}},
 				},
@@ -2231,6 +2259,10 @@ func TestOperators(t *testing.T) {
 				{
 					Query:    `SELECT 'def'::"char" = 'abc'::"char";`,
 					Expected: []sql.Row{{"f"}},
+				},
+				{
+					Query:    `SELECT 'abc'::"char" = 'aef';`,
+					Expected: []sql.Row{{"t"}},
 				},
 				{
 					Query:    `SELECT E'\\x01'::bytea = E'\\x01'::bytea;`,

--- a/testing/go/types_test.go
+++ b/testing/go/types_test.go
@@ -313,7 +313,6 @@ var typesTests = []ScriptTest{
 				},
 			},
 			{
-				Skip:  true, // TODO: Should be able to cast name to "char" even though cast does not exist
 				Query: `SELECT 'def'::name::"char";`,
 				Expected: []sql.Row{
 					{"d"},
@@ -337,6 +336,25 @@ var typesTests = []ScriptTest{
 				Query: "SELECT * FROM t_char WHERE id=6;",
 				Expected: []sql.Row{
 					{6, "0"},
+				},
+			},
+			{
+				Query:       "INSERT INTO t_char VALUES (7, 'abc'::name);",
+				ExpectedErr: "expression is of type",
+			},
+			{
+				Query:    "INSERT INTO t_char VALUES (8, 'def'::text);",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "INSERT INTO t_char VALUES (9, 'ghi'::varchar);",
+				Expected: []sql.Row{},
+			},
+			{
+				Query: `SELECT * FROM t_char WHERE id >= 7 ORDER BY id;`,
+				Expected: []sql.Row{
+					{8, "d"},
+					{9, "g"},
 				},
 			},
 		},


### PR DESCRIPTION
Three main things here:
* I accidentally got the automatic string casting backwards. Automatic assignment should be _to strings_, and automatic explicit should be _from_ strings.
* I think I got these backward because string literals should technically have the `unknown` type, which can be interpreted as any type using the `IoInput` functions. However, I assign them the `text` type, which is incorrect, and caused a difference in behavior where reversing the automatic casts caused the correct observable behavior for the written tests. Of course, more tests showed the flaws.
* My assumptions with the operators was still partially correct. It's automatically casting `"char"` to `text`, and then using the `text` operators. The tests all passed because they're valid for both `"char"` and `text` operators. I added some tests that are specifically valid for `"char"` that return the opposite result for `text` operators, which are failing since we need to add the `"char"` operators. Even though our tests that we have written pass, we should still make sure to be thorough in adding all of the proper casts, operators, etc. as it's usually a matter of our testing rather than the behavior actually being correct, which may cause hard-to-track errors in the future. I also added `true` and `false` tests for all of the `"char"` operators, I should have caught that in the initial review pass.

You can use this query to get all of the operator functions:
```sql
SELECT
	o.oprname,
	src_typ.typname AS oprleft,
	tgt_typ.typname AS oprright,
	res_typ.typname AS oprresult,
	o.oprcode::varchar
FROM
	pg_operator o 
JOIN 
    pg_catalog.pg_type src_typ ON o.oprleft = src_typ.oid
JOIN 
    pg_catalog.pg_type tgt_typ ON o.oprright = tgt_typ.oid
JOIN 
    pg_catalog.pg_type res_typ ON o.oprresult = res_typ.oid
ORDER BY
	src_typ.typname, tgt_typ.typname;
```