### PR TITLE
Support for IN with a subquery

### DIFF
--- a/server/ast/expr.go
+++ b/server/ast/expr.go
@@ -325,7 +325,7 @@ func nodeExpr(node tree.Expr) (vitess.Expr, error) {
 			}, nil
 		case tree.In:
 			switch right := right.(type) {
-			case *vitess.ValTuple:
+			case vitess.ValTuple:
 				return vitess.InjectedExpr{
 					Expression: pgexprs.NewInTuple(),
 					Children:   vitess.Exprs{left, right},

--- a/server/ast/expr.go
+++ b/server/ast/expr.go
@@ -155,12 +155,12 @@ func nodeExpr(node tree.Expr) (vitess.Expr, error) {
 		case tree.Div:
 			operator = framework.Operator_BinaryDivide
 		case tree.FloorDiv:
-			//TODO: replace with floor divide function
+			// TODO: replace with floor divide function
 			return nil, fmt.Errorf("the floor divide operator is not yet supported")
 		case tree.Mod:
 			operator = framework.Operator_BinaryMod
 		case tree.Pow:
-			//TODO: replace with power function
+			// TODO: replace with power function
 			return nil, fmt.Errorf("the power operator is not yet supported")
 		case tree.Concat:
 			operator = framework.Operator_BinaryConcatenate
@@ -324,10 +324,20 @@ func nodeExpr(node tree.Expr) (vitess.Expr, error) {
 				Children:   vitess.Exprs{left, right},
 			}, nil
 		case tree.In:
-			return vitess.InjectedExpr{
-				Expression: pgexprs.NewInTuple(),
-				Children:   vitess.Exprs{left, right},
-			}, nil
+			switch right := right.(type) {
+			case *vitess.ValTuple:
+				return vitess.InjectedExpr{
+					Expression: pgexprs.NewInTuple(),
+					Children:   vitess.Exprs{left, right},
+				}, nil
+			case *vitess.Subquery:
+				return vitess.InjectedExpr{
+					Expression: pgexprs.NewInSubquery(),
+					Children:   vitess.Exprs{left, right},
+				}, nil
+			default:
+				return nil, fmt.Errorf("right side of IN expression is not a tuple or subquery, got %T", right)
+			}
 		case tree.NotIn:
 			innerExpr := vitess.InjectedExpr{
 				Expression: pgexprs.NewInTuple(),
@@ -409,7 +419,7 @@ func nodeExpr(node tree.Expr) (vitess.Expr, error) {
 			Operator: operator,
 			Left:     left,
 			Right:    right,
-			Escape:   nil, //TODO: is '\' the default in Postgres as well?
+			Escape:   nil, // TODO: is '\' the default in Postgres as well?
 		}, nil
 	case *tree.DArray:
 		return nil, fmt.Errorf("the statement is not yet supported")
@@ -480,10 +490,10 @@ func nodeExpr(node tree.Expr) (vitess.Expr, error) {
 	case *tree.IfErrExpr:
 		return nil, fmt.Errorf("IFERROR is not yet supported")
 	case *tree.IfExpr:
-		//TODO: probably should be the IF function
+		// TODO: probably should be the IF function
 		return nil, fmt.Errorf("IF is not yet supported")
 	case *tree.IndexedVar:
-		//TODO: figure out if I can delete this
+		// TODO: figure out if I can delete this
 		return nil, fmt.Errorf("this should probably be deleted (internal error, IndexedVar)")
 	case *tree.IndirectionExpr:
 		return nil, fmt.Errorf("subscripts are not yet supported")
@@ -622,7 +632,7 @@ func nodeExpr(node tree.Expr) (vitess.Expr, error) {
 		}
 		return retExpr, nil
 	case *tree.StrVal:
-		//TODO: determine what to do when node.WasScannedAsBytes() is true
+		// TODO: determine what to do when node.WasScannedAsBytes() is true
 		stringLiteral := pgexprs.NewStringLiteral(node.RawString())
 		return vitess.InjectedExpr{
 			Expression: stringLiteral,
@@ -651,7 +661,7 @@ func nodeExpr(node tree.Expr) (vitess.Expr, error) {
 		}
 		var operator framework.Operator
 		switch node.Operator {
-		//TODO: need to add UnaryPlus, it's like a no-op but Postgres actually implements it and it affects coercion
+		// TODO: need to add UnaryPlus, it's like a no-op but Postgres actually implements it and it affects coercion
 		case tree.UnaryMinus:
 			operator = framework.Operator_UnaryMinus
 		case tree.UnaryComplement:
@@ -660,13 +670,13 @@ func nodeExpr(node tree.Expr) (vitess.Expr, error) {
 				Expr:     expr,
 			}, nil
 		case tree.UnarySqrt:
-			//TODO: replace with a function
+			// TODO: replace with a function
 			return nil, fmt.Errorf("square root operator is not yet supported")
 		case tree.UnaryCbrt:
-			//TODO: replace with a function
+			// TODO: replace with a function
 			return nil, fmt.Errorf("cube root operator is not yet supported")
 		case tree.UnaryAbsolute:
-			//TODO: replace with a function
+			// TODO: replace with a function
 			return nil, fmt.Errorf("absolute operator is not yet supported")
 		default:
 			return nil, fmt.Errorf("the unary operator used is not yet supported")

--- a/server/expression/in_subquery.go
+++ b/server/expression/in_subquery.go
@@ -39,9 +39,9 @@ type InSubquery struct {
 	compFuncs     []*framework.CompiledFunction
 }
 
-var _ vitess.Injectable = (*BinaryOperator)(nil)
-var _ sql.Expression = (*BinaryOperator)(nil)
-var _ expression.BinaryExpression = (*BinaryOperator)(nil)
+var _ vitess.Injectable = (*InSubquery)(nil)
+var _ sql.Expression = (*InSubquery)(nil)
+var _ expression.BinaryExpression = (*InSubquery)(nil)
 
 // NewInSubquery returns a new *InSubquery.
 func NewInSubquery() *InSubquery {

--- a/server/expression/in_subquery.go
+++ b/server/expression/in_subquery.go
@@ -48,12 +48,12 @@ func NewInSubquery() *InSubquery {
 	return &InSubquery{}
 }
 
-var nilKey, _ = sql.HashOf(sql.NewRow(nil))
-
 // Children implements the sql.Expression interface.
 func (in *InSubquery) Children() []sql.Expression {
 	return []sql.Expression{in.leftExpr, in.rightExpr}
 }
+
+var nilKey, _ = sql.HashOf(sql.NewRow(nil))
 
 // Eval implements the sql.Expression interface.
 func (in *InSubquery) Eval(ctx *sql.Context, row sql.Row) (any, error) {
@@ -131,7 +131,7 @@ func (in *InSubquery) valuesEqual(ctx *sql.Context, left interface{}, row sql.Ro
 	}
 
 	for _, compFunc := range in.compFuncs {
-		result, err := compFunc.Eval(ctx, row)
+		result, err := compFunc.Eval(ctx, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/testing/go/enginetest/doltgres_engine_test.go
+++ b/testing/go/enginetest/doltgres_engine_test.go
@@ -110,13 +110,13 @@ func TestSchemaOverrides(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	t.Skip()
+	// t.Skip()
 
 	var scripts = []queries.ScriptTest{
 		{
 			Name: "bigtable",
 			SetUpScript: []string{
-				"SELECT count(*), (SELECT i FROM mytable WHERE i = 1 group by i);",
+				"SELECT * from mytable where i in (SELECT i FROM mytable);",
 			},
 		},
 	}

--- a/testing/go/expressions_test.go
+++ b/testing/go/expressions_test.go
@@ -230,6 +230,10 @@ func TestSubqueries(t *testing.T) {
 					Expected: []sql.Row{{int32(2)}},
 				},
 				{
+					Query:    `SELECT * FROM test WHERE id IN (SELECT id FROM test WHERE id = 3);`,
+					Expected: []sql.Row{{int32(3)}},
+				},
+				{
 					Query:    `SELECT * FROM test WHERE id IN (SELECT * FROM test WHERE id > 0);`,
 					Expected: []sql.Row{{int32(1)}, {int32(3)}, {int32(2)}},
 				},
@@ -245,10 +249,17 @@ func TestSubqueries(t *testing.T) {
 					},
 				},
 				{
-					Query: `SELECT * FROM test2 WHERE (2, 10) IN (SELECT id, test_id FROM test2 WHERE id > 0);`,
-					Skip:  true, // TODO: Support tuples in IN operator
+					Query: `SELECT id FROM test2 WHERE (2, 10) IN (SELECT id, test_id FROM test2 WHERE id > 0);`,
+					Skip:  true, // won't pass until we have a doltgres tuple type to match against for equality funcs
 					Expected: []sql.Row{
-						{int32(2), int32(10), "bar"},
+						{1}, {2}, {3},
+					},
+				},
+				{
+					Query: `SELECT id FROM test2 WHERE (id, test_id) IN (SELECT id, test_id FROM test2 WHERE id > 0);`,
+					Skip:  true, // won't pass until we have a doltgres tuple type to match against for equality funcs
+					Expected: []sql.Row{
+						{2},
 					},
 				},
 			},

--- a/testing/go/expressions_test.go
+++ b/testing/go/expressions_test.go
@@ -44,12 +44,10 @@ func TestExpressions(t *testing.T) {
 					Expected: []sql.Row{{int32(1)}, {int32(3)}, {int32(2)}},
 				},
 				{
-					Skip:     true, // TODO: Support subqueries with IN operator
 					Query:    `SELECT * FROM test2 WHERE test_id IN (SELECT * FROM test WHERE id = 2);`,
 					Expected: []sql.Row{{int32(3), int32(2), "baz"}},
 				},
 				{
-					Skip:  true, // TODO: Support subqueries with IN operator
 					Query: `SELECT * FROM test2 WHERE test_id IN(SELECT * FROM test WHERE id > 0);`,
 					Expected: []sql.Row{
 						{int32(1), int32(1), "foo"},
@@ -118,17 +116,17 @@ func anyTests(name string) ScriptTest {
 			},
 		},
 		{
-			Skip:     true, // TODO: Fix subqueries
+			Skip:     true,
 			Query:    `SELECT * FROM test2 WHERE test_id = %s(SELECT * FROM test WHERE id = 2);`,
 			Expected: []sql.Row{{int32(3), int32(2), "baz"}},
 		},
 		{
-			Skip:     true, // TODO: Fix subqueries
+			Skip:     true,
 			Query:    `SELECT * FROM test2 WHERE test_id = %s(SELECT * FROM test WHERE id = 10);`,
 			Expected: []sql.Row{},
 		},
 		{
-			Skip:     true, // TODO: Fix subqueries
+			Skip:     true,
 			Query:    `SELECT * FROM test2 WHERE test_id = %s(SELECT * FROM test WHERE id > 1) AND txt = 'baz';`,
 			Expected: []sql.Row{{int32(3), int32(2), "baz"}},
 		},
@@ -149,7 +147,22 @@ func anyTests(name string) ScriptTest {
 			},
 		},
 		{
-			Query: `SELECT "ns"."nspname" AS "table_schema", "t"."relname" AS "table_name", "cnst"."conname" AS "constraint_name", pg_get_constraintdef("cnst"."oid") AS "expression", CASE "cnst"."contype" WHEN 'p' THEN 'PRIMARY' WHEN 'u' THEN 'UNIQUE' WHEN 'c' THEN 'CHECK' WHEN 'x' THEN 'EXCLUDE' END AS "constraint_type", "a"."attname" AS "column_name" FROM "pg_catalog"."pg_constraint" "cnst" INNER JOIN "pg_catalog"."pg_class" "t" ON "t"."oid" = "cnst"."conrelid" INNER JOIN "pg_catalog"."pg_namespace" "ns" ON "ns"."oid" = "cnst"."connamespace" LEFT JOIN "pg_catalog"."pg_attribute" "a" ON "a"."attrelid" = "cnst"."conrelid" AND "a"."attnum" = %s ("cnst"."conkey") WHERE "t"."relkind" IN ('r', 'p') AND (("ns"."nspname" = 'public' AND "t"."relname" = 'test2'));`,
+			Query: `SELECT "ns"."nspname" AS "table_schema",
+       "t"."relname" AS "table_name",
+       "cnst"."conname" AS "constraint_name",
+       pg_get_constraintdef("cnst"."oid") AS "expression",
+       CASE "cnst"."contype" 
+           WHEN 'p' THEN 'PRIMARY'
+           WHEN 'u' THEN 'UNIQUE'
+           WHEN 'c' THEN 'CHECK'
+           WHEN 'x' THEN 'EXCLUDE'
+           END AS "constraint_type", 
+    "a"."attname" AS "column_name" 
+FROM "pg_catalog"."pg_constraint" "cnst" 
+    INNER JOIN "pg_catalog"."pg_class" "t" ON "t"."oid" = "cnst"."conrelid"
+    INNER JOIN "pg_catalog"."pg_namespace" "ns" ON "ns"."oid" = "cnst"."connamespace"
+    LEFT JOIN "pg_catalog"."pg_attribute" "a" ON "a"."attrelid" = "cnst"."conrelid" AND "a"."attnum" = %s ("cnst"."conkey")
+WHERE "t"."relkind" IN ('r', 'p') AND (("ns"."nspname" = 'public' AND "t"."relname" = 'test2'));`,
 			Expected: []sql.Row{
 				{"public", "test2", "test2_pkey", "PRIMARY KEY (id)", "PRIMARY", "id"},
 			},

--- a/testing/go/expressions_test.go
+++ b/testing/go/expressions_test.go
@@ -217,7 +217,6 @@ func TestSubqueries(t *testing.T) {
 		},
 		{
 			Name: "IN",
-			Skip: true, // ERROR: expected vitess child to be an expression tuple but has type `*plan.Subquery`
 			SetUpScript: []string{
 				`CREATE TABLE test (id INT);`,
 				`INSERT INTO test VALUES (1), (3), (2);`,
@@ -243,6 +242,13 @@ func TestSubqueries(t *testing.T) {
 					Expected: []sql.Row{
 						{int32(1), int32(1), "foo"},
 						{int32(3), int32(2), "baz"},
+					},
+				},
+				{
+					Query: `SELECT * FROM test2 WHERE (2, 10) IN (SELECT id, test_id FROM test2 WHERE id > 0);`,
+					Skip:  true, // TODO: Support tuples in IN operator
+					Expected: []sql.Row{
+						{int32(2), int32(10), "bar"},
 					},
 				},
 			},


### PR DESCRIPTION
Tuples won't work until we have a doltgres tuple type, but should work for everything else.

New expression type is a combination of InTuple from Doltgres and InSubquery from GMS. GMS code couldn't really be reused usefully.