### PR TITLE
use ParameterObjectIDs in Parse message for binding variable types

### DIFF
--- a/postgres/messages/parameter_description.go
+++ b/postgres/messages/parameter_description.go
@@ -22,7 +22,7 @@ func init() {
 
 // ParameterDescription represents a PostgreSQL message.
 type ParameterDescription struct {
-	ObjectIDs []int32
+	ObjectIDs []uint32
 }
 
 var parameterDescriptionDefault = connection.MessageFormat{
@@ -74,9 +74,9 @@ func (m ParameterDescription) Decode(s connection.MessageFormat) (connection.Mes
 		return nil, err
 	}
 	count := int(s.Field("Parameters").MustGet().(int32))
-	objectIDs := make([]int32, count)
+	objectIDs := make([]uint32, count)
 	for i := 0; i < count; i++ {
-		objectIDs[i] = s.Field("Parameters").Child("ObjectID", i).MustGet().(int32)
+		objectIDs[i] = uint32(s.Field("Parameters").Child("ObjectID", i).MustGet().(int32))
 	}
 	return ParameterDescription{
 		ObjectIDs: objectIDs,

--- a/postgres/messages/parse.go
+++ b/postgres/messages/parse.go
@@ -32,7 +32,7 @@ func init() {
 type Parse struct {
 	Name               string
 	Query              string
-	ParameterObjectIDs []int32
+	ParameterObjectIDs []uint32
 }
 
 var _ sql.DebugStringer = Parse{}
@@ -98,9 +98,9 @@ func (m Parse) Decode(s connection.MessageFormat) (connection.Message, error) {
 		return nil, err
 	}
 	count := int(s.Field("Parameters").MustGet().(int32))
-	objectIDs := make([]int32, count)
+	objectIDs := make([]uint32, count)
 	for i := 0; i < count; i++ {
-		objectIDs[i] = s.Field("Parameters").Child("ObjectID", i).MustGet().(int32)
+		objectIDs[i] = uint32(s.Field("Parameters").Child("ObjectID", i).MustGet().(int32))
 	}
 	return Parse{
 		Name:               s.Field("Name").MustGet().(string),

--- a/postgres/messages/row_description.go
+++ b/postgres/messages/row_description.go
@@ -24,84 +24,84 @@ import (
 )
 
 const (
-	OidBool              = 16
-	OidBytea             = 17
-	OidChar              = 18
-	OidName              = 19
-	OidInt8              = 20
-	OidInt2              = 21
-	OidInt2Vector        = 22
-	OidInt4              = 23
-	OidRegproc           = 24
-	OidText              = 25
-	OidOid               = 26
-	OidTid               = 27
-	OidXid               = 28
-	OidCid               = 29
-	OidOidVector         = 30
-	OidPgType            = 71
-	OidPgAttribute       = 75
-	OidPgProc            = 81
-	OidPgClass           = 83
-	OidJson              = 114
-	OidXml               = 142
-	OidXmlArray          = 143
-	OidPgNodeTree        = 194
-	OidPgNodeTreeArray   = 195
-	OidJsonArray         = 199
-	OidSmgr              = 210
-	OidIndexAm           = 261
-	OidPoint             = 600
-	OidLseg              = 601
-	OidPath              = 602
-	OidBox               = 603
-	OidPolygon           = 604
-	OidLine              = 628
-	OidCidr              = 650
-	OidCidrArray         = 651
-	OidFloat4            = 700
-	OidFloat8            = 701
-	OidAbstime           = 702
-	OidReltime           = 703
-	OidTinterval         = 704
-	OidUnknown           = 705
-	OidCircle            = 718
-	OidCash              = 790
-	OidMacaddr           = 829
-	OidInet              = 869
-	OidByteaArray        = 1001
-	OidInt2Array         = 1005
-	OidInt4Array         = 1007
-	OidTextArray         = 1009
-	OidVarcharArray      = 1015
-	OidInt8Array         = 1016
-	OidPointArray        = 1017
-	OidFloat4Array       = 1021
-	OidFloat8Array       = 1022
-	OidAclitem           = 1033
-	OidAclitemArray      = 1034
-	OidInetArray         = 1041
-	OidVarchar           = 1043
-	OidDate              = 1082
-	OidTime              = 1083
-	OidTimestamp         = 1114
-	OidTimestampArray    = 1115
-	OidDateArray         = 1182
-	OidTimeArray         = 1183
-	OidInterval          = 1186
-	OidIntervalArray     = 1187
-	OidNumeric           = 1700
-	OidRefcursor         = 1790
-	OidRegprocedure      = 2202
-	OidRegoper           = 2203
-	OidRegoperator       = 2204
-	OidRegclass          = 2205
-	OidRegtype           = 2206
-	OidRegrole           = 4096
-	OidRegnamespace      = 4097
-	OidRegnamespaceArray = 4098
-	OidRegclassArray     = 4099
-	OidRegRoleArray      = 4090
+	OidBool              = uint32(16)
+	OidBytea             = uint32(17)
+	OidChar              = uint32(18)
+	OidName              = uint32(19)
+	OidInt8              = uint32(20)
+	OidInt2              = uint32(21)
+	OidInt2Vector        = uint32(22)
+	OidInt4              = uint32(23)
+	OidRegproc           = uint32(24)
+	OidText              = uint32(25)
+	OidOid               = uint32(26)
+	OidTid               = uint32(27)
+	OidXid               = uint32(28)
+	OidCid               = uint32(29)
+	OidOidVector         = uint32(30)
+	OidPgType            = uint32(71)
+	OidPgAttribute       = uint32(75)
+	OidPgProc            = uint32(81)
+	OidPgClass           = uint32(83)
+	OidJson              = uint32(114)
+	OidXml               = uint32(142)
+	OidXmlArray          = uint32(143)
+	OidPgNodeTree        = uint32(194)
+	OidPgNodeTreeArray   = uint32(195)
+	OidJsonArray         = uint32(199)
+	OidSmgr              = uint32(210)
+	OidIndexAm           = uint32(261)
+	OidPoint             = uint32(600)
+	OidLseg              = uint32(601)
+	OidPath              = uint32(602)
+	OidBox               = uint32(603)
+	OidPolygon           = uint32(604)
+	OidLine              = uint32(628)
+	OidCidr              = uint32(650)
+	OidCidrArray         = uint32(651)
+	OidFloat4            = uint32(700)
+	OidFloat8            = uint32(701)
+	OidAbstime           = uint32(702)
+	OidReltime           = uint32(703)
+	OidTinterval         = uint32(704)
+	OidUnknown           = uint32(705)
+	OidCircle            = uint32(718)
+	OidCash              = uint32(790)
+	OidMacaddr           = uint32(829)
+	OidInet              = uint32(869)
+	OidByteaArray        = uint32(1001)
+	OidInt2Array         = uint32(1005)
+	OidInt4Array         = uint32(1007)
+	OidTextArray         = uint32(1009)
+	OidVarcharArray      = uint32(1015)
+	OidInt8Array         = uint32(1016)
+	OidPointArray        = uint32(1017)
+	OidFloat4Array       = uint32(1021)
+	OidFloat8Array       = uint32(1022)
+	OidAclitem           = uint32(1033)
+	OidAclitemArray      = uint32(1034)
+	OidInetArray         = uint32(1041)
+	OidVarchar           = uint32(1043)
+	OidDate              = uint32(1082)
+	OidTime              = uint32(1083)
+	OidTimestamp         = uint32(1114)
+	OidTimestampArray    = uint32(1115)
+	OidDateArray         = uint32(1182)
+	OidTimeArray         = uint32(1183)
+	OidInterval          = uint32(1186)
+	OidIntervalArray     = uint32(1187)
+	OidNumeric           = uint32(1700)
+	OidRefcursor         = uint32(1790)
+	OidRegprocedure      = uint32(2202)
+	OidRegoper           = uint32(2203)
+	OidRegoperator       = uint32(2204)
+	OidRegclass          = uint32(2205)
+	OidRegtype           = uint32(2206)
+	OidRegrole           = uint32(4096)
+	OidRegnamespace      = uint32(4097)
+	OidRegnamespaceArray = uint32(4098)
+	OidRegclassArray     = uint32(4099)
+	OidRegRoleArray      = uint32(4090)
 )
 
 func init() {
@@ -217,13 +217,13 @@ func (m RowDescription) DefaultMessage() *connection.MessageFormat {
 
 // VitessFieldToDataTypeObjectID returns the type of a vitess Field into a type as defined by Postgres.
 // OIDs can be obtained with the following query: `SELECT oid, typname FROM pg_type ORDER BY 1;`
-func VitessFieldToDataTypeObjectID(field *query.Field) (int32, error) {
+func VitessFieldToDataTypeObjectID(field *query.Field) (uint32, error) {
 	return VitessTypeToObjectID(field.Type)
 }
 
 // VitessFieldToDataTypeObjectID returns a type, as defined by Vitess, into a type as defined by Postgres.
 // OIDs can be obtained with the following query: `SELECT oid, typname FROM pg_type ORDER BY 1;`
-func VitessTypeToObjectID(typ query.Type) (int32, error) {
+func VitessTypeToObjectID(typ query.Type) (uint32, error) {
 	switch typ {
 	case query.Type_INT8:
 		// Postgres doesn't make use of a small integer type for integer returns, which presents a bit of a conundrum.

--- a/server/connection_handler.go
+++ b/server/connection_handler.go
@@ -18,11 +18,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	pgexprs "github.com/dolthub/doltgresql/server/expression"
-	pgtypes "github.com/dolthub/doltgresql/server/types"
-	"github.com/dolthub/go-mysql-server/sql/expression"
-	"github.com/dolthub/go-mysql-server/sql/plan"
-	"github.com/dolthub/go-mysql-server/sql/transform"
 	"io"
 	"net"
 	"os"
@@ -30,6 +25,9 @@ import (
 	"sync/atomic"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/transform"
 	"github.com/dolthub/vitess/go/mysql"
 	"github.com/dolthub/vitess/go/sqltypes"
 	querypb "github.com/dolthub/vitess/go/vt/proto/query"
@@ -41,7 +39,9 @@ import (
 	"github.com/dolthub/doltgresql/postgres/messages"
 	"github.com/dolthub/doltgresql/postgres/parser/parser"
 	"github.com/dolthub/doltgresql/server/ast"
+	pgexprs "github.com/dolthub/doltgresql/server/expression"
 	"github.com/dolthub/doltgresql/server/node"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
 // ConnectionHandler is responsible for the entire lifecycle of a user connection: receiving messages they send,

--- a/server/connection_handler.go
+++ b/server/connection_handler.go
@@ -18,6 +18,11 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	pgexprs "github.com/dolthub/doltgresql/server/expression"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/transform"
 	"io"
 	"net"
 	"os"
@@ -25,9 +30,6 @@ import (
 	"sync/atomic"
 
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/expression"
-	"github.com/dolthub/go-mysql-server/sql/plan"
-	"github.com/dolthub/go-mysql-server/sql/transform"
 	"github.com/dolthub/vitess/go/mysql"
 	"github.com/dolthub/vitess/go/sqltypes"
 	querypb "github.com/dolthub/vitess/go/vt/proto/query"
@@ -39,9 +41,7 @@ import (
 	"github.com/dolthub/doltgresql/postgres/messages"
 	"github.com/dolthub/doltgresql/postgres/parser/parser"
 	"github.com/dolthub/doltgresql/server/ast"
-	pgexprs "github.com/dolthub/doltgresql/server/expression"
 	"github.com/dolthub/doltgresql/server/node"
-	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
 // ConnectionHandler is responsible for the entire lifecycle of a user connection: receiving messages they send,
@@ -414,15 +414,19 @@ func (h *ConnectionHandler) handleParse(message messages.Parse) error {
 		return nil
 	}
 
-	plan, fields, err := h.getPlanAndFields(query)
+	analyzedPlan, fields, err := h.getPlanAndFields(query)
 	if err != nil {
 		return err
 	}
 
-	// TODO: bindvar types can be specified directly in the message, need tests of this
-	bindVarTypes, err := extractBindVarTypes(plan)
-	if err != nil {
-		return err
+	// A valid Parse message must have ParameterObjectIDs if there are any binding variables.
+	bindVarTypes := message.ParameterObjectIDs
+	if len(bindVarTypes) == 0 {
+		// NOTE: This is used for Prepared Statement Tests only.
+		bindVarTypes, err = extractBindVarTypes(analyzedPlan)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Nil fields means an OKResult, fill one in here
@@ -447,7 +451,7 @@ func (h *ConnectionHandler) handleParse(message messages.Parse) error {
 // handleDescribe handles a Describe message, returning any error that occurs
 func (h *ConnectionHandler) handleDescribe(message messages.Describe) error {
 	var fields []*querypb.Field
-	var bindvarTypes []int32
+	var bindvarTypes []uint32
 	var tag string
 
 	h.waitForSync = true
@@ -564,14 +568,14 @@ func (h *ConnectionHandler) deallocatePreparedStatement(name string, preparedSta
 	return connection.Send(conn, commandComplete)
 }
 
-func extractBindVarTypes(queryPlan sql.Node) ([]int32, error) {
+func extractBindVarTypes(queryPlan sql.Node) ([]uint32, error) {
 	inspectNode := queryPlan
 	switch queryPlan := queryPlan.(type) {
 	case *plan.InsertInto:
 		inspectNode = queryPlan.Source
 	}
 
-	types := make([]int32, 0)
+	types := make([]uint32, 0)
 	var err error
 	extractBindVars := func(expr sql.Expression) bool {
 		if err != nil {
@@ -579,9 +583,9 @@ func extractBindVarTypes(queryPlan sql.Node) ([]int32, error) {
 		}
 		switch e := expr.(type) {
 		case *expression.BindVar:
-			var oid int32
+			var oid uint32
 			if doltgresType, ok := e.Type().(pgtypes.DoltgresType); ok {
-				oid = int32(doltgresType.OID())
+				oid = doltgresType.OID()
 			} else {
 				oid, err = messages.VitessTypeToObjectID(e.Type().Type())
 				if err != nil {
@@ -592,9 +596,9 @@ func extractBindVarTypes(queryPlan sql.Node) ([]int32, error) {
 			types = append(types, oid)
 		case *pgexprs.ExplicitCast:
 			if bindVar, ok := e.Child().(*expression.BindVar); ok {
-				var oid int32
+				var oid uint32
 				if doltgresType, ok := bindVar.Type().(pgtypes.DoltgresType); ok {
-					oid = int32(doltgresType.OID())
+					oid = doltgresType.OID()
 				} else {
 					oid, err = messages.VitessTypeToObjectID(e.Type().Type())
 					if err != nil {
@@ -608,7 +612,7 @@ func extractBindVarTypes(queryPlan sql.Node) ([]int32, error) {
 		// $1::text and similar get converted to a Convert expression wrapping the bindvar
 		case *expression.Convert:
 			if bindVar, ok := e.Child.(*expression.BindVar); ok {
-				var oid int32
+				var oid uint32
 				oid, err = messages.VitessTypeToObjectID(e.Type().Type())
 				if err != nil {
 					err = fmt.Errorf("could not determine OID for placeholder %s: %w", bindVar.Name, err)
@@ -627,18 +631,15 @@ func extractBindVarTypes(queryPlan sql.Node) ([]int32, error) {
 }
 
 // convertBindParameters handles the conversion from bind parameters to variable values.
-func (h *ConnectionHandler) convertBindParameters(types []int32, formatCodes []int32, values []messages.BindParameterValue) (map[string]*querypb.BindVariable, error) {
+func (h *ConnectionHandler) convertBindParameters(types []uint32, formatCodes []int32, values []messages.BindParameterValue) (map[string]*querypb.BindVariable, error) {
 	bindings := make(map[string]*querypb.BindVariable, len(values))
 	for i := range values {
 		bindingName := fmt.Sprintf("v%d", i+1)
 		typ := convertType(types[i])
 		var bindVarString string
 
-		// TODO: need to check for byte length for given type length. E.g. int16, int32 and uint32 expects 4 bytes
-		//  but currently, receives 8 bytes.
-
 		// We'll rely on a library to decode each format, which will deal with text and binary representations for us
-		if err := h.pgTypeMap.Scan(uint32(types[i]), int16(formatCodes[i]), values[i].Data, &bindVarString); err != nil {
+		if err := h.pgTypeMap.Scan(types[i], int16(formatCodes[i]), values[i].Data, &bindVarString); err != nil {
 			return nil, err
 		}
 		bindVar := &querypb.BindVariable{
@@ -652,7 +653,7 @@ func (h *ConnectionHandler) convertBindParameters(types []int32, formatCodes []i
 }
 
 // TODO: we need to migrate this away from vitess types and deal strictly with OIDs which are compatible with Postgres types
-func convertType(oid int32) querypb.Type {
+func convertType(oid uint32) querypb.Type {
 	switch oid {
 	// TODO: this should never be 0
 	case 0:
@@ -799,7 +800,7 @@ func spoolRowsCallback(conn net.Conn, commandComplete *messages.CommandComplete,
 }
 
 // sendDescribeResponse sends a response message for a Describe message
-func (h *ConnectionHandler) sendDescribeResponse(conn net.Conn, fields []*querypb.Field, types []int32, tag string) (err error) {
+func (h *ConnectionHandler) sendDescribeResponse(conn net.Conn, fields []*querypb.Field, types []uint32, tag string) (err error) {
 	// The prepared statement variant of the describe command returns the OIDs of the parameters.
 	if types != nil {
 		if err := connection.Send(conn, messages.ParameterDescription{
@@ -989,12 +990,12 @@ func (h *ConnectionHandler) getPlanAndFields(query ConvertedQuery) (sql.Node, []
 		return nil, nil, err
 	}
 
-	plan, ok := parsedQuery.(sql.Node)
+	analyzedPlan, ok := parsedQuery.(sql.Node)
 	if !ok {
 		return nil, nil, fmt.Errorf("expected a sql.Node, got %T", parsedQuery)
 	}
 
-	return plan, fields, nil
+	return analyzedPlan, fields, nil
 }
 
 // comQuery is a shortcut that determines which version of ComQuery to call based on whether the query has been parsed.

--- a/server/converted_query.go
+++ b/server/converted_query.go
@@ -33,7 +33,7 @@ type ConvertedQuery struct {
 type PreparedStatementData struct {
 	Query        ConvertedQuery
 	ReturnFields []*querypb.Field
-	BindVarTypes []int32
+	BindVarTypes []uint32
 }
 
 type PortalData struct {


### PR DESCRIPTION
Note: the prepared tests don't utilize this field in the `Parse` message, so it needs to extract the binding value types from analyzed plan of the query.