### PR TITLE
Adding support for using `TEXT` fields in `UNIQUE` indexes

### DIFF
--- a/testing/bats/dataloading/french-towns-communes-francaises.sql
+++ b/testing/bats/dataloading/french-towns-communes-francaises.sql
@@ -18,9 +18,7 @@ CREATE TABLE Regions (
    id SERIAL UNIQUE NOT NULL,
    code VARCHAR(4) UNIQUE NOT NULL, 
    capital VARCHAR(10) NOT NULL, -- REFERENCES Towns (code),
-   -- TODO: TEXT columns do not work correctly in Doltgres yet
-   -- name TEXT UNIQUE NOT NULL
-   name VARCHAR(255) UNIQUE NOT NULL
+   name TEXT UNIQUE NOT NULL
 );
 
 -- Departments / Départements
@@ -31,21 +29,15 @@ CREATE TABLE Departments (
    capital VARCHAR(10) UNIQUE NOT NULL, -- REFERENCES Towns (code), 
              -- Actually, it is the concatenation of D.code + T.code.
    region VARCHAR(4) NOT NULL REFERENCES Regions (code),
-   -- TODO: TEXT columns do not work correctly in Doltgres yet
-   -- name TEXT UNIQUE NOT NULL
-   name VARCHAR(255) UNIQUE NOT NULL
+   name TEXT UNIQUE NOT NULL
 );
 
 -- Towns / Communes
 CREATE TABLE Towns (
    id SERIAL UNIQUE NOT NULL,
    code VARCHAR(10) NOT NULL, -- Only unique inside a department
-   -- TODO: TEXT columns do not work correctly in Doltgres yet
-   -- article TEXT,
-   article VARCHAR(255),
-   -- TODO: TEXT columns do not work correctly in Doltgres yet
-   -- name TEXT NOT NULL, -- Names are not really unique, for instance 'Sainte-Croix'
-   name VARCHAR(255) NOT NULL, -- Names are not really unique, for instance 'Sainte-Croix'
+   article TEXT,
+   name TEXT NOT NULL, -- Names are not really unique, for instance 'Sainte-Croix'
    department VARCHAR(4) NOT NULL REFERENCES Departments (code),
    UNIQUE (code, department)
    -- UNIQUE (name, department) -- Not perfectly unique but almost

--- a/testing/go/types_test.go
+++ b/testing/go/types_test.go
@@ -2111,18 +2111,25 @@ var typesTests = []ScriptTest{
 	{
 		Name: "Text type",
 		SetUpScript: []string{
-			"CREATE TABLE t_text (id INTEGER primary key, v1 TEXT);",
-			"INSERT INTO t_text VALUES (1, 'Hello'), (2, 'World'), (3, ''), (4, NULL);",
+			"CREATE TABLE t_text (id INTEGER primary key, v1 TEXT, v2 TEXT NOT NULL UNIQUE);",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
+				Query:    "INSERT INTO t_text VALUES (1, 'Hello', 'Bonjour'), (2, 'World', 'tout le monde'), (3, '', ''), (4, NULL, '!');",
+				Expected: []sql.Row{},
+			},
+			{
 				Query: "SELECT * FROM t_text ORDER BY id;",
 				Expected: []sql.Row{
-					{1, "Hello"},
-					{2, "World"},
-					{3, ""},
-					{4, nil},
+					{1, "Hello", "Bonjour"},
+					{2, "World", "tout le monde"},
+					{3, "", ""},
+					{4, nil, "!"},
 				},
+			},
+			{
+				Query:       "INSERT INTO t_text VALUES (5, 'Another', 'Bonjour');",
+				ExpectedErr: "ERROR: duplicate unique key given: [dfad80eab9ae06d1c9c0eaf2ef667a2bb45293f3] (errno 1062) (sqlstate HY000) (SQLSTATE XX000)",
 			},
 			{
 				Query:    `SELECT text 'text' || ' and unknown';`,


### PR DESCRIPTION
As part of testing a data dump load, I noticed that Doltgres panics when a `TEXT` field is used with a `UNIQUE` index. The issues were that:
* `TextType` didn't implement `sql.StringType`, which Dolt is requiring as part of `schemaImpl::getKeyColumnsDescriptor`
* `TextType`'s `SerializedCompare` method was trying to decode the text value _address_ as a variable length encoded string value

I implemented `sql.StringType`'s interface and changed the implementation of `SerializedCompare` to simply compare the bytes in the addresses, which works for uniqueness testing. However, this won't work for proper sorting, since the content-hashes won't always sort in the same order as the raw content, and I'm assuming `SerializedCompare` is used for sorting somewhere, too. The generated uniqueness violation error message is also not ideal, since it includes the content-address, not the actual value the user entered. Because of that, I'm not confident this is the right fix, but still wanted to get this out for some feedback. It seems like we need to go to the node store to pull the real content and compare it in order to fulfill this function's contract, but that seems inefficient/unnecessary for validating uniqueness and I don't see a good way to access the node store from this code yet. 