### PR TITLE
Fixed panic for some index joins

### DIFF
--- a/server/index/table.go
+++ b/server/index/table.go
@@ -34,10 +34,14 @@ var _ sql.IndexSearchableTable = (*DoltgresTable)(nil)
 
 // IndexedAccess implements the sql.IndexSearchableTable interface.
 func (dt *DoltgresTable) IndexedAccess(lookup sql.IndexLookup) sql.IndexedTable {
-	return &IndexedDoltgresTable{
-		IndexedDoltTable: dt.DoltTable.IndexedAccess(lookup).(*sqle.IndexedDoltTable),
-		idx:              lookup.Index,
-		rc:               lookup.Ranges.(index.DoltgresRangeCollection),
+	if dgRanges, ok := lookup.Ranges.(index.DoltgresRangeCollection); ok {
+		return &IndexedDoltgresTable{
+			IndexedDoltTable: dt.DoltTable.IndexedAccess(lookup).(*sqle.IndexedDoltTable),
+			idx:              lookup.Index,
+			rc:               dgRanges,
+		}
+	} else {
+		return dt.DoltTable.IndexedAccess(lookup)
 	}
 }
 

--- a/server/index/writable_table.go
+++ b/server/index/writable_table.go
@@ -34,10 +34,14 @@ var _ sql.IndexSearchableTable = (*WritableDoltgresTable)(nil)
 
 // IndexedAccess implements the sql.IndexSearchableTable interface.
 func (dt *WritableDoltgresTable) IndexedAccess(lookup sql.IndexLookup) sql.IndexedTable {
-	return &IndexedWritableDoltgresTable{
-		WritableIndexedDoltTable: dt.WritableDoltTable.IndexedAccess(lookup).(*sqle.WritableIndexedDoltTable),
-		idx:                      lookup.Index,
-		rc:                       lookup.Ranges.(index.DoltgresRangeCollection),
+	if dgRanges, ok := lookup.Ranges.(index.DoltgresRangeCollection); ok {
+		return &IndexedWritableDoltgresTable{
+			WritableIndexedDoltTable: dt.WritableDoltTable.IndexedAccess(lookup).(*sqle.WritableIndexedDoltTable),
+			idx:                      lookup.Index,
+			rc:                       dgRanges,
+		}
+	} else {
+		return dt.WritableDoltTable.IndexedAccess(lookup)
 	}
 }
 

--- a/testing/go/framework.go
+++ b/testing/go/framework.go
@@ -319,6 +319,9 @@ func NormalizeExpectedRow(fds []pgconn.FieldDescription, rows []sql.Row) []sql.R
 	for ri, row := range rows {
 		if len(row) == 0 {
 			newRows[ri] = nil
+		} else if len(row) != len(fds) {
+			// Return if the expected row count does not match the field description count, we'll error elsewhere
+			return rows
 		} else {
 			newRow := make(sql.Row, len(row))
 			for i := range row {

--- a/testing/go/smoke_test.go
+++ b/testing/go/smoke_test.go
@@ -185,6 +185,17 @@ func TestSmokeTests(t *testing.T) {
 			},
 			Assertions: []ScriptTestAssertion{
 				{
+					Query: "select first_name, last_name, team_name from employees " +
+						"join employees_teams on (employees.id=employees_teams.employee_id) " +
+						"join teams on (teams.id=employees_teams.team_id) where team_name='Engineering';",
+					Expected: []sql.Row{
+						{"Timothy", "Sehn", "Engineering"},
+						{"Brian", "Hendriks", "Engineering"},
+						{"Aaron", "Son", "Engineering"},
+						{"Daylon", "Wilkins", "Engineering"},
+					},
+				},
+				{
 					Query: "select to_last_name, to_first_name, to_id, to_commit, from_last_name, from_first_name," +
 						"from_id, from_commit, diff_type from dolt_diff('main', 'modifications', 'employees');",
 					Expected: []sql.Row{


### PR DESCRIPTION
Fixes:
* https://github.com/dolthub/doltgresql/issues/730

For _some_ index joins, the analyzer will create a specific type of plan that creates MySQL ranges rather than Doltgres ranges. It appears as though there may be divergent branches for the join logic, so I attempted to look for the source of the divergence, however I came up short.

For now, rather than chasing this down and delaying a PR (since Tim needs this fixed asap), we can pass the lookup to the internal Dolt table. This will return incorrect results in some situations, but it won't panic for now, so I'll follow up with a better search through GMS at a later date to merge the index join paths.