### PR TITLE
[no-release-notes] Flush messages in regression tool after ReadyForQuery

### DIFF
--- a/server/connection_handler.go
+++ b/server/connection_handler.go
@@ -62,12 +62,12 @@ type ConnectionHandler struct {
 // Set this env var to disable panic handling in the connection, which is useful when debugging a panic
 const disablePanicHandlingEnvVar = "DOLT_PGSQL_PANIC"
 
-// handlePanics determines whether panics should be handled in the connection handler. See |disablePanicHandlingEnvVar|.
-var handlePanics = true
+// HandlePanics determines whether panics should be handled in the connection handler. See |disablePanicHandlingEnvVar|.
+var HandlePanics = true
 
 func init() {
 	if _, ok := os.LookupEnv(disablePanicHandlingEnvVar); ok {
-		handlePanics = false
+		HandlePanics = false
 	}
 }
 
@@ -110,7 +110,7 @@ func NewConnectionHandler(conn net.Conn, handler mysql.Handler) *ConnectionHandl
 // Expected to run in a goroutine per connection.
 func (h *ConnectionHandler) HandleConnection() {
 	var returnErr error
-	if handlePanics {
+	if HandlePanics {
 		defer func() {
 			if r := recover(); r != nil {
 				fmt.Printf("Listener recovered panic: %v", r)
@@ -291,7 +291,7 @@ func (h *ConnectionHandler) receiveMessage() (bool, error) {
 	// forcibly close the connection. Contrast this with the panic handling logic in HandleConnection, where we treat any
 	// panic as unrecoverable to the connection. As we fill out the implementation, we can revisit this decision and
 	// rethink our posture over whether panics should terminate a connection.
-	if handlePanics {
+	if HandlePanics {
 		defer func() {
 			if r := recover(); r != nil {
 				fmt.Printf("Listener recovered panic: %v", r)

--- a/testing/go/regression/tool/message_reader.go
+++ b/testing/go/regression/tool/message_reader.go
@@ -89,6 +89,21 @@ func (mr *MessageReader) PushQueue(messages ...pgproto3.Message) {
 	mr.queue = append(mr.queue, messages...)
 }
 
+// SurroundingMessages returns the messages that are surrounding the ones at the current index. This is primarily for
+// debugging, as it can be hard to locate messages when there are thousands in the reader, and you want to know which
+// messages surround the current one.
+func (mr *MessageReader) SurroundingMessages(amountBefore int, amountAfter int) []pgproto3.Message {
+	amountBefore = mr.idx - amountBefore
+	amountAfter = mr.idx + amountAfter
+	if amountBefore < 0 {
+		amountBefore = 0
+	}
+	if amountAfter > len(mr.messages) {
+		amountAfter = len(mr.messages) - 1
+	}
+	return mr.messages[amountBefore:amountAfter]
+}
+
 // SyncToNextQuery advances the reader forward to the next query.
 func (mr *MessageReader) SyncToNextQuery() {
 	for {

--- a/testing/go/regression/tool/replay.go
+++ b/testing/go/regression/tool/replay.go
@@ -146,6 +146,17 @@ ListenerLoop:
 						return nil, fmt.Errorf("unable to determine what to do with %T", message)
 					}
 				}
+				if postgresConnFrontend.ReadBufferLen() > 0 {
+					for postgresConnFrontend.ReadBufferLen() > 0 {
+						_, _ = postgresConnFrontend.Receive()
+					}
+					tracker.Failed++
+					tracker.Add(ReplayTrackerItem{
+						Query:           "DESCRIBE",
+						UnexpectedError: "Doltgres sent additional messages after ReadyForQuery",
+					})
+					continue MessageLoop
+				}
 				if expectedError == nil {
 					if responseError != nil {
 						tracker.Failed++
@@ -274,6 +285,17 @@ ListenerLoop:
 						return nil, fmt.Errorf("unable to determine what to do with %T", message)
 					}
 				}
+				if postgresConnFrontend.ReadBufferLen() > 0 {
+					for postgresConnFrontend.ReadBufferLen() > 0 {
+						_, _ = postgresConnFrontend.Receive()
+					}
+					tracker.Failed++
+					tracker.Add(ReplayTrackerItem{
+						Query:           fmt.Sprintf("Function OID: %d", message.Function),
+						UnexpectedError: "Doltgres sent additional messages after ReadyForQuery",
+					})
+					continue MessageLoop
+				}
 				if expectedError == nil {
 					if responseError != nil {
 						tracker.Failed++
@@ -389,6 +411,17 @@ ListenerLoop:
 					default:
 						return nil, fmt.Errorf("unable to determine what to do with %T", message)
 					}
+				}
+				if postgresConnFrontend.ReadBufferLen() > 0 {
+					for postgresConnFrontend.ReadBufferLen() > 0 {
+						_, _ = postgresConnFrontend.Receive()
+					}
+					tracker.Failed++
+					tracker.Add(ReplayTrackerItem{
+						Query:           message.Query,
+						UnexpectedError: "Doltgres sent additional messages after ReadyForQuery",
+					})
+					continue MessageLoop
 				}
 				if expectedError == nil {
 					if responseError != nil {
@@ -530,6 +563,17 @@ ListenerLoop:
 					default:
 						return nil, fmt.Errorf("unable to determine what to do with %T", message)
 					}
+				}
+				if postgresConnFrontend.ReadBufferLen() > 0 {
+					for postgresConnFrontend.ReadBufferLen() > 0 {
+						_, _ = postgresConnFrontend.Receive()
+					}
+					tracker.Failed++
+					tracker.Add(ReplayTrackerItem{
+						Query:           message.String,
+						UnexpectedError: "Doltgres sent additional messages after ReadyForQuery",
+					})
+					continue MessageLoop
 				}
 				if expectedError == nil {
 					if responseError != nil {


### PR DESCRIPTION
Doltgres may occasionally send multiple `ReadyForQuery` messages rather than just one, which is an error. This changes the regression tool so that it now flushes after receiving `ReadyForQuery`, so that such errors do not cause big regression swings when they are fixed.