### PR TITLE
Added RFC5802 for user client authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,8 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.4
 	github.com/twpayne/go-geom v1.3.6
+	github.com/xdg-go/stringprep v1.0.4
+	golang.org/x/crypto v0.23.0
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/net v0.25.0
 	golang.org/x/sync v0.7.0
@@ -145,7 +147,6 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
-	golang.org/x/crypto v0.23.0 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect
 	golang.org/x/term v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -897,6 +897,8 @@ github.com/vbauerster/mpb v3.4.0+incompatible h1:mfiiYw87ARaeRW6x5gWwYRUawxaW1tL
 github.com/vbauerster/mpb v3.4.0+incompatible/go.mod h1:zAHG26FUhVKETRu+MWqYXcI70POlC6N8up9p1dID7SU=
 github.com/vbauerster/mpb/v8 v8.0.2 h1:alVQG69Jg5+Ku9Hu1dakDx50uACEHnIzS7i356NQ/Vs=
 github.com/vbauerster/mpb/v8 v8.0.2/go.mod h1:Z9VJYIzXls7xZwirZjShGsi+14enzJhQfGyb/XZK0ZQ=
+github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6c8=
+github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/server/users/mock_database.go
+++ b/server/users/mock_database.go
@@ -1,0 +1,84 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package users
+
+import (
+	"fmt"
+
+	"github.com/dolthub/doltgresql/server/users/rfc5802"
+)
+
+// TODO: this will actually hold whatever needs to be held for proper authentication and role management.
+//  For now though, this just exists to test that passwords for users are being stored and retrieved correctly.
+
+var (
+	globalMockDatabase MockDatabase
+)
+
+// MockDatabase is a temporary database to hold user passwords.
+type MockDatabase struct {
+	Users map[string]MockUser
+}
+
+// MockUser is a temporary user to hold a user's password.
+type MockUser struct {
+	Name     string
+	Exists   bool
+	Password ScramSha256Password
+}
+
+// ScramSha256Password is the struct form of an encrypted password.
+type ScramSha256Password struct {
+	Iterations uint32
+	Salt       rfc5802.OctetString
+	StoredKey  rfc5802.OctetString
+	ServerKey  rfc5802.OctetString
+}
+
+// AsPasswordString returns the password as defined in https://www.postgresql.org/docs/15/catalog-pg-authid.html
+func (password ScramSha256Password) AsPasswordString() string {
+	return fmt.Sprintf(`SCRAM-SHA-256$%d:%s$%s:%s`,
+		password.Iterations, password.Salt.ToBase64(), password.StoredKey.ToBase64(), password.ServerKey.ToBase64())
+}
+
+// GetUser returns the user with the given name.
+func GetUser(name string) MockUser {
+	return globalMockDatabase.Users[name]
+}
+
+// init initializes the mock database and fills it with default users for testing.
+func init() {
+	globalMockDatabase = MockDatabase{make(map[string]MockUser)}
+	createUser("doltgres", "", "h2745oyhgwek4j")
+	createUser("postgres", "password", "87835hg29u4has")
+	createUser("user1", "abc123z", "g842hkaASF5320")
+	createUser("user2", "bad_pass", "u924gf190yg4rb")
+}
+
+// createUser is called from within init to create a default set of users.
+func createUser(name string, password string, salt string) {
+	scramPassword := ScramSha256Password{
+		Iterations: 4096,
+		Salt:       rfc5802.OctetString(salt),
+	}
+	postgresSaltedPassword := rfc5802.SaltedPassword(password, scramPassword.Salt, scramPassword.Iterations)
+	scramPassword.StoredKey = rfc5802.StoredKey(rfc5802.ClientKey(postgresSaltedPassword))
+	scramPassword.ServerKey = rfc5802.ServerKey(postgresSaltedPassword)
+	globalMockDatabase.Users[name] = MockUser{
+		Name:     name,
+		Exists:   true,
+		Password: scramPassword,
+	}
+}

--- a/server/users/rfc5802/doc.go
+++ b/server/users/rfc5802/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rfc5802
+
+// This package is meant to implement the functions defined in RFC 5802. As such, function names will be non-standard
+// compared to most other names in the project.
+// https://datatracker.ietf.org/doc/html/rfc5802

--- a/server/users/rfc5802/functions.go
+++ b/server/users/rfc5802/functions.go
@@ -1,0 +1,147 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rfc5802
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+
+	"github.com/xdg-go/stringprep"
+	"golang.org/x/crypto/pbkdf2"
+)
+
+var (
+	clientKeyConstant = OctetString("Client Key")
+	serverKeyConstant = OctetString("Server Key")
+)
+
+// OctetString is equivalent to a byte slice. An octet, as defined in the RFC, is an 8-bit byte. Go only supports 8-bit
+// bytes. Additionally, an octet string is defined as a sequence of octets, which we can represent as a slice.
+type OctetString []byte
+
+// Base64ToOctetString returns the original octet string from its base64 encoded form.
+func Base64ToOctetString(base64String string) OctetString {
+	decoded, err := base64.StdEncoding.DecodeString(base64String)
+	if err != nil {
+		// If we've encountered an error, then we'll return the equivalent of an empty hash. This will fail in a later step.
+		return make(OctetString, 32)
+	}
+	return decoded
+}
+
+// ClientKey returns the client key created using the salted password and a specific constant.
+func ClientKey(saltedPassword OctetString) OctetString {
+	return HMAC(saltedPassword, clientKeyConstant)
+}
+
+// ClientProof returns the client proof by xor'ing the client key and client signature.
+func ClientProof(clientKey OctetString, clientSignature OctetString) OctetString {
+	if len(clientKey) != len(clientSignature) {
+		return make(OctetString, 32)
+	}
+	return clientKey.Xor(clientSignature)
+}
+
+// ClientSignature returns the client signature using the given stored key and auth message.
+func ClientSignature(storedKey OctetString, authMessage string) OctetString {
+	return HMAC(storedKey, OctetString(authMessage))
+}
+
+// H performs the SHA256 hash function, which is the hash function used by Postgres.
+func H(str OctetString) OctetString {
+	ret := sha256.Sum256(str)
+	return ret[:]
+}
+
+// Hi is, essentially, PBKDF2 with HMAC as the pseudorandom function.
+func Hi(str OctetString, salt OctetString, i uint32) OctetString {
+	return pbkdf2.Key(str, salt, int(i), 32, sha256.New)
+}
+
+// HMAC applies the HMAC keyed hash algorithm on the given octet strings.
+func HMAC(key OctetString, str OctetString) OctetString {
+	mac := hmac.New(sha256.New, key)
+	mac.Write(str)
+	return mac.Sum(nil)
+}
+
+// Normalize runs the SASLprep profile (https://datatracker.ietf.org/doc/html/rfc4013) of the stringprep algorithm
+// (https://datatracker.ietf.org/doc/html/rfc3454). This accepts a standard UTF8 encoded string, unlike other functions
+// which may take an OctetString.
+func Normalize(str string) (string, error) {
+	return stringprep.SASLprep.Prepare(str)
+}
+
+// SaltedPassword returns the salted password. The password should not have been normalized, as it is normalized within
+// the function.
+func SaltedPassword(password string, salt OctetString, i uint32) OctetString {
+	normalizedPassword, err := Normalize(password)
+	if err != nil {
+		// If there is an error, then it should be fine to return the zero hash
+		return make(OctetString, 32)
+	}
+	return Hi(OctetString(normalizedPassword), salt, i)
+}
+
+// ServerKey returns the server key created using the salted password and a specific constant.
+func ServerKey(saltedPassword OctetString) OctetString {
+	return HMAC(saltedPassword, serverKeyConstant)
+}
+
+// ServerSignature returns the server signature using the given server key and auth message.
+func ServerSignature(serverKey OctetString, authMessage string) OctetString {
+	return HMAC(serverKey, OctetString(authMessage))
+}
+
+// StoredKey returns the stored key created using the client key.
+func StoredKey(clientKey OctetString) OctetString {
+	return H(clientKey)
+}
+
+// AppendInteger appends the given integer.
+func (os OctetString) AppendInteger(val uint32) OctetString {
+	result := make(OctetString, len(os)+4)
+	binary.BigEndian.PutUint32(result[len(os):], val)
+	return result
+}
+
+// Equals returns whether the calling octet string is equal to the given octet string.
+func (os OctetString) Equals(other OctetString) bool {
+	return bytes.Equal(os, other)
+}
+
+// ToBase64 returns the OctetString as a base64 encoded UTF8 string.
+func (os OctetString) ToBase64() string {
+	return base64.StdEncoding.EncodeToString(os)
+}
+
+// ToHex returns the OctetString as a hex encoded UTF8 string (lowercase).
+func (os OctetString) ToHex() string {
+	return hex.EncodeToString(os)
+}
+
+// Xor applies "exclusive or" for every octet between both strings. Assumes that both strings have the same length, so
+// perform any checks before calling this function.
+func (os OctetString) Xor(other OctetString) OctetString {
+	result := make(OctetString, len(os))
+	for i := range os {
+		result[i] = os[i] ^ other[i]
+	}
+	return result
+}

--- a/testing/go/framework.go
+++ b/testing/go/framework.go
@@ -127,6 +127,7 @@ func RunScript(t *testing.T, script ScriptTest, normalizeRows bool) {
 
 // runScript runs the script given on the postgres connection provided
 func runScript(t *testing.T, ctx context.Context, script ScriptTest, conn *pgx.Conn, normalizeRows bool) {
+	dserver.EnableAuthentication = true
 	if script.Skip {
 		t.Skip("Skip has been set in the script")
 	}


### PR DESCRIPTION
For the most part, this implements the following portions of [RFC 5802](https://datatracker.ietf.org/doc/html/rfc5802):
* [Section 2.2](https://datatracker.ietf.org/doc/html/rfc5802#section-2.2)
* [Section 3](https://datatracker.ietf.org/doc/html/rfc5802#section-3)
* Validation portion of [Section 5](https://datatracker.ietf.org/doc/html/rfc5802#section-5)

This also bases the stored data from:
* https://www.postgresql.org/docs/15/catalog-pg-authid.html

This PR finally lets the server do the full authentication routine with the client. For now, I've created a mock database full of mock users, which are actually being tested by all of our engine tests since we do supply a username and password when creating and setting up the server. The `pgx` library is handling the client-side authentication for these tests.

The next step is to handle basic `CREATE USER` and `DROP USER` statements. With those in, I'll create a full battery of tests (bats tests, unit tests, dedicated engine tests, etc.). Unit tests are not included in this PR since I may make further changes with the next PR, and I'd prefer to do a big testing pass at once since none of this is in production just yet.

After the aforementioned statements and testing, I'll move on to designing the storage portion, since the mock user and mock database are stand-ins for an actual implementation.