### PR TITLE
fix: fix slice init length

### DIFF
--- a/postgres/parser/sem/tree/pretty.go
+++ b/postgres/parser/sem/tree/pretty.go
@@ -1125,7 +1125,7 @@ func (p *PrettyCfg) exprDocWithParen(e Expr) pretty.Doc {
 }
 
 func (node *Update) doc(p *PrettyCfg) pretty.Doc {
-	items := make([]pretty.TableRow, 8)
+	items := make([]pretty.TableRow, 0, 8)
 	items = append(items,
 		node.With.docRow(p),
 		p.row("UPDATE", p.Doc(node.Table)),
@@ -1143,7 +1143,7 @@ func (node *Update) doc(p *PrettyCfg) pretty.Doc {
 }
 
 func (node *Delete) doc(p *PrettyCfg) pretty.Doc {
-	items := make([]pretty.TableRow, 6)
+	items := make([]pretty.TableRow, 0, 6)
 	items = append(items,
 		node.With.docRow(p),
 		p.row("DELETE FROM", p.Doc(node.Table)),


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of length rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW