### PR TITLE
Label contribution PRs

### DIFF
--- a/.github/workflows/label-customer-issues.yaml
+++ b/.github/workflows/label-customer-issues.yaml
@@ -1,0 +1,19 @@
+name: Label Customer Issues
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    branches: [main]
+    types: [opened]
+
+jobs:
+  label_customer_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dolthub/label-customer-issues@main
+        with:
+          repo-token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          issue-label: customer issue
+          pr-label: contribution
+          exclude: dependabot


### PR DESCRIPTION
Adds a GitHub Actions workflow to label PRs from outside the team with the "contribution" label. This is the same workflow we use for dolt/go-mysql-server/etc. 