### PR TITLE
Allow `nextval()` to take a regclass instance

### DIFF
--- a/server/functions/current_schema.go
+++ b/server/functions/current_schema.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
+	"github.com/dolthub/doltgresql/server/settings"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
@@ -33,7 +34,7 @@ var current_schema = framework.Function0{
 	IsNonDeterministic: true,
 	Strict:             true,
 	Callable: func(ctx *sql.Context) (any, error) {
-		schemas, err := GetCurrentSchemas(ctx)
+		schemas, err := settings.GetCurrentSchemas(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/server/functions/current_schemas.go
+++ b/server/functions/current_schemas.go
@@ -15,12 +15,11 @@
 package functions
 
 import (
-	"strings"
-
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/postgres/parser/sessiondata"
 	"github.com/dolthub/doltgresql/server/functions/framework"
+	"github.com/dolthub/doltgresql/server/settings"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
@@ -41,7 +40,7 @@ var current_schemas = framework.Function1{
 		if val.(bool) {
 			schemas = append(schemas, sessiondata.PgCatalogName)
 		}
-		searchPaths, err := GetCurrentSchemas(ctx)
+		searchPaths, err := settings.GetCurrentSchemas(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -50,25 +49,4 @@ var current_schemas = framework.Function1{
 		}
 		return schemas, nil
 	},
-}
-
-// GetCurrentSchemas returns all the schemas in the search_path setting, with elements like "$user" excluded
-func GetCurrentSchemas(ctx *sql.Context) ([]string, error) {
-	searchPathVar, err := ctx.GetSessionVariable(ctx, "search_path")
-	if err != nil {
-		return nil, err
-	}
-
-	pathElems := strings.Split(searchPathVar.(string), ",")
-	var path []string
-
-	for _, schemaName := range pathElems {
-		schemaName = strings.Trim(schemaName, " ")
-		if schemaName == "\"$user\"" {
-			continue
-		}
-		path = append(path, schemaName)
-	}
-
-	return path, nil
 }

--- a/server/functions/nextval.go
+++ b/server/functions/nextval.go
@@ -24,18 +24,23 @@ import (
 
 // initNextVal registers the functions to the catalog.
 func initNextVal() {
-	framework.RegisterFunction(nextval_text)
+	framework.RegisterFunction(nextval_regclass)
 }
 
-// nextval_text represents the PostgreSQL function of the same name, taking the same parameters.
-var nextval_text = framework.Function1{
+// nextval_regclass represents the PostgreSQL function of the same name, taking the same parameters.
+var nextval_regclass = framework.Function1{
 	Name:               "nextval",
 	Return:             pgtypes.Int64,
-	Parameters:         [1]pgtypes.DoltgresType{pgtypes.Text},
+	Parameters:         [1]pgtypes.DoltgresType{pgtypes.Regclass},
 	IsNonDeterministic: true,
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val any) (any, error) {
-		schema, sequence, err := parseRelationName(ctx, val.(string))
+		relationName, err := pgtypes.Regclass.IoOutput(ctx, val)
+		if err != nil {
+			return nil, err
+		}
+
+		schema, sequence, err := parseRelationName(ctx, relationName)
 		if err != nil {
 			return nil, err
 		}

--- a/server/functions/nextval.go
+++ b/server/functions/nextval.go
@@ -24,7 +24,34 @@ import (
 
 // initNextVal registers the functions to the catalog.
 func initNextVal() {
+	framework.RegisterFunction(nextval_text)
 	framework.RegisterFunction(nextval_regclass)
+}
+
+// nextval_text represents the PostgreSQL function of the same name, taking the same parameters.
+//
+// TODO: Even though we can implicitly convert a text param to a regclass param, it's an expensive process
+// to convert it to a regclass, then convert the regclass back into the relation name, so we provide an overload
+// that takes a text param directly, in addition to the function form that takes a regclass. Once we can optimize
+// the regclass to text conversion, we can potentially remove this overload.
+var nextval_text = framework.Function1{
+	Name:               "nextval",
+	Return:             pgtypes.Int64,
+	Parameters:         [1]pgtypes.DoltgresType{pgtypes.Text},
+	IsNonDeterministic: true,
+	Strict:             true,
+	Callable: func(ctx *sql.Context, _ [2]pgtypes.DoltgresType, val any) (any, error) {
+		schema, sequence, err := parseRelationName(ctx, val.(string))
+		if err != nil {
+			return nil, err
+		}
+
+		collection, err := core.GetSequencesCollectionFromContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return collection.NextVal(schema, sequence)
+	},
 }
 
 // nextval_regclass represents the PostgreSQL function of the same name, taking the same parameters.

--- a/server/settings/current_schemas.go
+++ b/server/settings/current_schemas.go
@@ -1,0 +1,56 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package settings
+
+import (
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// GetCurrentSchemas returns all the schemas in the search_path setting, with elements like "$user" excluded
+func GetCurrentSchemas(ctx *sql.Context) ([]string, error) {
+	searchPathVar, err := ctx.GetSessionVariable(ctx, "search_path")
+	if err != nil {
+		return nil, err
+	}
+
+	pathElems := strings.Split(searchPathVar.(string), ",")
+	var path []string
+
+	for _, schemaName := range pathElems {
+		schemaName = strings.Trim(schemaName, " ")
+		if schemaName == "\"$user\"" {
+			continue
+		}
+		path = append(path, schemaName)
+	}
+
+	return path, nil
+}
+
+// GetCurrentSchemasAsMap returns the schemas from the search_path setting as a map for easy lookup. Any
+// elements like "$user" are excluded.
+func GetCurrentSchemasAsMap(ctx *sql.Context) (map[string]struct{}, error) {
+	schemas, err := GetCurrentSchemas(ctx)
+	if err != nil {
+		return nil, err
+	}
+	schemaMap := make(map[string]struct{}, len(schemas))
+	for _, schema := range schemas {
+		schemaMap[schema] = struct{}{}
+	}
+	return schemaMap, nil
+}

--- a/server/settings/doc.go
+++ b/server/settings/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package settings provides utility functions for working with settings, such as the search_path setting.
+//
+// This package is intended to be a leaf in the package dependency graph, and should not add dependencies to
+// other Doltgres packages.
+package settings

--- a/server/types/text.go
+++ b/server/types/text.go
@@ -106,6 +106,10 @@ func (b TextType) Convert(val any) (any, sql.ConvertInRange, error) {
 
 // Equals implements the DoltgresType interface.
 func (b TextType) Equals(otherType sql.Type) bool {
+	if _, ok := otherType.(TextType); !ok {
+		return false
+	}
+
 	if otherExtendedType, ok := otherType.(types.ExtendedType); ok {
 		return bytes.Equal(MustSerializeType(b), MustSerializeType(otherExtendedType))
 	}

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -202,6 +202,24 @@ func TestFunctionsOID(t *testing.T) {
 						{nil},
 					},
 				},
+				{
+					// When the relation is from a schema on the search path, it is not qualified with the schema name
+					Query: `SELECT to_regclass(('public.testing'::regclass)::text);`,
+					Expected: []sql.Row{
+						{"testing"},
+					},
+				},
+				{
+					// Clear out the current search_path setting to test fully qualified relation names
+					Query:    `SET search_path = '';`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query: `SELECT to_regclass(('public.testing'::regclass)::text);`,
+					Expected: []sql.Row{
+						{"public.testing"},
+					},
+				},
 			},
 		},
 		{

--- a/testing/go/sequences_test.go
+++ b/testing/go/sequences_test.go
@@ -42,6 +42,14 @@ func TestSequences(t *testing.T) {
 					Expected: []sql.Row{{3}},
 				},
 				{
+					Query:    "SELECT nextval('test'::regclass);",
+					Expected: []sql.Row{{4}},
+				},
+				{
+					Query:       "SELECT nextval('doesnotexist'::regclass);",
+					ExpectedErr: "does not exist",
+				},
+				{
 					Query:    "DROP SEQUENCE test;",
 					Expected: []sql.Row{},
 				},


### PR DESCRIPTION
Allows the `nextval()` function to take a `regclass` parameter. Also changes the output function of `regclass` so that the returned relation name is schema-qualified if the schema is not on `search_path`. 

This change also moves the `GetCurrentSchemas()` function into a new `settings` package to break a package import cycle. The new `settings` package is intended for low-level functions that access settings, without dependencies on other packages. 

Fixes: https://github.com/dolthub/doltgresql/issues/850