### PR TITLE
drop domain support

### DIFF
--- a/core/typecollection/merge.go
+++ b/core/typecollection/merge.go
@@ -1,0 +1,67 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typecollection
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dolthub/doltgresql/server/types"
+)
+
+// Merge handles merging sequences on our root and their root.
+func Merge(ctx context.Context, ourCollection, theirCollection, ancCollection *TypeCollection) (*TypeCollection, error) {
+	mergedCollection := ourCollection.Clone()
+	err := theirCollection.IterateTypes(func(schema string, theirType *types.Type) error {
+		// If we don't have the type, then we simply add it
+		mergedType, exists := mergedCollection.GetType(schema, theirType.Name)
+		if !exists {
+			newSeq := *theirType
+			return mergedCollection.CreateType(schema, &newSeq)
+		}
+
+		// Different types with the same name cannot be merged. (e.g.: 'domain' type and 'base' type with the same name)
+		if mergedType.TypType != theirType.TypType {
+			return fmt.Errorf(`cannot merge type "%s" because type types do not match: '%s' and '%s'"`, theirType.Name, mergedType.TypType, theirType.TypType)
+		}
+
+		switch theirType.TypType {
+		case types.TypeType_Domain:
+			if mergedType.BaseTypeOID != theirType.BaseTypeOID {
+				// TODO: we can extend on this in the future (e.g.: maybe uses preferred type?)
+				return fmt.Errorf(`base types of domain type "%s" do not match`, theirType.Name)
+			}
+			if mergedType.Default == "" {
+				mergedType.Default = theirType.Default
+			} else if theirType.Default != "" && mergedType.Default != theirType.Default {
+				return fmt.Errorf(`default values of domain type "%s" do not match`, theirType.Name)
+			}
+			// if either of types defined as NOT NULL, take NOT NULL
+			if mergedType.NotNull || theirType.NotNull {
+				mergedType.NotNull = true
+			}
+			if len(theirType.Checks) > 0 {
+				mergedType.Checks = append(mergedType.Checks, theirType.Checks...)
+			}
+		default:
+			// TODO: support merge for other types. (base, range, etc.)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return mergedCollection, nil
+}

--- a/core/typecollection/merge.go
+++ b/core/typecollection/merge.go
@@ -53,6 +53,7 @@ func Merge(ctx context.Context, ourCollection, theirCollection, ancCollection *T
 				mergedType.NotNull = true
 			}
 			if len(theirType.Checks) > 0 {
+				// TODO: check for duplicate check constraints
 				mergedType.Checks = append(mergedType.Checks, theirType.Checks...)
 			}
 		default:

--- a/core/typecollection/serialization.go
+++ b/core/typecollection/serialization.go
@@ -46,12 +46,13 @@ func (pgs *TypeCollection) Serialize(ctx context.Context) ([]byte, error) {
 		writer.VariableUint(uint64(len(nameMapKeys)))
 		for _, nameMapKey := range nameMapKeys {
 			typ := nameMap[nameMapKey]
+			writer.Uint32(typ.Oid)
 			writer.String(typ.Name)
 			writer.String(typ.Owner)
 			writer.Int16(typ.Length)
 			writer.Bool(typ.PassedByVal)
-			writer.String(string(typ.Typ))
-			writer.String(string(typ.Category))
+			writer.String(string(typ.TypType))
+			writer.String(string(typ.TypCategory))
 			writer.Bool(typ.IsPreferred)
 			writer.Bool(typ.IsDefined)
 			writer.String(typ.Delimiter)
@@ -110,13 +111,14 @@ func Deserialize(ctx context.Context, data []byte) (*TypeCollection, error) {
 		numOfTypes := reader.VariableUint()
 		nameMap := make(map[string]*types.Type)
 		for j := uint64(0); j < numOfTypes; j++ {
-			typ := &types.Type{}
+			typ := &types.Type{Schema: schemaName}
+			typ.Oid = reader.Uint32()
 			typ.Name = reader.String()
 			typ.Owner = reader.String()
 			typ.Length = reader.Int16()
 			typ.PassedByVal = reader.Bool()
-			typ.Typ = types.TypeType(reader.String())
-			typ.Category = types.TypeCategory(reader.String())
+			typ.TypType = types.TypeType(reader.String())
+			typ.TypCategory = types.TypeCategory(reader.String())
 			typ.IsPreferred = reader.Bool()
 			typ.IsDefined = reader.Bool()
 			typ.Delimiter = reader.String()

--- a/core/typecollection/typecollection.go
+++ b/core/typecollection/typecollection.go
@@ -48,7 +48,7 @@ func (pgs *TypeCollection) GetDomainType(schName, typName string) (*types.Type, 
 	defer pgs.mutex.RUnlock()
 
 	if nameMap, ok := pgs.schemaMap[schName]; ok {
-		if typ, ok := nameMap[typName]; ok && typ.Typ == types.TypeType_Domain {
+		if typ, ok := nameMap[typName]; ok && typ.TypType == types.TypeType_Domain {
 			return typ, true
 		}
 	}

--- a/server/ast/drop_domain.go
+++ b/server/ast/drop_domain.go
@@ -20,26 +20,26 @@ import (
 	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/doltgresql/postgres/parser/sem/tree"
+	pgnodes "github.com/dolthub/doltgresql/server/node"
 )
 
 // nodeDropDomain handles *tree.DropDomain nodes.
 func nodeDropDomain(node *tree.DropDomain) (vitess.Statement, error) {
-	return nil, fmt.Errorf("DROP DOMAIN is not supported yet")
-	//if node == nil {
-	//	return nil, nil
-	//}
-	//if len(node.Names) != 1 {
-	//	return nil, fmt.Errorf("dropping multiple domains in DROP DOMAIN is not yet supported")
-	//}
-	//name, err := nodeTableName(&node.Names[0])
-	//if err != nil {
-	//	return nil, err
-	//}
-	//if len(name.DbQualifier.String()) > 0 {
-	//	return nil, fmt.Errorf("DROP DOMAIN is currently only supported for the current database")
-	//}
-	//return vitess.InjectedStatement{
-	//	Statement: pgnodes.NewDropDomain(node.IfExists, name.SchemaQualifier.String(), name.Name.String(), node.DropBehavior == tree.DropCascade),
-	//	Children:  nil,
-	//}, nil
+	if node == nil {
+		return nil, nil
+	}
+	if len(node.Names) != 1 {
+		return nil, fmt.Errorf("dropping multiple domains in DROP DOMAIN is not yet supported")
+	}
+	name, err := nodeTableName(&node.Names[0])
+	if err != nil {
+		return nil, err
+	}
+	if len(name.DbQualifier.String()) > 0 {
+		return nil, fmt.Errorf("DROP DOMAIN is currently only supported for the current database")
+	}
+	return vitess.InjectedStatement{
+		Statement: pgnodes.NewDropDomain(node.IfExists, name.SchemaQualifier.String(), name.Name.String(), node.DropBehavior == tree.DropCascade),
+		Children:  nil,
+	}, nil
 }

--- a/server/ast/drop_domain.go
+++ b/server/ast/drop_domain.go
@@ -16,7 +16,6 @@ package ast
 
 import (
 	"fmt"
-
 	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/doltgresql/postgres/parser/sem/tree"
@@ -35,11 +34,13 @@ func nodeDropDomain(node *tree.DropDomain) (vitess.Statement, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(name.DbQualifier.String()) > 0 {
-		return nil, fmt.Errorf("DROP DOMAIN is currently only supported for the current database")
-	}
 	return vitess.InjectedStatement{
-		Statement: pgnodes.NewDropDomain(node.IfExists, name.SchemaQualifier.String(), name.Name.String(), node.DropBehavior == tree.DropCascade),
-		Children:  nil,
+		Statement: pgnodes.NewDropDomain(
+			node.IfExists,
+			name.DbQualifier.String(),
+			name.SchemaQualifier.String(),
+			name.Name.String(),
+			node.DropBehavior == tree.DropCascade),
+		Children: nil,
 	}, nil
 }

--- a/server/ast/drop_domain.go
+++ b/server/ast/drop_domain.go
@@ -16,6 +16,7 @@ package ast
 
 import (
 	"fmt"
+
 	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/doltgresql/postgres/parser/sem/tree"

--- a/server/node/create_domain.go
+++ b/server/node/create_domain.go
@@ -76,16 +76,8 @@ func (c *CreateDomain) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error)
 			return nil, err
 		}
 	}
-	d := types.DomainType{
-		Schema:      c.SchemaName,
-		Name:        c.Name,
-		AsType:      c.AsType,
-		DefaultExpr: defExpr,
-		NotNull:     c.IsNotNull,
-		Checks:      checkDefs,
-	}
 
-	newType, err := types.NewDomainType(ctx, d, "")
+	newType, err := types.NewDomainType(ctx, c.SchemaName, c.Name, c.AsType, defExpr, c.IsNotNull, checkDefs, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/node/drop_domain.go
+++ b/server/node/drop_domain.go
@@ -27,6 +27,7 @@ import (
 
 // DropDomain handles the DROP DOMAIN statement.
 type DropDomain struct {
+	database string
 	schema   string
 	domain   string
 	ifExists bool
@@ -37,8 +38,9 @@ var _ sql.ExecSourceRel = (*DropDomain)(nil)
 var _ vitess.Injectable = (*DropDomain)(nil)
 
 // NewDropDomain returns a new *DropDomain.
-func NewDropDomain(ifExists bool, schema string, domain string, cascade bool) *DropDomain {
+func NewDropDomain(ifExists bool, db string, schema string, domain string, cascade bool) *DropDomain {
 	return &DropDomain{
+		database: db,
 		schema:   schema,
 		domain:   domain,
 		ifExists: ifExists,
@@ -68,6 +70,10 @@ func (c *DropDomain) Resolved() bool {
 
 // RowIter implements the interface sql.ExecSourceRel.
 func (c *DropDomain) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error) {
+	currentDb := ctx.GetCurrentDatabase()
+	if len(c.database) > 0 && c.database != currentDb {
+		return nil, fmt.Errorf("DROP DOMAIN is currently only supported for the current database")
+	}
 	schema, err := core.GetSchemaName(ctx, nil, c.schema)
 	if err != nil {
 		return nil, err
@@ -108,7 +114,9 @@ func (c *DropDomain) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error) {
 			for _, col := range t.Schema() {
 				if dt, isDomainType := col.Type.(types.DomainType); isDomainType {
 					if dt.Name == domain.Name {
-						return nil, fmt.Errorf(`cannot drop type %s because other objects depend on it`, c.domain)
+						// TODO: issue a detail (list of all columns and tables that uses this domain)
+						//  and a hint (when we support CASCADE)
+						return nil, fmt.Errorf(`cannot drop type %s because other objects depend on it - column %s of table %s depends on type %s'`, c.domain, col.Name, t.Name(), c.domain)
 					}
 				}
 			}

--- a/server/types/domain.go
+++ b/server/types/domain.go
@@ -38,46 +38,53 @@ type DomainType struct {
 // NewDomainType creates new instance of domain Type.
 func NewDomainType(
 	ctx *sql.Context,
-	domain DomainType,
+	schema string,
+	name string,
+	asType DoltgresType,
+	defaultExpr string,
+	notNull bool,
+	checks []*sql.CheckDefinition,
 	owner string, // TODO
 ) (*Type, error) {
 	passedByVal := false
-	l := domain.AsType.MaxTextResponseByteLength(ctx)
+	l := asType.MaxTextResponseByteLength(ctx)
 	if l&1 == 0 && l < 9 {
 		passedByVal = true
 	}
 	return &Type{
-		Name:          domain.Name,
+		Oid:           0, // TODO: generate unique OID
+		Name:          name,
+		Schema:        schema,
 		Owner:         owner,
 		Length:        int16(l),
 		PassedByVal:   passedByVal,
-		Typ:           TypeType_Domain,
-		Category:      domain.AsType.Category(),
-		IsPreferred:   domain.AsType.IsPreferredType(),
+		TypType:       TypeType_Domain,
+		TypCategory:   asType.Category(),
+		IsPreferred:   asType.IsPreferredType(),
 		IsDefined:     true,
 		Delimiter:     ",",
-		RelID:         0, // composite type only
+		RelID:         0,
 		SubscriptFunc: "",
 		Elem:          0,
 		Array:         0, // TODO: refers to array type of this type
 		InputFunc:     "domain_in",
-		OutputFunc:    "",
+		OutputFunc:    "", // TODO: base type's out function
 		ReceiveFunc:   "domain_recv",
-		SendFunc:      "",
+		SendFunc:      "", // TODO: base type's send function
 		ModInFunc:     "-",
 		ModOutFunc:    "-",
 		AnalyzeFunc:   "-",
-		Align:         domain.AsType.Alignment(),
-		Storage:       TypeStorage_Plain, // TODO
-		NotNull:       domain.NotNull,
-		BaseTypeOID:   domain.AsType.OID(),
+		Align:         asType.Alignment(),
+		Storage:       TypeStorage_Plain, // TODO: base type's storage
+		NotNull:       notNull,
+		BaseTypeOID:   asType.OID(),
 		TypMod:        -1,
 		NDims:         0,
 		Collation:     0,
 		DefaulBin:     "",
-		Default:       domain.DefaultExpr,
+		Default:       defaultExpr,
 		Acl:           "",
-		Checks:        domain.Checks,
+		Checks:        checks,
 	}, nil
 }
 

--- a/server/types/globals.go
+++ b/server/types/globals.go
@@ -148,7 +148,7 @@ const (
 	TypeType_Composite  TypeType = "c"
 	TypeType_Domain     TypeType = "d"
 	TypeType_Enum       TypeType = "e"
-	TypeType_Shell      TypeType = "p" // a pseudo-type
+	TypeType_Pseudo     TypeType = "p"
 	TypeType_Range      TypeType = "r"
 	TypeType_MultiRange TypeType = "m"
 )

--- a/server/types/interface.go
+++ b/server/types/interface.go
@@ -28,12 +28,14 @@ var ErrTypeDoesNotExist = errors.NewKind(`type "%s" does not exist`)
 
 // Type represents a single type.
 type Type struct {
+	Oid           uint32
 	Name          string
+	Schema        string // TODO: should be `uint32`.
 	Owner         string // TODO: should be `uint32`.
 	Length        int16
 	PassedByVal   bool
-	Typ           TypeType
-	Category      TypeCategory
+	TypType       TypeType
+	TypCategory   TypeCategory
 	IsPreferred   bool
 	IsDefined     bool
 	Delimiter     string

--- a/testing/generation/command_docs/output/drop_domain_test.go
+++ b/testing/generation/command_docs/output/drop_domain_test.go
@@ -18,16 +18,16 @@ import "testing"
 
 func TestDropDomain(t *testing.T) {
 	tests := []QueryParses{
-		Parses("DROP DOMAIN name"),
-		Parses("DROP DOMAIN IF EXISTS name"),
+		Converts("DROP DOMAIN name"),
+		Converts("DROP DOMAIN IF EXISTS name"),
 		Parses("DROP DOMAIN name , name"),
 		Parses("DROP DOMAIN IF EXISTS name , name"),
-		Parses("DROP DOMAIN name CASCADE"),
-		Parses("DROP DOMAIN IF EXISTS name CASCADE"),
+		Converts("DROP DOMAIN name CASCADE"),
+		Converts("DROP DOMAIN IF EXISTS name CASCADE"),
 		Parses("DROP DOMAIN name , name CASCADE"),
 		Parses("DROP DOMAIN IF EXISTS name , name CASCADE"),
-		Parses("DROP DOMAIN name RESTRICT"),
-		Parses("DROP DOMAIN IF EXISTS name RESTRICT"),
+		Converts("DROP DOMAIN name RESTRICT"),
+		Converts("DROP DOMAIN IF EXISTS name RESTRICT"),
 		Parses("DROP DOMAIN name , name RESTRICT"),
 		Parses("DROP DOMAIN IF EXISTS name , name RESTRICT"),
 	}

--- a/testing/go/domain_test.go
+++ b/testing/go/domain_test.go
@@ -199,6 +199,14 @@ func TestDomain(t *testing.T) {
 					Expected: []sql.Row{},
 				},
 				{
+					Query:    `DROP DOMAIN IF EXISTS postgres.public.year;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:       `DROP DOMAIN IF EXISTS mydb.public.year;`,
+					ExpectedErr: `DROP DOMAIN is currently only supported for the current database`,
+				},
+				{
 					Query:       `DROP DOMAIN non_existing_domain;`,
 					ExpectedErr: `type "non_existing_domain" does not exist`,
 				},

--- a/testing/go/domain_test.go
+++ b/testing/go/domain_test.go
@@ -176,7 +176,6 @@ func TestDomain(t *testing.T) {
 			},
 		},
 		{
-			Skip: true, // TODO: support DROP DOMAIN in separate PR
 			Name: "drop domain",
 			SetUpScript: []string{
 				`CREATE DOMAIN year AS integer CONSTRAINT year_check CHECK (((VALUE >= 1901) AND (VALUE <= 2155)));`,


### PR DESCRIPTION
Added:
- merge functionality for domain types
- check for domain usage in tables for dropping domain

TODO:
- creating domain type creates instance of array type of this domain type
- unique OID generated for each domain created
- add domains to pg_type
- `ALTER TABLE` (e.g.: modify existing column to domain type column)
- use domain type as underlying type to another domain