### PR TITLE
Add caching for `pg_catalog` tables

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -80,7 +80,7 @@ func GetPgCatalogCache(ctx *sql.Context) (any, error) {
 
 // SetPgCatalogCache sets |pgCatalogCache| as the catalog cache instance for this session.
 //
-// TODO: The return type here is currently any, to avoid a package import cycle. This could be cleaned up by
+// TODO: The input type here is currently any, to avoid a package import cycle. This could be cleaned up by
 // introducing a new interface type, in a package that does not depend on core or pgcatalog packages.
 func SetPgCatalogCache(ctx *sql.Context, pgCatalogCache any) error {
 	cv, err := getContextValues(ctx)

--- a/server/tables/pgcatalog/pg_catalog_cache.go
+++ b/server/tables/pgcatalog/pg_catalog_cache.go
@@ -1,0 +1,111 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgcatalog
+
+import (
+	"fmt"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/core"
+	"github.com/dolthub/doltgresql/core/sequences"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+	"github.com/dolthub/doltgresql/server/types/oid"
+)
+
+// pgCatalogCache is a session cache that stores the contents of pg_catalog tables. Since this cache instance is only
+// ever used by a single session, it does not include any synchronization for concurrent data access. A pgCatalogCache
+// only caches data for the length of a single query, using |pid| to identify the current query. This means that the
+// initial read of data from a pg_catalog table will always be generated fresh, then stored in this cache for any other
+// table reads needed as part of that same query.
+type pgCatalogCache struct {
+	// pid marks the process id for the query this cache data represents. pgCatalogCache instances currently only
+	// cache data within the context of a single query – not across multiple queries.
+	pid uint64
+
+	// pg_classes
+	pgClasses []pgClass
+
+	// pg_constraints
+	pgConstraints []pgConstraint
+
+	// pg_namespace
+	schemaNames []string
+	schemaOids  []uint32
+
+	// pg_attribute
+	attributeCols      []*sql.Column
+	attributeTableOIDs []uint32
+	attributeColIdxs   []int
+
+	// pg_index / pg_indexes
+	indexes        []sql.Index
+	indexOIDs      []uint32
+	indexTableOIDs []uint32
+	indexSchemas   []string
+
+	// pg_sequence
+	sequences    []*sequences.Sequence
+	sequenceOids []uint32
+
+	// pg_attrdef
+	attrdefCols      []oid.ItemColumnDefault
+	attrdefTableOIDs []uint32
+
+	// pg_views
+	views       []sql.ViewDefinition
+	viewSchemas []string
+
+	// pg_types
+	types        []pgtypes.DoltgresType
+	pgCatalogOid uint32
+
+	// pg_tables
+	tables       []sql.Table
+	tableSchemas []string
+}
+
+func newPgCatalogCache(pid uint64) *pgCatalogCache {
+	return &pgCatalogCache{
+		pid: pid,
+	}
+}
+
+func getPgCatalogCache(ctx *sql.Context) (*pgCatalogCache, error) {
+	untypedPgCatalogCache, err := core.GetPgCatalogCache(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if untypedPgCatalogCache == nil {
+		return initializeNewPgCatalogCache(ctx)
+	}
+
+	cache, ok := untypedPgCatalogCache.(*pgCatalogCache)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type %T for pg_catalog cache", untypedPgCatalogCache)
+	}
+	if cache.pid != ctx.Pid() {
+		return initializeNewPgCatalogCache(ctx)
+	}
+	return cache, nil
+}
+
+func initializeNewPgCatalogCache(ctx *sql.Context) (*pgCatalogCache, error) {
+	cache := newPgCatalogCache(ctx.Pid())
+	if err := core.SetPgCatalogCache(ctx, cache); err != nil {
+		return nil, err
+	}
+	return cache, nil
+}

--- a/server/tables/pgcatalog/pg_type.go
+++ b/server/tables/pgcatalog/pg_type.go
@@ -46,31 +46,46 @@ func (p PgTypeHandler) Name() string {
 
 // RowIter implements the interface tables.Handler.
 func (p PgTypeHandler) RowIter(ctx *sql.Context) (sql.RowIter, error) {
-	var pgCatalogOid uint32
-	err := oid.IterateCurrentDatabase(ctx, oid.Callbacks{
-		Schema: func(ctx *sql.Context, schema oid.ItemSchema) (cont bool, err error) {
-			if schema.Item.SchemaName() == PgCatalogName {
-				pgCatalogOid = schema.OID
-				return false, nil
-			}
-			return true, nil
-		},
-	})
+	// Use cached data from this process if it exists
+	pgCatalogCache, err := getPgCatalogCache(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	var displayTypes []pgtypes.DoltgresType
-	err = oid.IterateCurrentDatabase(ctx, oid.Callbacks{
-		Type: func(ctx *sql.Context, typ oid.ItemType) (cont bool, err error) {
-			displayTypes = append(displayTypes, typ.Item)
-			return true, nil
-		},
-	})
-	if err != nil {
-		return nil, err
+	if pgCatalogCache.types == nil {
+		var pgCatalogOid uint32
+		err := oid.IterateCurrentDatabase(ctx, oid.Callbacks{
+			Schema: func(ctx *sql.Context, schema oid.ItemSchema) (cont bool, err error) {
+				if schema.Item.SchemaName() == PgCatalogName {
+					pgCatalogOid = schema.OID
+					return false, nil
+				}
+				return true, nil
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		var types []pgtypes.DoltgresType
+		err = oid.IterateCurrentDatabase(ctx, oid.Callbacks{
+			Type: func(ctx *sql.Context, typ oid.ItemType) (cont bool, err error) {
+				types = append(types, typ.Item)
+				return true, nil
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		pgCatalogCache.types = types
+		pgCatalogCache.pgCatalogOid = pgCatalogOid
 	}
-	return &pgTypeRowIter{pgCatalogOid: pgCatalogOid, types: displayTypes, idx: 0}, nil
+
+	return &pgTypeRowIter{
+		pgCatalogOid: pgCatalogCache.pgCatalogOid,
+		types:        pgCatalogCache.types,
+		idx:          0,
+	}, nil
 }
 
 // Schema implements the interface tables.Handler.

--- a/server/types/oid/iterate.go
+++ b/server/types/oid/iterate.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqlserver"
 	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression/function"
@@ -152,9 +153,7 @@ func IterateDatabase(ctx *sql.Context, database string, callbacks Callbacks) err
 		}
 	}
 
-	doltSession := dsess.DSessFromSess(ctx.Session)
-
-	cat := sqle.NewDefault(doltSession.Provider()).Analyzer.Catalog
+	cat := sqlserver.GetRunningServer().Engine.Analyzer.Catalog
 	currentDatabase, err := cat.Database(ctx, database)
 	if err != nil {
 		return err

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -172,7 +172,11 @@ func TestPgAttribute(t *testing.T) {
 					Expected: []sql.Row{{0}},
 				},
 				{
-					Skip: true, // This test times out, needs some analysis to figure out why, possible a 5-table join of generated tables with no indexes is just too much
+					// TODO: Even with the caching added to prevent having to regenerate pg_catalog table data
+					//       multiple times within the same query, this massive query still times out. The problem
+					//       is that this query joins over 7 tables and without a way to do index lookups into the
+					//       table data, we end up iterating over the results over and over.
+					Skip: true,
 					Query: `SELECT "con"."conname" AS "constraint_name", 
        "con"."nspname" AS "table_schema", 
        "con"."relname" AS "table_name", 
@@ -546,9 +550,11 @@ func TestPgClass(t *testing.T) {
 			},
 			Assertions: []ScriptTestAssertion{
 				{
+					// TODO: Now that catalog data is cached for each query, this query no longer iterates the database
+					//       100k times, and this query executes in a couple seconds. This is still slow and should
+					//       be improved with lookup index support now that we have cached data available.
 					Query:    `SELECT ix.relname AS index_name, upper(am.amname) AS index_algorithm FROM pg_index i JOIN pg_class t ON t.oid = i.indrelid JOIN pg_class ix ON ix.oid = i.indexrelid JOIN pg_namespace n ON t.relnamespace = n.oid JOIN pg_am AS am ON ix.relam = am.oid WHERE t.relname = 'foo' AND n.nspname = 'public';`,
 					Expected: []sql.Row{{"foo_pkey", "BTREE"}, {"b", "BTREE"}, {"b_2", "BTREE"}}, // TODO: should follow Postgres index naming convention: "foo_pkey", "foo_b_idx", "foo_b_a_idx"
-					Skip:     true,                                                               // test hangs
 				},
 			},
 		},
@@ -1162,7 +1168,6 @@ func TestPgIndex(t *testing.T) {
 					Expected: []sql.Row{{1614807040}, {1614807041}, {1614807042}},
 				},
 				{
-					Skip:  true, // TODO: Timing out
 					Query: "SELECT i.indexrelid, i.indrelid, c.relname, t.relname  FROM pg_catalog.pg_index i JOIN pg_catalog.pg_class c ON i.indexrelid = c.oid JOIN pg_catalog.pg_class t ON i.indrelid = t.oid;",
 					Expected: []sql.Row{
 						{1614807040, 2688548864, "testing_pkey", "testing"},


### PR DESCRIPTION
While investigating performance on some skipped tests for `pg_catalog` tables, I found a few areas to optimize around how we deal with OIDs. The biggest source of latency I found was that `pg_catalog` tables must iterate through every object in a database (e.g. schemas, tables, indexes, types) to generate OIDs and create the rows for each `pg_catalog` table. When multiple `pg_catalog` tables are joined together, this starts to consume a significant amount of time, with some queries triggering this database iteration process hundreds of thousands of times. 

This change creates a new cache in the session object that stores the data for `pg_catalog` tables so that it can be reused within the same query. The effect is that several queries that timed out before will now complete. Some of these queries are still slow (e.g. multiple seconds to execute) and can be further optimized. The biggest source of latency now seems to be from the join operations, since the data is currently not eligible for point lookups and has to be scanned repeatedly to stitch rows together.

Another area for future optimization is the `regclass`/`regtype`/`regproc` `IO_Output` and `IO_Input` functions, which also trigger iterations over database objects to turn a relation name into an OID, and to turn an OID into a relation name. 

Longer term, instead of relying on iterating database objects and caching OID information, we eventually need to store this information so it can be quickly loaded, and keep it in sync as database objects are created/modified/deleted, including changes made through merges, resets, and other database version control changes. 