### PR TITLE
throw unsupported error for `PARTITION OF` statements

### DIFF
--- a/server/ast/create_table.go
+++ b/server/ast/create_table.go
@@ -91,6 +91,8 @@ func nodeCreateTable(ctx *Context, node *tree.CreateTable) (*vitess.DDL, error) 
 			Expr:          vitess.NewColName(string(node.PartitionBy.Elems[0].Column)),
 		}
 	}
-
+	if node.PartitionOf.Table() != "" {
+		return nil, fmt.Errorf("PARTITION OF is not yet supported")
+	}
 	return ddl, nil
 }


### PR DESCRIPTION
Catch `PARTITION OF` statements and return error instead of panicking. 