### PR TITLE
Support for `ALTER TABLE OWNER`

### DIFF
--- a/server/auth/ownership.go
+++ b/server/auth/ownership.go
@@ -45,6 +45,14 @@ func AddOwner(key OwnershipKey, role RoleID) {
 	ownerMap[role] = struct{}{}
 }
 
+// SetOwners adds |roles| as an owner for the entity identified by |key| to the global database.
+func SetOwners(key OwnershipKey, roles ...RoleID) {
+	RemoveOwners(key, GetOwners(key)...)
+	for _, role := range roles {
+		AddOwner(key, role)
+	}
+}
+
 // GetOwners returns all owners matching the given key.
 func GetOwners(key OwnershipKey) []RoleID {
 	if ownerMap, ok := globalDatabase.ownership.Data[key]; ok {
@@ -69,6 +77,13 @@ func RemoveOwner(key OwnershipKey, role RoleID) {
 		if len(ownerMap) == 0 {
 			delete(globalDatabase.ownership.Data, key)
 		}
+	}
+}
+
+// RemoveOwners removes all specified |roles| as owners for the entity |key| from the global database.
+func RemoveOwners(key OwnershipKey, roles ...RoleID) {
+	for _, role := range roles {
+		RemoveOwner(key, role)
 	}
 }
 

--- a/testing/go/alter_table_test.go
+++ b/testing/go/alter_table_test.go
@@ -356,5 +356,28 @@ func TestAlterTable(t *testing.T) {
 				},
 			},
 		},
+		{
+			// TODO: Table ownership metadata is not supported yet
+			Skip: true,
+			Name: "Alter Table Owner",
+			SetUpScript: []string{
+				"CREATE TABLE test1 (a INT, b smallint);",
+				"CREATE USER user1;",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    "SELECT tableowner FROM pg_tables WHERE tablename = 'test1';",
+					Expected: []sql.Row{{"postgres"}},
+				},
+				{
+					Query:    "ALTER TABLE test1 OWNER TO user1;",
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    "SELECT tableowner FROM pg_tables WHERE tablename = 'test1';",
+					Expected: []sql.Row{{"user1"}},
+				},
+			},
+		},
 	})
 }

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -3517,7 +3517,7 @@ func TestPgTables(t *testing.T) {
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT * FROM "pg_catalog"."pg_tables" WHERE tablename='testing';`,
-					Expected: []sql.Row{{"testschema", "testing", "", "", "t", "f", "f", "f"}},
+					Expected: []sql.Row{{"testschema", "testing", "postgres", "", "t", "f", "f", "f"}},
 				},
 				{
 					Query:    `SELECT count(*) FROM "pg_catalog"."pg_tables" WHERE schemaname='pg_catalog';`,

--- a/testing/go/prepared_statement_test.go
+++ b/testing/go/prepared_statement_test.go
@@ -409,7 +409,7 @@ var pgCatalogTests = []ScriptTest{
 			{
 				Query:    `SELECT * FROM "pg_catalog"."pg_tables" WHERE tablename=$1;`,
 				BindVars: []any{"testing"},
-				Expected: []sql.Row{{"public", "testing", "", "", "t", "f", "f", "f"}},
+				Expected: []sql.Row{{"public", "testing", "postgres", "", "t", "f", "f", "f"}},
 			},
 			{
 				Query:    `SELECT count(*) FROM "pg_catalog"."pg_tables" WHERE schemaname=$1;`,


### PR DESCRIPTION
`ALTER TABLE OWNER` is commonly used in data imports, and this change allows the table ownership data to be updated by a superuser. 

Longer term, instead of handling these statements directly at the Doltgres layer, it would be cleaner to introduce a new interface in GMS for ownership modifications so that Doltgres could provide an implementation, then GMS could cleanly call back into Doltgres to make the ownership update. As we add ownership metadata support for additional entities, that seems like the right time to refactor out  an interface. 

Related to: https://github.com/dolthub/doltgresql/issues/724