### PR TITLE
bug fix for column defaults with function values

### DIFF
--- a/server/analyzer/init.go
+++ b/server/analyzer/init.go
@@ -15,8 +15,6 @@
 package analyzer
 
 import (
-	"github.com/cockroachdb/errors"
-
 	"github.com/dolthub/go-mysql-server/sql/analyzer"
 )
 
@@ -75,17 +73,6 @@ func Init() {
 		analyzer.Rule{Id: ruleId_AddDomainConstraintsToCasts, Apply: AddDomainConstraintsToCasts},
 		analyzer.Rule{Id: ruleId_ReplaceNode, Apply: ReplaceNode},
 		analyzer.Rule{Id: ruleId_InsertContextRootFinalizer, Apply: InsertContextRootFinalizer})
-}
-
-// getAnalyzerRule returns the rule matching the given ID.
-func getAnalyzerRule(rules []analyzer.Rule, id analyzer.RuleId) analyzer.Rule {
-	for _, rule := range rules {
-		if rule.Id == id {
-			return rule
-		}
-	}
-	// This will only occur if GMS has been changed
-	panic(errors.Errorf("rule not found: %d", id))
 }
 
 // insertAnalyzerRules inserts the given rule(s) before or after the given analyzer.RuleId, returning an updated slice.

--- a/server/analyzer/init.go
+++ b/server/analyzer/init.go
@@ -37,7 +37,7 @@ const (
 	ruleId_ResolveType                                                // resolveType
 	ruleId_ReplaceArithmeticExpressions                               // replaceArithmeticExpressions
 	ruleId_OptimizeFunctions                                          // optimizeFunctions
-	ruleId_ValidateColumnDefaults 																	  // validateColumnDefaults
+	ruleId_ValidateColumnDefaults                                     // validateColumnDefaults
 )
 
 // Init adds additional rules to the analyzer to handle Doltgres-specific functionality.

--- a/server/analyzer/init.go
+++ b/server/analyzer/init.go
@@ -37,6 +37,7 @@ const (
 	ruleId_ResolveType                                                // resolveType
 	ruleId_ReplaceArithmeticExpressions                               // replaceArithmeticExpressions
 	ruleId_OptimizeFunctions                                          // optimizeFunctions
+	ruleId_ValidateColumnDefaults 																	  // validateColumnDefaults
 )
 
 // Init adds additional rules to the analyzer to handle Doltgres-specific functionality.
@@ -45,13 +46,13 @@ func Init() {
 		analyzer.Rule{Id: ruleId_ResolveType, Apply: ResolveType},
 		analyzer.Rule{Id: ruleId_TypeSanitizer, Apply: TypeSanitizer},
 		analyzer.Rule{Id: ruleId_AddDomainConstraints, Apply: AddDomainConstraints},
-		getAnalyzerRule(analyzer.OnceBeforeDefault, analyzer.ValidateColumnDefaultsId),
+		analyzer.Rule{Id: ruleId_ValidateColumnDefaults, Apply: ValidateColumnDefaults},
 		analyzer.Rule{Id: ruleId_AssignInsertCasts, Apply: AssignInsertCasts},
 		analyzer.Rule{Id: ruleId_AssignUpdateCasts, Apply: AssignUpdateCasts},
 		analyzer.Rule{Id: ruleId_ReplaceIndexedTables, Apply: ReplaceIndexedTables},
 	)
 
-	// Column default validation was moved to occur after type sanitization, so we'll remove it from its original place
+	// We remove the original column default rule, as we have our own implementation
 	analyzer.OnceBeforeDefault = removeAnalyzerRules(analyzer.OnceBeforeDefault, analyzer.ValidateColumnDefaultsId)
 
 	// PostgreSQL doesn't have the concept of prefix lengths, so we add a rule to implicitly add them

--- a/server/analyzer/validate_column_defaults.go
+++ b/server/analyzer/validate_column_defaults.go
@@ -1,0 +1,201 @@
+// Copyright 2020-2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzer
+
+import (
+	pgnode "github.com/dolthub/doltgresql/server/node"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/analyzer"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/transform"
+)
+
+// validateColumnDefaults ensures that newly created column defaults from a DDL statement are legal for the type of
+// column, various other business logic checks to match MySQL's logic.
+func ValidateColumnDefaults(ctx *sql.Context, _ *analyzer.Analyzer, n sql.Node, _ *plan.Scope, _ analyzer.RuleSelector, qFlags *sql.QueryFlags) (sql.Node, transform.TreeIdentity, error) {
+	span, ctx := ctx.Span("validateColumnDefaults")
+	defer span.End()
+
+	return transform.Node(n, func(n sql.Node) (sql.Node, transform.TreeIdentity, error) {
+		switch node := n.(type) {
+		case *plan.AlterDefaultSet:
+			table := getResolvedTable(node)
+			sch := table.Schema()
+			index := sch.IndexOfColName(node.ColumnName)
+			if index == -1 {
+				return nil, transform.SameTree, sql.ErrColumnNotFound.New(node.ColumnName)
+			}
+			col := sch[index]
+			err := validateColumnDefault(ctx, col, node.Default)
+			if err != nil {
+				return node, transform.SameTree, err
+			}
+
+			return node, transform.SameTree, nil
+
+		case sql.SchemaTarget:
+			switch node.(type) {
+			case *plan.AlterPK, *plan.AddColumn, *plan.ModifyColumn, *plan.AlterDefaultDrop, *plan.CreateTable, *plan.DropColumn, *pgnode.CreateTable:
+				// DDL nodes must validate any new column defaults, continue to logic below
+			default:
+				// other node types are not altering the schema and therefore don't need validation of column defaults
+				return n, transform.SameTree, nil
+			}
+
+			// There may be multiple DDL nodes in the plan (ALTER TABLE statements can have many clauses), and for each of them
+			// we need to count the column indexes in the very hacky way outlined above.
+			i := 0
+			return transform.NodeExprs(n, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
+				eWrapper, ok := e.(*expression.Wrapper)
+				if !ok {
+					return e, transform.SameTree, nil
+				}
+
+				defer func() {
+					i++
+				}()
+
+				eVal := eWrapper.Unwrap()
+				if eVal == nil {
+					return e, transform.SameTree, nil
+				}
+				colDefault, ok := eVal.(*sql.ColumnDefaultValue)
+				if !ok {
+					return e, transform.SameTree, nil
+				}
+
+				col, err := lookupColumnForTargetSchema(ctx, node, i)
+				if err != nil {
+					return nil, transform.SameTree, err
+				}
+
+				err = validateColumnDefault(ctx, col, colDefault)
+				if err != nil {
+					return nil, transform.SameTree, err
+				}
+
+				return e, transform.SameTree, nil
+			})
+		default:
+			return node, transform.SameTree, nil
+		}
+	})
+}
+
+// lookupColumnForTargetSchema looks at the target schema for the specified SchemaTarget node and returns
+// the column based on the specified index. For most node types, this is simply indexing into the target
+// schema but a few types require special handling.
+func lookupColumnForTargetSchema(_ *sql.Context, node sql.SchemaTarget, colIndex int) (*sql.Column, error) {
+	schema := node.TargetSchema()
+
+	switch n := node.(type) {
+	case *plan.ModifyColumn:
+		if colIndex < len(schema) {
+			return schema[colIndex], nil
+		} else {
+			return n.NewColumn(), nil
+		}
+	case *plan.AddColumn:
+		if colIndex < len(schema) {
+			return schema[colIndex], nil
+		} else {
+			return n.Column(), nil
+		}
+	case *plan.AlterDefaultSet:
+		index := schema.IndexOfColName(n.ColumnName)
+		if index == -1 {
+			return nil, sql.ErrTableColumnNotFound.New(n.Table, n.ColumnName)
+		}
+		return schema[index], nil
+	default:
+		if colIndex < len(schema) {
+			return schema[colIndex], nil
+		} else {
+			// TODO: sql.ErrColumnNotFound would be a better error here, but we need to add all the different node types to
+			//  the switch to get it
+			return nil, expression.ErrIndexOutOfBounds.New(colIndex, len(schema))
+		}
+	}
+}
+
+// validateColumnDefault validates that the column default expression is valid for the column type and returns an error
+// if not
+func validateColumnDefault(ctx *sql.Context, col *sql.Column, colDefault *sql.ColumnDefaultValue) error {
+	if colDefault == nil {
+		return nil
+	}
+
+	var err error
+	sql.Inspect(colDefault.Expr, func(e sql.Expression) bool {
+		switch e.(type) {
+		case sql.FunctionExpression, *expression.UnresolvedFunction:
+			// TODO: functions must be deterministic to be used in column defaults
+			return true
+		case *plan.Subquery:
+			err = sql.ErrColumnDefaultSubquery.New(col.Name)
+			return false
+		case *expression.GetField:
+			if !colDefault.IsParenthesized() {
+				err = sql.ErrInvalidColumnDefaultValue.New(col.Name)
+				return false
+			}
+			return true
+		default:
+			return true
+		}
+	})
+
+	if err != nil {
+		return err
+	}
+
+	// validate type of default expression
+	if err = colDefault.CheckType(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Finds first ResolvedTable node that is a descendant of the node given
+// This function will not look inside SubqueryAliases
+func getResolvedTable(node sql.Node) *plan.ResolvedTable {
+	var table *plan.ResolvedTable
+	transform.Inspect(node, func(n sql.Node) bool {
+		// Inspect is called on all children of a node even if an earlier child's call returns false.
+		// We only want the first TableNode match.
+		if table != nil {
+			return false
+		}
+		switch nn := n.(type) {
+		case *plan.SubqueryAlias:
+			// We should not be matching with ResolvedTables inside SubqueryAliases
+			return false
+		case *plan.ResolvedTable:
+			if !plan.IsDualTable(nn) {
+				table = nn
+				return false
+			}
+		case *plan.IndexedTableAccess:
+			if rt, ok := nn.TableNode.(*plan.ResolvedTable); ok {
+				table = rt
+				return false
+			}
+		}
+		return true
+	})
+	return table
+}

--- a/server/analyzer/validate_column_defaults.go
+++ b/server/analyzer/validate_column_defaults.go
@@ -15,12 +15,13 @@
 package analyzer
 
 import (
-	pgnode "github.com/dolthub/doltgresql/server/node"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/analyzer"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/transform"
+
+	pgnode "github.com/dolthub/doltgresql/server/node"
 )
 
 // validateColumnDefaults ensures that newly created column defaults from a DDL statement are legal for the type of

--- a/server/doltgres_handler.go
+++ b/server/doltgres_handler.go
@@ -43,7 +43,7 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-var printErrorStackTraces = false
+var printErrorStackTraces = true
 
 const PrintErrorStackTracesEnvKey = "DOLTGRES_PRINT_ERROR_STACK_TRACES"
 
@@ -104,11 +104,17 @@ func (h *DoltgresHandler) ComBind(ctx context.Context, c *mysql.Conn, query stri
 
 	bvs, err := h.convertBindParameters(sqlCtx, bindVars.varTypes, bindVars.formatCodes, bindVars.parameters)
 	if err != nil {
+		if printErrorStackTraces {
+			fmt.Printf("unable to convert bind params: %+v\n", err)
+		}
 		return nil, nil, err
 	}
 
 	queryPlan, err := h.e.BoundQueryPlan(sqlCtx, query, stmt, bvs)
 	if err != nil {
+		if printErrorStackTraces {
+			fmt.Printf("unable to bind query plan: %+v\n", err)
+		}
 		return nil, nil, err
 	}
 

--- a/server/doltgres_handler.go
+++ b/server/doltgres_handler.go
@@ -43,7 +43,7 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-var printErrorStackTraces = true
+var printErrorStackTraces = false
 
 const PrintErrorStackTracesEnvKey = "DOLTGRES_PRINT_ERROR_STACK_TRACES"
 

--- a/server/functions/gen_random_uuid.go
+++ b/server/functions/gen_random_uuid.go
@@ -15,10 +15,11 @@
 package functions
 
 import (
+	"github.com/dolthub/go-mysql-server/sql"
+
 	"github.com/dolthub/doltgresql/postgres/parser/uuid"
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
-	"github.com/dolthub/go-mysql-server/sql"
 )
 
 // initRadians registers the functions to the catalog.
@@ -27,9 +28,9 @@ func initGenRandomUuid() {
 }
 
 var gen_random_uuid = framework.Function0{
-	Name:       "gen_random_uuid",
-	Return:     pgtypes.Uuid,
-	Strict:     true,
+	Name:   "gen_random_uuid",
+	Return: pgtypes.Uuid,
+	Strict: true,
 	Callable: func(ctx *sql.Context) (any, error) {
 		return uuid.NewV4()
 	},

--- a/server/functions/gen_random_uuid.go
+++ b/server/functions/gen_random_uuid.go
@@ -22,7 +22,7 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// initRadians registers the functions to the catalog.
+// initGenRandomUuid registers the functions to the catalog.
 func initGenRandomUuid() {
 	framework.RegisterFunction(gen_random_uuid)
 }

--- a/server/functions/gen_random_uuid.go
+++ b/server/functions/gen_random_uuid.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+import (
+	"github.com/dolthub/doltgresql/postgres/parser/uuid"
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// initRadians registers the functions to the catalog.
+func initGenRandomUuid() {
+	framework.RegisterFunction(gen_random_uuid)
+}
+
+var gen_random_uuid = framework.Function0{
+	Name:       "gen_random_uuid",
+	Return:     pgtypes.Uuid,
+	Strict:     true,
+	Callable: func(ctx *sql.Context) (any, error) {
+		return uuid.NewV4()
+	},
+}

--- a/server/functions/init.go
+++ b/server/functions/init.go
@@ -102,6 +102,7 @@ func Init() {
 	initFloor()
 	initFormatType()
 	initGcd()
+	initGenRandomUuid()
 	initInitcap()
 	initLcm()
 	initLeft()

--- a/server/node/create_table.go
+++ b/server/node/create_table.go
@@ -29,6 +29,7 @@ type CreateTable struct {
 }
 
 var _ sql.ExecSourceRel = (*CreateTable)(nil)
+var _ sql.SchemaTarget = (*CreateTable)(nil)
 
 // NewCreateTable returns a new *CreateTable.
 func NewCreateTable(createTable *plan.CreateTable, sequences []*CreateSequence) *CreateTable {
@@ -100,4 +101,19 @@ func (c *CreateTable) WithChildren(children ...sql.Node) (sql.Node, error) {
 		gmsCreateTable: gmsCreateTable.(*plan.CreateTable),
 		sequences:      c.sequences,
 	}, nil
+}
+
+func (c *CreateTable) TargetSchema() sql.Schema {
+	return c.gmsCreateTable.TargetSchema()
+}
+
+func (c CreateTable) WithTargetSchema(schema sql.Schema) (sql.Node, error) {
+	n, err := c.gmsCreateTable.WithTargetSchema(schema)
+	if err != nil {
+		return nil, err
+	}
+	
+	c.gmsCreateTable = n.(*plan.CreateTable)
+	
+	return &c, nil
 }

--- a/server/node/create_table.go
+++ b/server/node/create_table.go
@@ -112,8 +112,8 @@ func (c CreateTable) WithTargetSchema(schema sql.Schema) (sql.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	c.gmsCreateTable = n.(*plan.CreateTable)
-	
+
 	return &c, nil
 }

--- a/testing/go/alter_table_test.go
+++ b/testing/go/alter_table_test.go
@@ -465,6 +465,7 @@ func TestAlterTable(t *testing.T) {
     uid uuid default gen_random_uuid() NOT NULL
 );`,
 				"INSERT INTO t1 (id) VALUES (1);",
+				"INSERT INTO t1 (id) VALUES (2);",
 			},
 			Assertions: []ScriptTestAssertion{
 				{
@@ -473,6 +474,15 @@ func TestAlterTable(t *testing.T) {
 				{
 					Query:    "select uid is not null from t1 where id = 1;",
 					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    "select uid is not null from t1 where id = 2;",
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    "select (select uid from t1 where id = 2) = (select uid from t1 where id = 1);",
+					Skip:     true, // panic in equality function
+					Expected: []sql.Row{{"f"}},
 				},
 			},
 		},

--- a/testing/go/alter_table_test.go
+++ b/testing/go/alter_table_test.go
@@ -428,5 +428,37 @@ func TestAlterTable(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "alter table add primary key with timestamp column default values",
+			SetUpScript: []string{
+				`CREATE TABLE t1 (
+    id int NOT NULL,
+    uid uuid NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);`,
+			"INSERT INTO t1 (id, uid) VALUES (1, '00000000-0000-0000-0000-000000000001');",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "ALTER TABLE ONLY public.t1 ADD CONSTRAINT t1_pkey PRIMARY KEY (id);",
+				},
+			},
+		},
+		{
+			Name: "alter table add primary key with uuid column default values",
+			SetUpScript: []string{
+				`CREATE TABLE t1 (
+    id int NOT NULL,
+    uid uuid default gen_random_uuid() NOT NULL
+);`,
+				"INSERT INTO t1 (id) VALUES (1);",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "ALTER TABLE ONLY public.t1 ADD CONSTRAINT t1_pkey PRIMARY KEY (id);",
+				},
+			},
+		},
 	})
 }

--- a/testing/go/alter_table_test.go
+++ b/testing/go/alter_table_test.go
@@ -437,11 +437,23 @@ func TestAlterTable(t *testing.T) {
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL
 );`,
-			"INSERT INTO t1 (id, uid) VALUES (1, '00000000-0000-0000-0000-000000000001');",
+				"INSERT INTO t1 (id, uid) VALUES (1, '00000000-0000-0000-0000-000000000001');",
 			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query: "ALTER TABLE ONLY public.t1 ADD CONSTRAINT t1_pkey PRIMARY KEY (id);",
+				},
+				{
+					Query:    "select created_at is not null from t1 where id = 1;",
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    "select updated_at is not null from t1 where id = 1;",
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    "select created_at = updated_at from t1 where id = 1;",
+					Expected: []sql.Row{{"t"}},
 				},
 			},
 		},
@@ -457,6 +469,10 @@ func TestAlterTable(t *testing.T) {
 			Assertions: []ScriptTestAssertion{
 				{
 					Query: "ALTER TABLE ONLY public.t1 ADD CONSTRAINT t1_pkey PRIMARY KEY (id);",
+				},
+				{
+					Query:    "select uid is not null from t1 where id = 1;",
+					Expected: []sql.Row{{"t"}},
 				},
 			},
 		},

--- a/testing/go/subqueries_test.go
+++ b/testing/go/subqueries_test.go
@@ -88,6 +88,34 @@ func TestSubqueries(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "subquery equality",
+			SetUpScript: []string{
+				`CREATE TABLE test (id INT, c varchar);`,
+				`INSERT INTO test VALUES (1, 'a'), (2, 'b'), (3, 'b');`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT * FROM test WHERE id = (SELECT id from test where id = 2);`,
+					Expected: []sql.Row{{int32(2), "b"}},
+				},
+				{
+					Skip:     true, // panic in equality func
+					Query:    `SELECT (SELECT id from test where id = 2) = (SELECT id from test where id = 2);`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Skip:     true, // panic in equality func
+					Query:    `SELECT (SELECT c from test where id = 2) = (SELECT c from test where id = 3);`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Skip:     true, // panic in equality func
+					Query:    `SELECT (SELECT c from test where id = 1) = (SELECT c from test where id = 2);`,
+					Expected: []sql.Row{{"f"}},
+				},
+			},
+		},
 	})
 }
 


### PR DESCRIPTION
Removed the GMS validateColumnDefaults rule in favor of our own, and also made it run on CreateTable statements (it wasn't before due to an oversight in a type assertion).

Also implemented the gen_random_uuid function.