### PR TITLE
PL/pgSQL: Add support for the `ALIAS` statement

### DIFF
--- a/server/functions/framework/interpreter_logic.go
+++ b/server/functions/framework/interpreter_logic.go
@@ -48,6 +48,12 @@ func (iFunc InterpretedFunction) Call(ctx *sql.Context, runner analyzer.Statemen
 
 		operation := iFunc.Statements[counter]
 		switch operation.OpCode {
+		case OpCode_Alias:
+			iv := stack.GetVariable(operation.PrimaryData)
+			if iv == nil {
+				return nil, fmt.Errorf("variable `%s` could not be found", operation.PrimaryData)
+			}
+			stack.NewVariableAlias(operation.Target, iv)
 		case OpCode_Assign:
 			iv := stack.GetVariable(operation.Target)
 			if iv == nil {

--- a/server/functions/framework/interpreter_operation.go
+++ b/server/functions/framework/interpreter_operation.go
@@ -19,7 +19,8 @@ package framework
 type OpCode uint16
 
 const (
-	OpCode_Assign     OpCode = iota // https://www.postgresql.org/docs/15/plpgsql-statements.html#PLPGSQL-STATEMENTS-ASSIGNMENT
+	OpCode_Alias      OpCode = iota // https://www.postgresql.org/docs/15/plpgsql-declarations.html#PLPGSQL-DECLARATION-ALIAS
+	OpCode_Assign                   // https://www.postgresql.org/docs/15/plpgsql-statements.html#PLPGSQL-STATEMENTS-ASSIGNMENT
 	OpCode_Case                     // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-CONDITIONALS
 	OpCode_Declare                  // https://www.postgresql.org/docs/15/plpgsql-declarations.html
 	OpCode_DeleteInto               // https://www.postgresql.org/docs/15/plpgsql-statements.html

--- a/server/functions/framework/interpreter_stack.go
+++ b/server/functions/framework/interpreter_stack.go
@@ -86,6 +86,12 @@ func (is *InterpreterStack) NewVariableWithValue(name string, typ *pgtypes.Doltg
 	}
 }
 
+// NewVariableAlias creates a new variable alias, named |alias|, in the current frame of this stack,
+// pointing to the specified |variable|.
+func (is *InterpreterStack) NewVariableAlias(alias string, variable *InterpreterVariable) {
+	is.stack.Peek().variables[alias] = variable
+}
+
 // PushScope creates a new scope.
 func (is *InterpreterStack) PushScope() {
 	is.stack.Push(&InterpreterScopeDetails{

--- a/testing/go/create_function_test.go
+++ b/testing/go/create_function_test.go
@@ -23,7 +23,7 @@ import (
 func TestCreateFunction(t *testing.T) {
 	RunScripts(t, []ScriptTest{
 		{
-			Name: "Interpreter Example",
+			Name: "Interpreter Assignment Example",
 			Assertions: []ScriptTestAssertion{
 				{
 					Query: "SELECT interpreted_assignment('Hello');",
@@ -48,6 +48,15 @@ func TestCreateFunction(t *testing.T) {
 					Expected: []sql.Row{
 						{"Initial: something - Over 5"},
 					},
+				},
+			},
+		},
+		{
+			Name: "Interpreter Alias Example",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    "SELECT interpreted_alias('123');",
+					Expected: []sql.Row{{"123"}},
 				},
 			},
 		},


### PR DESCRIPTION
Adds support for the execution logic for the `ALIAS` statement in user defined functions. 