### PR TITLE
Changed created functions to persist on the root

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -16,12 +16,12 @@ package core
 
 import (
 	"github.com/cockroachdb/errors"
-
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/resolve"
 	"github.com/dolthub/go-mysql-server/sql"
 
+	"github.com/dolthub/doltgresql/core/functions"
 	"github.com/dolthub/doltgresql/core/sequences"
 	"github.com/dolthub/doltgresql/core/typecollection"
 )
@@ -30,6 +30,7 @@ import (
 type contextValues struct {
 	collection     *sequences.Collection
 	types          *typecollection.TypeCollection
+	funcs          *functions.Collection
 	pgCatalogCache any
 }
 
@@ -61,6 +62,17 @@ func getRootFromContext(ctx *sql.Context) (*dsess.DoltSession, *RootValue, error
 		return nil, nil, errors.Errorf("cannot find the database while fetching root from context")
 	}
 	return session, state.WorkingRoot().(*RootValue), nil
+}
+
+// IsContextValid returns whether the context is valid for use with any of the functions in the package. If this is not
+// false, then there's a high likelihood that the context is being used in a temporary scenario (such as setting up the
+// database, etc.).
+func IsContextValid(ctx *sql.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	_, ok := ctx.Session.(*dsess.DoltSession)
+	return ok
 }
 
 // GetPgCatalogCache returns a cache of data for pg_catalog tables. This function should only be used by
@@ -185,6 +197,26 @@ func GetSqlTableFromContext(ctx *sql.Context, databaseName string, tableName dol
 	return nil, nil
 }
 
+// GetFunctionsCollectionFromContext returns the functions collection from the given context. Will always return a
+// collection if no error is returned.
+func GetFunctionsCollectionFromContext(ctx *sql.Context) (*functions.Collection, error) {
+	cv, err := getContextValues(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if cv.funcs == nil {
+		_, root, err := getRootFromContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+		cv.funcs, err = root.GetFunctions(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return cv.funcs, nil
+}
+
 // GetSequencesCollectionFromContext returns the given sequence collection from the context. Will always return a collection if
 // no error is returned.
 func GetSequencesCollectionFromContext(ctx *sql.Context) (*sequences.Collection, error) {
@@ -244,6 +276,10 @@ func CloseContextRootFinalizer(ctx *sql.Context) error {
 		return err
 	}
 	newRoot, err := root.PutSequences(ctx, cv.collection)
+	if err != nil {
+		return err
+	}
+	newRoot, err = newRoot.PutFunctions(ctx, cv.funcs)
 	if err != nil {
 		return err
 	}

--- a/core/functions/function.go
+++ b/core/functions/function.go
@@ -1,0 +1,128 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+import (
+	"maps"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/dolthub/doltgresql/core/id"
+	"github.com/dolthub/doltgresql/server/plpgsql"
+)
+
+// Collection contains a collection of functions.
+type Collection struct {
+	funcMap     map[id.Function]*Function
+	overloadMap map[id.Function][]*Function
+	mutex       *sync.Mutex
+}
+
+// Function represents a created function.
+type Function struct {
+	ID                 id.Function
+	ReturnType         id.Type
+	ParameterNames     []string
+	ParameterTypes     []id.Type
+	Variadic           bool
+	IsNonDeterministic bool
+	Strict             bool
+	Operations         []plpgsql.InterpreterOperation
+}
+
+// GetFunction returns the function with the given ID. Returns nil if the function cannot be found.
+func (pgf *Collection) GetFunction(funcID id.Function) *Function {
+	pgf.mutex.Lock()
+	defer pgf.mutex.Unlock()
+
+	if f, ok := pgf.funcMap[funcID]; ok {
+		return f
+	}
+	return nil
+}
+
+// GetFunctionOverloads returns the overloads for the function matching the schema and the function name. The parameter
+// types are ignored when searching for overloads.
+func (pgf *Collection) GetFunctionOverloads(funcID id.Function) []*Function {
+	pgf.mutex.Lock()
+	defer pgf.mutex.Unlock()
+
+	funcNameOnly := id.NewFunction(funcID.SchemaName(), funcID.FunctionName())
+	return pgf.overloadMap[funcNameOnly]
+}
+
+// HasFunction returns whether the function is present.
+func (pgf *Collection) HasFunction(funcID id.Function) bool {
+	return pgf.GetFunction(funcID) != nil
+}
+
+// AddFunction adds a new function.
+func (pgf *Collection) AddFunction(f *Function) error {
+	pgf.mutex.Lock()
+	defer pgf.mutex.Unlock()
+
+	if _, ok := pgf.funcMap[f.ID]; ok {
+		return errors.Errorf(`function "%s" already exists with same argument types`, f.ID.FunctionName())
+	}
+	pgf.funcMap[f.ID] = f
+	funcNameOnly := id.NewFunction(f.ID.SchemaName(), f.ID.FunctionName())
+	pgf.overloadMap[funcNameOnly] = append(pgf.overloadMap[funcNameOnly], f)
+	return nil
+}
+
+// DropFunction drops an existing function.
+func (pgf *Collection) DropFunction(funcID id.Function) error {
+	pgf.mutex.Lock()
+	defer pgf.mutex.Unlock()
+
+	if _, ok := pgf.funcMap[funcID]; ok {
+		delete(pgf.funcMap, funcID)
+		funcNameOnly := id.NewFunction(funcID.SchemaName(), funcID.FunctionName())
+		for i, f := range pgf.overloadMap[funcNameOnly] {
+			if f.ID == funcID {
+				pgf.overloadMap[funcNameOnly] = append(pgf.overloadMap[funcNameOnly][:i], pgf.overloadMap[funcNameOnly][i+1:]...)
+				break
+			}
+		}
+		return nil
+	}
+	return errors.Errorf(`function %s does not exist`, funcID.FunctionName())
+}
+
+// IterateFunctions iterates over all functions in the collection.
+func (pgf *Collection) IterateFunctions(callback func(f *Function) error) error {
+	pgf.mutex.Lock()
+	defer pgf.mutex.Unlock()
+
+	for _, f := range pgf.funcMap {
+		if err := callback(f); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Clone returns a new *Collection with the same contents as the original.
+func (pgf *Collection) Clone() *Collection {
+	pgf.mutex.Lock()
+	defer pgf.mutex.Unlock()
+
+	return &Collection{
+		funcMap:     maps.Clone(pgf.funcMap),
+		overloadMap: maps.Clone(pgf.overloadMap),
+		mutex:       &sync.Mutex{},
+	}
+}

--- a/core/functions/merge.go
+++ b/core/functions/merge.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Merge handles merging functions on our root and their root.
+func Merge(ctx context.Context, ourCollection, theirCollection, ancCollection *Collection) (*Collection, error) {
+	mergedCollection := ourCollection.Clone()
+	err := theirCollection.IterateFunctions(func(theirFunc *Function) error {
+		// If we don't have the sequence, then we simply add it
+		if !mergedCollection.HasFunction(theirFunc.ID) {
+			newFunc := *theirFunc
+			return mergedCollection.AddFunction(&newFunc)
+		}
+		// TODO: figure out a decent merge strategy
+		return errors.Errorf(`unable to merge "%s"`, theirFunc.ID.AsId().String())
+	})
+	if err != nil {
+		return nil, err
+	}
+	return mergedCollection, nil
+}

--- a/core/functions/serialization.go
+++ b/core/functions/serialization.go
@@ -1,0 +1,120 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/dolthub/doltgresql/core/id"
+	"github.com/dolthub/doltgresql/server/plpgsql"
+	"github.com/dolthub/doltgresql/utils"
+)
+
+// Serialize returns the Collection as a byte slice. If the Collection is nil, then this returns a nil slice.
+func (pgf *Collection) Serialize(ctx context.Context) ([]byte, error) {
+	if pgf == nil {
+		return nil, nil
+	}
+	pgf.mutex.Lock()
+	defer pgf.mutex.Unlock()
+
+	// Write all of the functions to the writer
+	writer := utils.NewWriter(256)
+	writer.VariableUint(0) // Version
+	funcIDs := utils.GetMapKeysSorted(pgf.funcMap)
+	writer.VariableUint(uint64(len(funcIDs)))
+	for _, funcID := range funcIDs {
+		f := pgf.funcMap[funcID]
+		writer.Id(f.ID.AsId())
+		writer.Id(f.ReturnType.AsId())
+		writer.StringSlice(f.ParameterNames)
+		writer.IdTypeSlice(f.ParameterTypes)
+		writer.Bool(f.Variadic)
+		writer.Bool(f.IsNonDeterministic)
+		writer.Bool(f.Strict)
+		// Write the operations
+		writer.VariableUint(uint64(len(f.Operations)))
+		for _, op := range f.Operations {
+			writer.Uint16(uint16(op.OpCode))
+			writer.String(op.PrimaryData)
+			writer.StringSlice(op.SecondaryData)
+			writer.String(op.Target)
+			writer.Int32(int32(op.Index))
+		}
+	}
+
+	return writer.Data(), nil
+}
+
+// Deserialize returns the Collection that was serialized in the byte slice. Returns an empty Collection if data is nil
+// or empty.
+func Deserialize(ctx context.Context, data []byte) (*Collection, error) {
+	if len(data) == 0 {
+		return &Collection{
+			funcMap:     make(map[id.Function]*Function),
+			overloadMap: make(map[id.Function][]*Function),
+			mutex:       &sync.Mutex{},
+		}, nil
+	}
+	funcMap := make(map[id.Function]*Function)
+	overloadMap := make(map[id.Function][]*Function)
+	reader := utils.NewReader(data)
+	version := reader.VariableUint()
+	if version != 0 {
+		return nil, errors.Errorf("version %d of functions is not supported, please upgrade the server", version)
+	}
+
+	// Read from the reader
+	numOfFunctions := reader.VariableUint()
+	for i := uint64(0); i < numOfFunctions; i++ {
+		f := &Function{}
+		f.ID = id.Function(reader.Id())
+		f.ReturnType = id.Type(reader.Id())
+		f.ParameterNames = reader.StringSlice()
+		f.ParameterTypes = reader.IdTypeSlice()
+		f.Variadic = reader.Bool()
+		f.IsNonDeterministic = reader.Bool()
+		f.Strict = reader.Bool()
+		// Read the operations
+		opCount := reader.VariableUint()
+		f.Operations = make([]plpgsql.InterpreterOperation, opCount)
+		for opIdx := uint64(0); opIdx < opCount; opIdx++ {
+			op := plpgsql.InterpreterOperation{}
+			op.OpCode = plpgsql.OpCode(reader.Uint16())
+			op.PrimaryData = reader.String()
+			op.SecondaryData = reader.StringSlice()
+			op.Target = reader.String()
+			op.Index = int(reader.Int32())
+			f.Operations[opIdx] = op
+		}
+		// Add the function to each map
+		funcMap[f.ID] = f
+		funcNameOnly := id.NewFunction(f.ID.SchemaName(), f.ID.FunctionName())
+		overloadMap[funcNameOnly] = append(overloadMap[funcNameOnly], f)
+	}
+	if !reader.IsEmpty() {
+		return nil, errors.Errorf("extra data found while deserializing functions")
+	}
+
+	// Return the deserialized object
+	return &Collection{
+		funcMap:     funcMap,
+		overloadMap: overloadMap,
+		mutex:       &sync.Mutex{},
+	}, nil
+}

--- a/core/init.go
+++ b/core/init.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dolthub/dolt/go/store/types"
 
 	"github.com/dolthub/doltgresql/core/id"
+	"github.com/dolthub/doltgresql/server/plpgsql"
 )
 
 // Init initializes this package.
@@ -27,5 +28,6 @@ func Init() {
 	doltdb.NewRootValue = newRootValue
 	types.DoltgresRootValueHumanReadableStringAtIndentationLevel = rootValueHumanReadableStringAtIndentationLevel
 	types.DoltgresRootValueWalkAddrs = rootValueWalkAddrs
+	plpgsql.GetTypesCollectionFromContext = GetTypesCollectionFromContext
 	id.RegisterListener(sequenceIDListener{}, id.Section_Table)
 }

--- a/core/storage.go
+++ b/core/storage.go
@@ -36,6 +36,17 @@ type rootStorage struct {
 	srv *serial.RootValue
 }
 
+// SetFunctions sets the function hash and returns a new storage object.
+func (r rootStorage) SetFunctions(ctx context.Context, h hash.Hash) (rootStorage, error) {
+	if len(r.srv.FunctionsBytes()) > 0 {
+		ret := r.clone()
+		copy(ret.srv.FunctionsBytes(), h[:])
+		return ret, nil
+	} else {
+		return r.clone(), nil
+	}
+}
+
 // SetSequences sets the sequence hash and returns a new storage object.
 func (r rootStorage) SetSequences(ctx context.Context, h hash.Hash) (rootStorage, error) {
 	if len(r.srv.SequencesBytes()) > 0 {
@@ -114,6 +125,15 @@ func (r rootStorage) SetSchemas(ctx context.Context, dbSchemas []schema.Database
 		return rootStorage{}, err
 	}
 	return rootStorage{msg}, nil
+}
+
+// GetFunctions returns the functions hash.
+func (r rootStorage) GetFunctions() hash.Hash {
+	hashBytes := r.srv.FunctionsBytes()
+	if len(hashBytes) == 0 {
+		return hash.Hash{}
+	}
+	return hash.New(hashBytes)
 }
 
 // GetSequences returns the sequence hash.

--- a/flatbuffers/gen/serial/rootvalue.go
+++ b/flatbuffers/gen/serial/rootvalue.go
@@ -235,7 +235,41 @@ func (rcv *RootValue) MutateTypes(j int, n byte) bool {
 	return false
 }
 
-const RootValueNumFields = 6
+func (rcv *RootValue) Functions(j int) byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
+	if o != 0 {
+		a := rcv._tab.Vector(o)
+		return rcv._tab.GetByte(a + flatbuffers.UOffsetT(j*1))
+	}
+	return 0
+}
+
+func (rcv *RootValue) FunctionsLength() int {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
+	if o != 0 {
+		return rcv._tab.VectorLen(o)
+	}
+	return 0
+}
+
+func (rcv *RootValue) FunctionsBytes() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
+func (rcv *RootValue) MutateFunctions(j int, n byte) bool {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
+	if o != 0 {
+		a := rcv._tab.Vector(o)
+		return rcv._tab.MutateByte(a+flatbuffers.UOffsetT(j*1), n)
+	}
+	return false
+}
+
+const RootValueNumFields = 8
 
 func RootValueStart(builder *flatbuffers.Builder) {
 	builder.StartObject(RootValueNumFields)
@@ -268,6 +302,18 @@ func RootValueAddSequences(builder *flatbuffers.Builder, sequences flatbuffers.U
 	builder.PrependUOffsetTSlot(5, flatbuffers.UOffsetT(sequences), 0)
 }
 func RootValueStartSequencesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+	return builder.StartVector(1, numElems, 1)
+}
+func RootValueAddTypes(builder *flatbuffers.Builder, types flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(6, flatbuffers.UOffsetT(types), 0)
+}
+func RootValueStartTypesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+	return builder.StartVector(1, numElems, 1)
+}
+func RootValueAddFunctions(builder *flatbuffers.Builder, functions flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(7, flatbuffers.UOffsetT(functions), 0)
+}
+func RootValueStartFunctionsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(1, numElems, 1)
 }
 func RootValueEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {

--- a/flatbuffers/serial/rootvalue.fbs
+++ b/flatbuffers/serial/rootvalue.fbs
@@ -29,6 +29,10 @@ table RootValue {
   schemas:[DatabaseSchema];
 
   sequences:[ubyte];
+
+  types:[ubyte];
+
+  functions:[ubyte];
 }
 
 table DatabaseSchema {

--- a/server/ast/create_function.go
+++ b/server/ast/create_function.go
@@ -79,6 +79,7 @@ func nodeCreateFunction(ctx *Context, node *tree.CreateFunction) (vitess.Stateme
 		Statement: pgnodes.NewCreateFunction(
 			tableName.Table(),
 			schemaName,
+			node.Replace,
 			retType,
 			paramNames,
 			paramTypes,

--- a/server/functions/framework/catalog.go
+++ b/server/functions/framework/catalog.go
@@ -35,12 +35,7 @@ var initializedFunctions = false
 // from within an init().
 func RegisterFunction(f FunctionInterface) {
 	if initializedFunctions {
-		// TODO: this should be able to handle overloads
-		name := strings.ToLower(f.GetName())
-		if err := validateFunction(name, []FunctionInterface{f}); err != nil {
-			panic(err) // TODO: replace panics here with errors
-		}
-		compileNonOperatorFunction(name, []FunctionInterface{f})
+		panic("attempted to register a function after the init() phase")
 	}
 	switch f := f.(type) {
 	case Function0:

--- a/server/plpgsql/interpreter_logic.go
+++ b/server/plpgsql/interpreter_logic.go
@@ -20,8 +20,8 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/analyzer"
 
-	"github.com/dolthub/doltgresql/core"
 	"github.com/dolthub/doltgresql/core/id"
+	"github.com/dolthub/doltgresql/core/typecollection"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
@@ -35,6 +35,10 @@ type InterpretedFunction interface {
 	QueryMultiReturn(ctx *sql.Context, stack InterpreterStack, stmt string, bindings []string) (rowIter sql.RowIter, err error)
 	QuerySingleReturn(ctx *sql.Context, stack InterpreterStack, stmt string, targetType *pgtypes.DoltgresType, bindings []string) (val any, err error)
 }
+
+// GetTypesCollectionFromContext is declared within the core package, but is assigned to this variable to work around
+// import cycles.
+var GetTypesCollectionFromContext func(ctx *sql.Context) (*typecollection.TypeCollection, error)
 
 // Call runs the contained operations on the given runner.
 func Call(ctx *sql.Context, iFunc InterpretedFunction, runner analyzer.StatementRunner, paramsAndReturn []*pgtypes.DoltgresType, vals []any) (any, error) {
@@ -84,7 +88,7 @@ func Call(ctx *sql.Context, iFunc InterpretedFunction, runner analyzer.Statement
 		case OpCode_Case:
 			// TODO: implement
 		case OpCode_Declare:
-			typeCollection, err := core.GetTypesCollectionFromContext(ctx)
+			typeCollection, err := GetTypesCollectionFromContext(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/testing/go/create_function_test.go
+++ b/testing/go/create_function_test.go
@@ -398,5 +398,58 @@ $$ LANGUAGE plpgsql;`,
 				},
 			},
 		},
+		{
+			Name: "Overloading",
+			SetUpScript: []string{`CREATE FUNCTION interpreted_overload(input TEXT) RETURNS TEXT AS $$
+DECLARE
+	var1 TEXT;
+BEGIN
+	IF length(input) > 3 THEN
+		var1 := input || '_long';
+	ELSE
+		var1 := input;
+	END IF;
+	RETURN var1;
+END;
+$$ LANGUAGE plpgsql;`,
+				`CREATE FUNCTION interpreted_overload(input INT4) RETURNS INT4 AS $$
+DECLARE
+	var1 INT4;
+BEGIN
+	IF input > 3 THEN
+		var1 := -input;
+	ELSE
+		var1 := input;
+	END IF;
+	RETURN var1;
+END;
+$$ LANGUAGE plpgsql;`},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT interpreted_overload('abc');",
+					Expected: []sql.Row{
+						{"abc"},
+					},
+				},
+				{
+					Query: "SELECT interpreted_overload('abcd');",
+					Expected: []sql.Row{
+						{"abcd_long"},
+					},
+				},
+				{
+					Query: "SELECT interpreted_overload(3);",
+					Expected: []sql.Row{
+						{3},
+					},
+				},
+				{
+					Query: "SELECT interpreted_overload(4);",
+					Expected: []sql.Row{
+						{-4},
+					},
+				},
+			},
+		},
 	})
 }

--- a/utils/reader.go
+++ b/utils/reader.go
@@ -349,6 +349,26 @@ func (reader *Reader) StringSlice() []string {
 	return vals
 }
 
+// IdSlice reads a slice of internal IDs.
+func (reader *Reader) IdSlice() []id.Id {
+	count := reader.VariableUint()
+	vals := make([]id.Id, count)
+	for i := uint64(0); i < count; i++ {
+		vals[i] = reader.Id()
+	}
+	return vals
+}
+
+// IdTypeSlice reads a slice of internal type IDs.
+func (reader *Reader) IdTypeSlice() []id.Type {
+	count := reader.VariableUint()
+	vals := make([]id.Type, count)
+	for i := uint64(0); i < count; i++ {
+		vals[i] = id.Type(reader.Id())
+	}
+	return vals
+}
+
 // IsEmpty returns true when all of the data has been read.
 func (reader *Reader) IsEmpty() bool {
 	return reader.offset >= uint64(len(reader.buf))

--- a/utils/writer.go
+++ b/utils/writer.go
@@ -273,6 +273,22 @@ func (writer *Writer) StringSlice(vals []string) {
 	}
 }
 
+// IdSlice writes a slice of internal IDs.
+func (writer *Writer) IdSlice(vals []id.Id) {
+	writer.VariableUint(uint64(len(vals)))
+	for i := range vals {
+		writer.Id(vals[i])
+	}
+}
+
+// IdTypeSlice writes a slice of internal type IDs.
+func (writer *Writer) IdTypeSlice(vals []id.Type) {
+	writer.VariableUint(uint64(len(vals)))
+	for i := range vals {
+		writer.Id(vals[i].AsId())
+	}
+}
+
 // Data returns the data written to the Writer.
 func (writer *Writer) Data() []byte {
 	return writer.buf.Bytes()


### PR DESCRIPTION
This changes created functions such that they're now written to the root value, instead of being added to the global function list. This also supports overloading created functions.