### PR TITLE
Fixed bug with generated values not being properly quoted

### DIFF
--- a/server/node/create_table.go
+++ b/server/node/create_table.go
@@ -30,6 +30,7 @@ type CreateTable struct {
 
 var _ sql.ExecSourceRel = (*CreateTable)(nil)
 var _ sql.SchemaTarget = (*CreateTable)(nil)
+var _ sql.Expressioner = (*CreateTable)(nil)
 
 // NewCreateTable returns a new *CreateTable.
 func NewCreateTable(createTable *plan.CreateTable, sequences []*CreateSequence) *CreateTable {
@@ -116,4 +117,19 @@ func (c CreateTable) WithTargetSchema(schema sql.Schema) (sql.Node, error) {
 	c.gmsCreateTable = n.(*plan.CreateTable)
 
 	return &c, nil
+}
+
+func (c *CreateTable) Expressions() []sql.Expression {
+	return c.gmsCreateTable.Expressions()
+}
+
+func (c *CreateTable) WithExpressions(expression ...sql.Expression) (sql.Node, error) {
+	nc := *c
+	n, err := nc.gmsCreateTable.WithExpressions(expression...)
+	if err != nil {
+		return nil, err
+	}
+
+	nc.gmsCreateTable = n.(*plan.CreateTable)
+	return &nc, nil
 }

--- a/testing/go/create_table_test.go
+++ b/testing/go/create_table_test.go
@@ -234,8 +234,7 @@ func TestCreateTable(t *testing.T) {
 			},
 		},
 		{
-			Name: "generated column with reference to another column that needs quote",
-			Skip: true, // generated columns are not being properly quoted, this is a bug in GMS
+			Name: "generated column with space in column name",
 			SetUpScript: []string{
 				`create table t1 (
     			a varchar(10) primary key,


### PR DESCRIPTION
This wasn't due to a bug in GMS, but rather a bug in our CreateTable wrapper node. This wasn't caught earlier because column default values in postgres can't contain column references, only generated columns can.