### PR TITLE
Add `LogFormat()` method from servercfg.ServerConfig to DoltgresConfig

### DIFF
--- a/servercfg/config.go
+++ b/servercfg/config.go
@@ -299,6 +299,10 @@ func (cfg *DoltgresConfig) LogLevel() servercfg.LogLevel {
 	}
 }
 
+func (cfg *DoltgresConfig) LogFormat() servercfg.LogFormat {
+	return servercfg.LogFormat_Text
+}
+
 func (cfg *DoltgresConfig) MaxConnections() uint64 {
 	return 0
 }


### PR DESCRIPTION
PR https://github.com/dolthub/dolt/pull/8890 added a new `LogFormat()` method to the `ServerConfig` interface. 