### PR TITLE
Support for `RAISE` in PL/pgSQL

### DIFF
--- a/core/functions/function.go
+++ b/core/functions/function.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/dolthub/doltgresql/core/id"
-	"github.com/dolthub/doltgresql/server/plpgsql"
+	"github.com/dolthub/doltgresql/core/interpreter"
 )
 
 // Collection contains a collection of functions.
@@ -40,7 +40,7 @@ type Function struct {
 	Variadic           bool
 	IsNonDeterministic bool
 	Strict             bool
-	Operations         []plpgsql.InterpreterOperation
+	Operations         []interpreter.InterpreterOperation
 }
 
 // GetFunction returns the function with the given ID. Returns nil if the function cannot be found.

--- a/core/functions/serialization.go
+++ b/core/functions/serialization.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/dolthub/doltgresql/core/id"
-	"github.com/dolthub/doltgresql/server/plpgsql"
+	"github.com/dolthub/doltgresql/core/interpreter"
 	"github.com/dolthub/doltgresql/utils"
 )
 
@@ -92,10 +92,10 @@ func Deserialize(ctx context.Context, data []byte) (*Collection, error) {
 		f.Strict = reader.Bool()
 		// Read the operations
 		opCount := reader.VariableUint()
-		f.Operations = make([]plpgsql.InterpreterOperation, opCount)
+		f.Operations = make([]interpreter.InterpreterOperation, opCount)
 		for opIdx := uint64(0); opIdx < opCount; opIdx++ {
-			op := plpgsql.InterpreterOperation{}
-			op.OpCode = plpgsql.OpCode(reader.Uint16())
+			op := interpreter.InterpreterOperation{}
+			op.OpCode = interpreter.OpCode(reader.Uint16())
 			op.PrimaryData = reader.String()
 			op.SecondaryData = reader.StringSlice()
 			op.Target = reader.String()

--- a/core/interpreter/interpreter_operation.go
+++ b/core/interpreter/interpreter_operation.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package plpgsql
+package interpreter
 
 // OpCode states the operation to be performed. Most operations have a direct analogue to a Pl/pgSQL operation, however
 // some exist only in Doltgres (specific to our interpreter implementation).
@@ -31,6 +31,7 @@ const (
 	OpCode_If                       // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-CONDITIONALS
 	OpCode_InsertInto               // https://www.postgresql.org/docs/15/plpgsql-statements.html
 	OpCode_Perform                  // https://www.postgresql.org/docs/15/plpgsql-statements.html
+	OpCode_Raise                    // https://www.postgresql.org/docs/15/plpgsql-errors-and-messages.html
 	OpCode_Return                   // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-STATEMENTS-RETURNING
 	OpCode_ScopeBegin               // This is used for scope control, specific to Doltgres
 	OpCode_ScopeEnd                 // This is used for scope control, specific to Doltgres
@@ -45,4 +46,5 @@ type InterpreterOperation struct {
 	SecondaryData []string // This represents auxiliary data, such as bindings, strictness, etc.
 	Target        string   // This is the variable that will store the results (if applicable)
 	Index         int      // This is the index that should be set for operations that move the function counter
+	Options       any      // This is extra, opaque data for operations that need it
 }

--- a/server/functions/framework/interpreted_function.go
+++ b/server/functions/framework/interpreted_function.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lib/pq"
 
 	"github.com/dolthub/doltgresql/core/id"
+	"github.com/dolthub/doltgresql/core/interpreter"
 	"github.com/dolthub/doltgresql/server/plpgsql"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
@@ -38,7 +39,7 @@ type InterpretedFunction struct {
 	Variadic           bool
 	IsNonDeterministic bool
 	Strict             bool
-	Statements         []plpgsql.InterpreterOperation
+	Statements         []interpreter.InterpreterOperation
 }
 
 var _ FunctionInterface = InterpretedFunction{}
@@ -70,7 +71,7 @@ func (iFunc InterpretedFunction) GetReturn() *pgtypes.DoltgresType {
 }
 
 // GetStatements returns the contained statements.
-func (iFunc InterpretedFunction) GetStatements() []plpgsql.InterpreterOperation {
+func (iFunc InterpretedFunction) GetStatements() []interpreter.InterpreterOperation {
 	return iFunc.Statements
 }
 

--- a/server/initialization/initialization.go
+++ b/server/initialization/initialization.go
@@ -32,6 +32,7 @@ import (
 	"github.com/dolthub/doltgresql/server/functions/binary"
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	"github.com/dolthub/doltgresql/server/functions/unary"
+	"github.com/dolthub/doltgresql/server/plpgsql"
 	"github.com/dolthub/doltgresql/server/tables"
 	"github.com/dolthub/doltgresql/server/tables/dprocedures"
 	"github.com/dolthub/doltgresql/server/tables/dtables"
@@ -62,5 +63,6 @@ func Initialize(dEnv *env.DoltEnv) {
 		information_schema.Init()
 		dtables.Init()
 		dprocedures.Init()
+		plpgsql.Init()
 	})
 }

--- a/server/node/create_function.go
+++ b/server/node/create_function.go
@@ -23,7 +23,7 @@ import (
 	"github.com/dolthub/doltgresql/core/functions"
 
 	"github.com/dolthub/doltgresql/core/id"
-	"github.com/dolthub/doltgresql/server/plpgsql"
+	"github.com/dolthub/doltgresql/core/interpreter"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
@@ -36,7 +36,7 @@ type CreateFunction struct {
 	ParameterNames []string
 	ParameterTypes []*pgtypes.DoltgresType
 	Strict         bool
-	Statements     []plpgsql.InterpreterOperation
+	Statements     []interpreter.InterpreterOperation
 }
 
 var _ sql.ExecSourceRel = (*CreateFunction)(nil)
@@ -51,7 +51,7 @@ func NewCreateFunction(
 	paramNames []string,
 	paramTypes []*pgtypes.DoltgresType,
 	strict bool,
-	statements []plpgsql.InterpreterOperation) *CreateFunction {
+	statements []interpreter.InterpreterOperation) *CreateFunction {
 	return &CreateFunction{
 		FunctionName:   functionName,
 		SchemaName:     schemaName,

--- a/server/plpgsql/init.go
+++ b/server/plpgsql/init.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Dolthub, Inc.
+// Copyright 2025 Dolthub, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,20 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package core
+package plpgsql
 
-import (
-	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
-	"github.com/dolthub/dolt/go/store/types"
+import "github.com/dolthub/doltgresql/core"
 
-	"github.com/dolthub/doltgresql/core/id"
-)
-
-// Init initializes this package.
 func Init() {
-	doltdb.EmptyRootValue = emptyRootValue
-	doltdb.NewRootValue = newRootValue
-	types.DoltgresRootValueHumanReadableStringAtIndentationLevel = rootValueHumanReadableStringAtIndentationLevel
-	types.DoltgresRootValueWalkAddrs = rootValueWalkAddrs
-	id.RegisterListener(sequenceIDListener{}, id.Section_Table)
+	GetTypesCollectionFromContext = core.GetTypesCollectionFromContext
 }

--- a/server/plpgsql/interpreter_logic.go
+++ b/server/plpgsql/interpreter_logic.go
@@ -20,8 +20,11 @@ import (
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/analyzer"
+	"github.com/jackc/pgx/v5/pgproto3"
 
+	"github.com/dolthub/doltgresql/core"
 	"github.com/dolthub/doltgresql/core/id"
+	"github.com/dolthub/doltgresql/core/interpreter"
 	"github.com/dolthub/doltgresql/core/typecollection"
 	"github.com/dolthub/doltgresql/postgres/parser/types"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
@@ -33,7 +36,7 @@ type InterpretedFunction interface {
 	GetParameters() []*pgtypes.DoltgresType
 	GetParameterNames() []string
 	GetReturn() *pgtypes.DoltgresType
-	GetStatements() []InterpreterOperation
+	GetStatements() []interpreter.InterpreterOperation
 	QueryMultiReturn(ctx *sql.Context, stack InterpreterStack, stmt string, bindings []string) (rowIter sql.RowIter, err error)
 	QuerySingleReturn(ctx *sql.Context, stack InterpreterStack, stmt string, targetType *pgtypes.DoltgresType, bindings []string) (val any, err error)
 }
@@ -68,13 +71,13 @@ func Call(ctx *sql.Context, iFunc InterpretedFunction, runner analyzer.Statement
 
 		operation := statements[counter]
 		switch operation.OpCode {
-		case OpCode_Alias:
+		case interpreter.OpCode_Alias:
 			iv := stack.GetVariable(operation.PrimaryData)
 			if iv == nil {
 				return nil, fmt.Errorf("variable `%s` could not be found", operation.PrimaryData)
 			}
 			stack.NewVariableAlias(operation.Target, iv)
-		case OpCode_Assign:
+		case interpreter.OpCode_Assign:
 			iv := stack.GetVariable(operation.Target)
 			if iv == nil {
 				return nil, fmt.Errorf("variable `%s` could not be found", operation.Target)
@@ -87,9 +90,7 @@ func Call(ctx *sql.Context, iFunc InterpretedFunction, runner analyzer.Statement
 			if err != nil {
 				return nil, err
 			}
-		case OpCode_Case:
-			// TODO: implement
-		case OpCode_Declare:
+		case interpreter.OpCode_Declare:
 			typeCollection, err := GetTypesCollectionFromContext(ctx)
 			if err != nil {
 				return nil, err
@@ -118,11 +119,11 @@ func Call(ctx *sql.Context, iFunc InterpretedFunction, runner analyzer.Statement
 				return nil, pgtypes.ErrTypeDoesNotExist.New(operation.PrimaryData)
 			}
 			stack.NewVariable(operation.Target, resolvedType)
-		case OpCode_DeleteInto:
+		case interpreter.OpCode_DeleteInto:
 			// TODO: implement
-		case OpCode_Exception:
+		case interpreter.OpCode_Exception:
 			// TODO: implement
-		case OpCode_Execute:
+		case interpreter.OpCode_Execute:
 			if len(operation.Target) > 0 {
 				target := stack.GetVariable(operation.Target)
 				if target == nil {
@@ -145,30 +146,30 @@ func Call(ctx *sql.Context, iFunc InterpretedFunction, runner analyzer.Statement
 					return nil, err
 				}
 			}
-		case OpCode_Get:
+		case interpreter.OpCode_Get:
 			// TODO: implement
-		case OpCode_Goto:
+		case interpreter.OpCode_Goto:
 			// We must compare to the index - 1, so that the increment hits our target
 			if counter <= operation.Index {
 				for ; counter < operation.Index-1; counter++ {
 					switch statements[counter].OpCode {
-					case OpCode_ScopeBegin:
+					case interpreter.OpCode_ScopeBegin:
 						stack.PushScope()
-					case OpCode_ScopeEnd:
+					case interpreter.OpCode_ScopeEnd:
 						stack.PopScope()
 					}
 				}
 			} else {
 				for ; counter > operation.Index-1; counter-- {
 					switch statements[counter].OpCode {
-					case OpCode_ScopeBegin:
+					case interpreter.OpCode_ScopeBegin:
 						stack.PopScope()
-					case OpCode_ScopeEnd:
+					case interpreter.OpCode_ScopeEnd:
 						stack.PushScope()
 					}
 				}
 			}
-		case OpCode_If:
+		case interpreter.OpCode_If:
 			retVal, err := iFunc.QuerySingleReturn(ctx, stack, operation.PrimaryData, pgtypes.Bool, operation.SecondaryData)
 			if err != nil {
 				return nil, err
@@ -178,9 +179,9 @@ func Call(ctx *sql.Context, iFunc InterpretedFunction, runner analyzer.Statement
 				// Also, we must assign to index-1, so that the increment hits our target.
 				counter = operation.Index - 1
 			}
-		case OpCode_InsertInto:
+		case interpreter.OpCode_InsertInto:
 			// TODO: implement
-		case OpCode_Perform:
+		case interpreter.OpCode_Perform:
 			rowIter, err := iFunc.QueryMultiReturn(ctx, stack, operation.PrimaryData, operation.SecondaryData)
 			if err != nil {
 				return nil, err
@@ -188,22 +189,104 @@ func Call(ctx *sql.Context, iFunc InterpretedFunction, runner analyzer.Statement
 			if _, err = sql.RowIterToRows(ctx, rowIter); err != nil {
 				return nil, err
 			}
-		case OpCode_Return:
+		case interpreter.OpCode_Raise:
+			backend, err := core.GetBackend(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			// TODO: Use the client_min_messages config param to determine which
+			//       notice levels to send to the client.
+			// https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-CLIENT-MIN-MESSAGES
+
+			// TODO: Notices at the EXCEPTION level should also abort the current tx.
+
+			message, err := evaluteNoticeMessage(ctx, iFunc, operation, stack)
+			if err != nil {
+				return nil, err
+			}
+
+			noticeResponse := &pgproto3.NoticeResponse{
+				Severity: operation.PrimaryData,
+				Message:  message,
+			}
+
+			applyNoticeOptions(ctx, noticeResponse, operation.Options.(map[uint8]string))
+			backend.Send(noticeResponse)
+			if err = backend.Flush(); err != nil {
+				return nil, err
+			}
+		case interpreter.OpCode_Return:
 			if len(operation.PrimaryData) == 0 {
 				return nil, nil
 			}
 			return iFunc.QuerySingleReturn(ctx, stack, operation.PrimaryData, iFunc.GetReturn(), operation.SecondaryData)
-		case OpCode_ScopeBegin:
+		case interpreter.OpCode_ScopeBegin:
 			stack.PushScope()
-		case OpCode_ScopeEnd:
+		case interpreter.OpCode_ScopeEnd:
 			stack.PopScope()
-		case OpCode_SelectInto:
+		case interpreter.OpCode_SelectInto:
 			// TODO: implement
-		case OpCode_UpdateInto:
+		case interpreter.OpCode_UpdateInto:
 			// TODO: implement
 		default:
 			panic("unimplemented opcode")
 		}
 	}
 	return nil, nil
+}
+
+// applyNoticeOptions adds the specified |options| to the |noticeResponse|.
+func applyNoticeOptions(ctx *sql.Context, noticeResponse *pgproto3.NoticeResponse, options map[uint8]string) {
+	for key, value := range options {
+		switch NoticeOptionType(key) {
+		case NoticeOptionTypeErrCode:
+			noticeResponse.Code = value
+		case NoticeOptionTypeMessage:
+			noticeResponse.Message = value
+		case NoticeOptionTypeDetail:
+			noticeResponse.Detail = value
+		case NoticeOptionTypeHint:
+			noticeResponse.Hint = value
+		case NoticeOptionTypeConstraint:
+			noticeResponse.ConstraintName = value
+		case NoticeOptionTypeDataType:
+			noticeResponse.DataTypeName = value
+		case NoticeOptionTypeTable:
+			noticeResponse.TableName = value
+		case NoticeOptionTypeSchema:
+			noticeResponse.SchemaName = value
+		default:
+			ctx.GetLogger().Warnf("unhandled notice option type: %d", key)
+		}
+	}
+}
+
+// evaluteNoticeMessage evaluates the message for a RAISE NOTICE statement, including
+// evaluating any specified parameters and plugging them into the message in place of
+// the % placeholders.
+func evaluteNoticeMessage(ctx *sql.Context, iFunc InterpretedFunction,
+	operation interpreter.InterpreterOperation, stack InterpreterStack) (string, error) {
+	message := operation.SecondaryData[0]
+	if len(operation.SecondaryData) > 1 {
+		params := operation.SecondaryData[1:]
+		currentParam := 0
+
+		parts := strings.Split(message, "%%")
+		for i, part := range parts {
+			for strings.Contains(part, "%") {
+				retVal, err := iFunc.QuerySingleReturn(ctx, stack, "SELECT "+params[currentParam], nil, nil)
+				if err != nil {
+					return "", err
+				}
+				currentParam += 1
+
+				s := fmt.Sprintf("%v", retVal)
+				part = strings.Replace(part, "%", s, 1)
+			}
+			parts[i] = part
+		}
+		message = strings.Join(parts, "%")
+	}
+	return message, nil
 }

--- a/server/plpgsql/json_convert.go
+++ b/server/plpgsql/json_convert.go
@@ -64,6 +64,8 @@ func jsonConvertStatement(stmt statement) (Statement, error) {
 		return stmt.Loop.Convert()
 	case stmt.Perform != nil:
 		return stmt.Perform.Convert(), nil
+	case stmt.Raise != nil:
+		return stmt.Raise.Convert(), nil
 	case stmt.Return != nil:
 		return stmt.Return.Convert(), nil
 	case stmt.While != nil:

--- a/server/plpgsql/notice.go
+++ b/server/plpgsql/notice.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plpgsql
+
+// NoticeLevel represents the severity, or level, of a notice created by a RAISE statement.
+type NoticeLevel uint8
+
+const (
+	NoticeLevelDebug     NoticeLevel = 14
+	NoticeLevelLog       NoticeLevel = 15
+	NoticeLevelInfo      NoticeLevel = 17
+	NoticeLevelNotice    NoticeLevel = 18
+	NoticeLevelWarning   NoticeLevel = 19
+	NoticeLevelException NoticeLevel = 21
+)
+
+// String returns a string representation of this NoticeLevel.
+func (nl NoticeLevel) String() string {
+	switch nl {
+	case NoticeLevelDebug:
+		return "DEBUG"
+	case NoticeLevelLog:
+		return "LOG"
+	case NoticeLevelInfo:
+		return "INFO"
+	case NoticeLevelNotice:
+		return "NOTICE"
+	case NoticeLevelWarning:
+		return "WARNING"
+	case NoticeLevelException:
+		return "EXCEPTION"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// NoticeOptionType represents the type of option specified for a notice in the USING clause of a RAISE statement.
+type NoticeOptionType uint8
+
+const (
+	NoticeOptionTypeErrCode    NoticeOptionType = 0
+	NoticeOptionTypeMessage    NoticeOptionType = 1
+	NoticeOptionTypeDetail     NoticeOptionType = 2
+	NoticeOptionTypeHint       NoticeOptionType = 3
+	NoticeOptionTypeConstraint NoticeOptionType = 5
+	NoticeOptionTypeDataType   NoticeOptionType = 6
+	NoticeOptionTypeTable      NoticeOptionType = 7
+	NoticeOptionTypeSchema     NoticeOptionType = 8
+)

--- a/server/plpgsql/parse.go
+++ b/server/plpgsql/parse.go
@@ -19,11 +19,13 @@ import (
 
 	"github.com/cockroachdb/errors"
 	pg_query "github.com/pganalyze/pg_query_go/v6"
+
+	"github.com/dolthub/doltgresql/core/interpreter"
 )
 
 // Parse parses the given CREATE FUNCTION string (which must be the entire string, not just the body) into a Block
 // containing the contents of the body.
-func Parse(fullCreateFunctionString string) ([]InterpreterOperation, error) {
+func Parse(fullCreateFunctionString string) ([]interpreter.InterpreterOperation, error) {
 	var functions []function
 	parsedBody, err := pg_query.ParsePlPgSqlToJSON(fullCreateFunctionString)
 	if err != nil {
@@ -40,7 +42,7 @@ func Parse(fullCreateFunctionString string) ([]InterpreterOperation, error) {
 	if err != nil {
 		return nil, err
 	}
-	ops := make([]InterpreterOperation, 0, len(block.Body)+len(block.Variable))
+	ops := make([]interpreter.InterpreterOperation, 0, len(block.Body)+len(block.Variable))
 	stack := NewInterpreterStack(nil)
 	if err = block.AppendOperations(&ops, &stack); err != nil {
 		return nil, err


### PR DESCRIPTION
Adds initial support for `RAISE` statements in PL/pgSQL functions. There are still a few edge case TODOs (e.g. using the `client_min_messages` config param to determine what level of notices to send to clients), and this initial pass does not include any exception handling. 

To send notice messages back to the client, I had to plumb through the `pgproto3.Backend` instance, through the context. This involved fixing an import cycle (`core` → `plpgsql` → `core`) by bringing the `InterpreterOperation` class into `core`. I'm open to other approaches, but this seemed like the simplest way to break the dependency from `core` to `plpgsql`. 

[PostgreSQL Docs](https://www.postgresql.org/docs/current/plpgsql-errors-and-messages.html)