### PR TITLE
Avoid name collisions for generated FK names

### DIFF
--- a/server/analyzer/convert_drop_primary_key_constraint.go
+++ b/server/analyzer/convert_drop_primary_key_constraint.go
@@ -44,7 +44,12 @@ func convertDropPrimaryKeyConstraint(ctx *sql.Context, _ *analyzer.Analyzer, n s
 			}
 			for _, index := range indexes {
 				if index.ID() == "PRIMARY" && dropConstraint.Name == rt.Name()+"_pkey" {
-					return plan.NewAlterDropPk(rt.Database(), rt), transform.NewTree, nil
+					alterDropPk := plan.NewAlterDropPk(rt.Database(), rt)
+					newNode, err := alterDropPk.WithTargetSchema(rt.Schema())
+					if err != nil {
+						return n, transform.SameTree, err
+					}
+					return newNode, transform.NewTree, nil
 				}
 			}
 		}

--- a/testing/go/alter_table_test.go
+++ b/testing/go/alter_table_test.go
@@ -586,5 +586,23 @@ func TestAlterTable(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "alter table drop primary key",
+			SetUpScript: []string{
+				"CREATE TABLE t1 (id int PRIMARY KEY);",
+				"INSERT INTO t1 (id) VALUES (1), (2);",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    "ALTER TABLE t1 DROP CONSTRAINT t1_pkey;",
+					Expected: []sql.Row{},
+				},
+				{
+					// Assert that the constraint is gone
+					Query:    "INSERT INTO t1 VALUES (1), (2);",
+					Expected: []sql.Row{},
+				},
+			},
+		},
 	})
 }

--- a/testing/go/foreign_keys_test.go
+++ b/testing/go/foreign_keys_test.go
@@ -472,6 +472,27 @@ func TestForeignKeys(t *testing.T) {
 				},
 			},
 			{
+				Name: "foreign key default naming, name collision ",
+				SetUpScript: []string{
+					"CREATE TABLE parent (id varchar not null primary key);",
+					"CREATE TABLE child (id varchar primary key, constraint t33_webhook_id_fk_fkey foreign key (id) references parent(id));",
+					"CREATE TABLE webhooks (id varchar not null, id2 int8, primary key (id));",
+					"CREATE TABLE t33 (id varchar not null, webhook_id_fk varchar not null, foreign key (webhook_id_fk) references webhooks(id), primary key (id));",
+				},
+				Assertions: []ScriptTestAssertion{
+					{
+						Query: "SELECT conname AS constraint_name FROM pg_constraint WHERE conrelid = 't33'::regclass  AND contype = 'f';",
+						Expected: []sql.Row{
+							{"t33_webhook_id_fk_fkey1"},
+						},
+					},
+					{
+						Query:    "ALTER TABLE t33 DROP CONSTRAINT t33_webhook_id_fk_fkey1;",
+						Expected: []sql.Row{},
+					},
+				},
+			},
+			{
 				Name: "foreign key default naming, in column definition",
 				SetUpScript: []string{
 					"CREATE TABLE webhooks (id varchar not null, primary key (id));",


### PR DESCRIPTION
Matches Postgres' behavior where default foreign key name collisions are resolved by adding an integer suffix to the name to make it unique. 

Also includes a bug fix for setting the target schema when dropping a primary key. 

Fixes a couple more issues with supporting DoltHub's schema in Doltgres. 