### PR TITLE
Changing how a constraint addition is structured, to match what Dolt/GMS does

### DIFF
--- a/server/ast/alter_table.go
+++ b/server/ast/alter_table.go
@@ -99,19 +99,9 @@ func nodeAlterTableCmds(
 			}
 			vitessDdlCmds = append(vitessDdlCmds, statement)
 
-			// Postgres (unlike MySQL) allows an inline FK constraint
-			// when altering a table to add a column. GMS doesn't support
-			// this directly in the ALTER TABLE ADD COLUMN DDL command,
-			// so we break this out into a separate DDL command.
+			// If inline constraints have been specified, set the ConstraintAction so that they get processed
 			if len(statement.TableSpec.Constraints) > 0 {
-				vitessDdlCmds = append(vitessDdlCmds,
-					&vitess.DDL{
-						Action:           "alter",
-						ConstraintAction: "add",
-						Table:            tableName,
-						IfExists:         ifExists,
-						TableSpec:        statement.TableSpec,
-					})
+				statement.ConstraintAction = vitess.AddStr
 			}
 
 		case *tree.AlterTableDropColumn:

--- a/testing/go/alter_table_test.go
+++ b/testing/go/alter_table_test.go
@@ -304,6 +304,22 @@ func TestAlterTable(t *testing.T) {
 			},
 		},
 		{
+			Name: "Add column with inline check constraint",
+			SetUpScript: []string{
+				"CREATE TABLE test1 (a INT, b INT);",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    "ALTER TABLE test1 ADD COLUMN c INT NOT NULL DEFAULT 42 CONSTRAINT chk1 CHECK (c > 0);",
+					Expected: []sql.Row{},
+				},
+				{
+					Query:       "INSERT INTO test1 VALUES (2, 2, -2);",
+					ExpectedErr: `Check constraint "chk1" violated`,
+				},
+			},
+		},
+		{
 			Name: "Drop Column",
 			SetUpScript: []string{
 				"CREATE TABLE test1 (a INT, b INT, c INT, d INT);",


### PR DESCRIPTION
We were previously modeling an inline constraint definition as a separate DDL command. This changes it to be consistent with how GMS and Dolt works, by using a single DDL command, and setting the constraint action. 