### PR TITLE
Add support for `ANALYZE;` without any tables specified

### DIFF
--- a/postgres/parser/parser/sql.y
+++ b/postgres/parser/parser/sql.y
@@ -5214,11 +5214,15 @@ table_name_list:
 // %Help: ANALYZE - collect table statistics
 // %Category: Misc
 // %Text:
-// ANALYZE <tablename>
+// ANALYZE [<tablename>]
 //
 // %SeeAlso: CREATE STATISTICS
 analyze_stmt:
-  ANALYZE analyze_target
+  ANALYZE
+  {
+    $$.val = &tree.Analyze{}
+  }
+| ANALYZE analyze_target
   {
     $$.val = &tree.Analyze{
       Table: $2.tblExpr(),

--- a/server/analyzer/apply_analyze_all_tables.go
+++ b/server/analyzer/apply_analyze_all_tables.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzer
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/analyzer"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/transform"
+)
+
+// applyTablesForAnalyzeAllTables finds plan.AnalyzeTable nodes that don't have any tables explicitly specified and fills in all
+// tables for the current database. This enables the ANALYZE; statement to analyze all tables.
+func applyTablesForAnalyzeAllTables(ctx *sql.Context, a *analyzer.Analyzer, node sql.Node, scope *plan.Scope, selector analyzer.RuleSelector, qFlags *sql.QueryFlags) (sql.Node, transform.TreeIdentity, error) {
+	analyzeTable, ok := node.(*plan.AnalyzeTable)
+	if !ok {
+		return node, transform.SameTree, nil
+	}
+
+	// If a set of tables is already populated, we don't need to do anything. We only fill in all tables when
+	// the caller didn't explicitly specify any tables to be analyzed.
+	if len(analyzeTable.Tables) > 0 {
+		return node, transform.SameTree, nil
+	}
+
+	db, err := a.Catalog.Database(ctx, ctx.GetCurrentDatabase())
+	if err != nil {
+		return node, transform.SameTree, err
+	}
+	tableNames, err := db.GetTableNames(ctx)
+	if err != nil {
+		return node, transform.SameTree, err
+	}
+
+	var tables []sql.Table
+	for _, tableName := range tableNames {
+		table, ok, err := db.GetTableInsensitive(ctx, tableName)
+		if err != nil {
+			return node, transform.SameTree, err
+		} else if !ok {
+			return node, transform.SameTree, sql.ErrTableNotFound.New(tableName)
+		}
+		tables = append(tables, table)
+	}
+
+	return analyzeTable.WithTables(tables), transform.NewTree, nil
+}

--- a/server/analyzer/init.go
+++ b/server/analyzer/init.go
@@ -26,6 +26,7 @@ const (
 	ruleId_TypeSanitizer                   analyzer.RuleId = iota + 1000 // typeSanitizer
 	ruleId_AddDomainConstraints                                          // addDomainConstraints
 	ruleId_AddDomainConstraintsToCasts                                   // addDomainConstraintsToCasts
+	ruleId_ApplyTablesForAnalyzeAllTables                                // applyTablesForAnalyzeAllTables
 	ruleId_AssignInsertCasts                                             // assignInsertCasts
 	ruleId_AssignUpdateCasts                                             // assignUpdateCasts
 	ruleId_ConvertDropPrimaryKeyConstraint                               // convertDropPrimaryKeyConstraint
@@ -60,6 +61,7 @@ func Init() {
 	// TODO: this should be replaced by implementing automatic toast semantics for blob types
 	analyzer.OnceBeforeDefault = append([]analyzer.Rule{
 		{Id: ruleId_AddImplicitPrefixLengths, Apply: AddImplicitPrefixLengths},
+		{Id: ruleId_ApplyTablesForAnalyzeAllTables, Apply: applyTablesForAnalyzeAllTables},
 		{Id: ruleId_ConvertDropPrimaryKeyConstraint, Apply: convertDropPrimaryKeyConstraint}},
 		analyzer.OnceBeforeDefault...)
 

--- a/server/ast/analyze.go
+++ b/server/ast/analyze.go
@@ -28,13 +28,15 @@ func nodeAnalyze(ctx *Context, node *tree.Analyze) (vitess.Statement, error) {
 		return nil, nil
 	}
 
+	// If no tables were specified, return an empty Analyze statement, and the analyzer
+	// will populate all tables to be analyzed.
+	if node.Table == nil {
+		return &vitess.Analyze{}, nil
+	}
+
 	objectName, ok := node.Table.(*tree.UnresolvedObjectName)
 	if !ok {
 		return nil, errors.Errorf("unsupported table type in Analyze node: %T", node.Table)
-	}
-
-	if objectName.Object() == "" && objectName.Schema() == "" && objectName.Catalog() == "" {
-		return nil, errors.Errorf("ANALYZE all tables not supported; must specify a table")
 	}
 
 	return &vitess.Analyze{Tables: []vitess.TableName{

--- a/testing/generation/command_docs/output/analyze_test.go
+++ b/testing/generation/command_docs/output/analyze_test.go
@@ -18,7 +18,7 @@ import "testing"
 
 func TestAnalyze(t *testing.T) {
 	tests := []QueryParses{
-		Unimplemented("ANALYZE"),
+		Converts("ANALYZE"),
 		Unimplemented("ANALYZE ( VERBOSE )"),
 		Unimplemented("ANALYZE ( VERBOSE true )"),
 		Unimplemented("ANALYZE ( SKIP_LOCKED )"),
@@ -291,7 +291,7 @@ func TestAnalyze(t *testing.T) {
 		Unimplemented("ANALYZE ( VERBOSE true , SKIP_LOCKED true ) table_name ( column_name , column_name ) , table_name ( column_name , column_name )"),
 		Unimplemented("ANALYZE ( SKIP_LOCKED , SKIP_LOCKED true ) table_name ( column_name , column_name ) , table_name ( column_name , column_name )"),
 		Unimplemented("ANALYZE ( SKIP_LOCKED true , SKIP_LOCKED true ) table_name ( column_name , column_name ) , table_name ( column_name , column_name )"),
-		Unimplemented("ANALYZE"),
+		Converts("ANALYZE"),
 		Unimplemented("ANALYZE VERBOSE"),
 		Converts("ANALYZE table_name"),
 		Unimplemented("ANALYZE VERBOSE table_name"),

--- a/testing/go/stats_test.go
+++ b/testing/go/stats_test.go
@@ -32,9 +32,6 @@ var StatsTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				// TODO: Postgres will analyze ALL tables if ANALYZE is invoked without a table name, but
-				//       our postgres parser and our analysis code doesn't support this yet.
-				Skip:     true,
 				Query:    "ANALYZE;",
 				Expected: []sql.Row{},
 			},


### PR DESCRIPTION
When Postgres processes an `ANALYZE;` statement without any tables explicitly specified, it analyzes all tables. 

[Postgres docs](https://www.postgresql.org/docs/current/sql-analyze.html)