### PR TITLE
Add support for `default_with_oids`

### DIFF
--- a/server/config/parameters_list.go
+++ b/server/config/parameters_list.go
@@ -911,6 +911,17 @@ var postgresConfigParameters = map[string]sql.SystemVariable{
 		ResetVal:  int8(0),
 		Scope:     GetPgsqlScope(PsqlScopeSession),
 	},
+	"default_with_oids": &Parameter{
+		Name:      "default_with_oids",
+		Default:   int8(0),
+		Category:  "Version and Platform Compatibility / Previous PostgreSQL Versions",
+		ShortDesc: "Provided for backwards compatibility; Doltgres does not support OID columns, even if this parameter is enabled.",
+		Context:   ParameterContextUser,
+		Type:      types.NewSystemBoolType("default_with_oids"),
+		Source:    ParameterSourceDefault,
+		ResetVal:  int8(0),
+		Scope:     GetPgsqlScope(PsqlScopeSession),
+	},
 	"dynamic_library_path": &Parameter{
 		Name:      "dynamic_library_path",
 		Default:   "$libdir",

--- a/testing/go/parameters_test.go
+++ b/testing/go/parameters_test.go
@@ -1,0 +1,39 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _go
+
+import (
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+func TestParameters(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "parameters",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    "SELECT default_with_oids;",
+					Expected: []sql.Row{{0}},
+				},
+				{
+					Query:    "SET default_with_oids = false;",
+					Expected: []sql.Row{},
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
[Postgres docs](https://www.postgresql.org/docs/11/runtime-config-compatible.html#GUC-DEFAULT-WITH-OIDS)

A few sample Postgres dumps set `default_with_oids`. This change allows them to set the parameter without triggering an error. Note that Doltgres does not support creating tables with OID columns, even if this parameter is set to true. 