### PR TITLE
Fixes for prepared statements and literal values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,22 @@
 module github.com/dolthub/doltgresql
 
+replace github.com/dolthub/vitess => ../vitess
+
+replace github.com/dolthub/go-mysql-server => ../go-mysql-server
+
+replace github.com/dolthub/dolt/go => ../dolt/go
+
 go 1.24.1
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/cockroachdb/apd/v2 v2.0.3-0.20200518165714-d020e156310a
 	github.com/cockroachdb/errors v1.7.5
-	github.com/dolthub/dolt/go v0.40.5-0.20250415001434-2fdac4b164b9
+	github.com/dolthub/dolt/go v0.40.5-0.20250417234826-cbc8ae986979
 	github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20241119094239-f4e529af734d
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
 	github.com/dolthub/go-icu-regex v0.0.0-20250327004329-6799764f2dad
-	github.com/dolthub/go-mysql-server v0.19.1-0.20250414233448-814abccc8b6d
+	github.com/dolthub/go-mysql-server v0.19.1-0.20250417231730-fcd059390dd6
 	github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216
 	github.com/dolthub/vitess v0.0.0-20250414165810-f0031a6472b7
 	github.com/fatih/color v1.13.0

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,5 @@
 module github.com/dolthub/doltgresql
 
-replace github.com/dolthub/vitess => ../vitess
-
-replace github.com/dolthub/go-mysql-server => ../go-mysql-server
-
-replace github.com/dolthub/dolt/go => ../dolt/go
-
 go 1.24.1
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,6 @@ github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5Xh
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 h1:IdqX7J8vi/Kn3T3Ee0VzqnLqwFmgA2hr8WZETPcQjfM=
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12/go.mod h1:rN7X8BHwkjPcfMQQ2QTAq/xM3leUSGLfb+1Js7Y6TVo=
-github.com/dolthub/dolt/go v0.40.5-0.20250415001434-2fdac4b164b9 h1:ZWDHwpVJTO8WQPLqhe63E1oXPPq0SVQVD6OrlO2rQ4Q=
-github.com/dolthub/dolt/go v0.40.5-0.20250415001434-2fdac4b164b9/go.mod h1:ugNKxGCsAzevsXPHmBsDAnZ+yU0ty4BLNHQ9pwPKh1A=
 github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20241119094239-f4e529af734d h1:gO9+wrmNHXukPNCO1tpfCcXIdMlW/qppbUStfLvqz/U=
 github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20241119094239-f4e529af734d/go.mod h1:L5RDYZbC9BBWmoU2+TjTekeqqhFXX5EqH9ln00O0stY=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=
@@ -266,8 +264,6 @@ github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
 github.com/dolthub/go-icu-regex v0.0.0-20250327004329-6799764f2dad h1:66ZPawHszNu37VPQckdhX1BPPVzREsGgNxQeefnlm3g=
 github.com/dolthub/go-icu-regex v0.0.0-20250327004329-6799764f2dad/go.mod h1:ylU4XjUpsMcvl/BKeRRMXSH7e7WBrPXdSLvnRJYrxEA=
-github.com/dolthub/go-mysql-server v0.19.1-0.20250414233448-814abccc8b6d h1:wDCmc0OCBo1+Bc8jWTdv1Ps8YUg9FcJxdOHlc9ZuRCY=
-github.com/dolthub/go-mysql-server v0.19.1-0.20250414233448-814abccc8b6d/go.mod h1:bOB8AJAqzKtYw/xDA9UININeFU1Il4eYEqSP3lZOqIA=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20240701202509-2b217167d718 h1:lT7hE5k+0nkBdj/1UOSFwjWpNxf+LCApbRHgnCA17XE=
@@ -276,8 +272,6 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216 h1:JWkKRE4EHUcEVQCMRBej8DYxjYjRz/9MdF/NNQh0o70=
 github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216/go.mod h1:e/FIZVvT2IR53HBCAo41NjqgtEnjMJGKca3Y/dAmZaA=
-github.com/dolthub/vitess v0.0.0-20250414165810-f0031a6472b7 h1:4Y043kZgAH1WhOER0nk+02KPKxJX8Ir6yK7cGzY04c4=
-github.com/dolthub/vitess v0.0.0-20250414165810-f0031a6472b7/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/go.sum
+++ b/go.sum
@@ -256,6 +256,8 @@ github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5Xh
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12 h1:IdqX7J8vi/Kn3T3Ee0VzqnLqwFmgA2hr8WZETPcQjfM=
 github.com/dolthub/aws-sdk-go-ini-parser v0.0.0-20250305001723-2821c37f6c12/go.mod h1:rN7X8BHwkjPcfMQQ2QTAq/xM3leUSGLfb+1Js7Y6TVo=
+github.com/dolthub/dolt/go v0.40.5-0.20250417234826-cbc8ae986979 h1:AtvujGDcRYBTSPL0G2IWZdoXOh3S1COdgTyX/o85RPI=
+github.com/dolthub/dolt/go v0.40.5-0.20250417234826-cbc8ae986979/go.mod h1:O4i55d+mBJhvlbUvpz7wZ+YaNWGb41t4KBL/6q+exVo=
 github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20241119094239-f4e529af734d h1:gO9+wrmNHXukPNCO1tpfCcXIdMlW/qppbUStfLvqz/U=
 github.com/dolthub/dolt/go/gen/proto/dolt/services/eventsapi v0.0.0-20241119094239-f4e529af734d/go.mod h1:L5RDYZbC9BBWmoU2+TjTekeqqhFXX5EqH9ln00O0stY=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=
@@ -264,6 +266,8 @@ github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
 github.com/dolthub/go-icu-regex v0.0.0-20250327004329-6799764f2dad h1:66ZPawHszNu37VPQckdhX1BPPVzREsGgNxQeefnlm3g=
 github.com/dolthub/go-icu-regex v0.0.0-20250327004329-6799764f2dad/go.mod h1:ylU4XjUpsMcvl/BKeRRMXSH7e7WBrPXdSLvnRJYrxEA=
+github.com/dolthub/go-mysql-server v0.19.1-0.20250417231730-fcd059390dd6 h1:mqr/9yLWqM8eMxxQ9/ruRpdJmyC6hR0K9AMiafqnLiE=
+github.com/dolthub/go-mysql-server v0.19.1-0.20250417231730-fcd059390dd6/go.mod h1:bOB8AJAqzKtYw/xDA9UININeFU1Il4eYEqSP3lZOqIA=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20240701202509-2b217167d718 h1:lT7hE5k+0nkBdj/1UOSFwjWpNxf+LCApbRHgnCA17XE=
@@ -272,6 +276,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216 h1:JWkKRE4EHUcEVQCMRBej8DYxjYjRz/9MdF/NNQh0o70=
 github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216/go.mod h1:e/FIZVvT2IR53HBCAo41NjqgtEnjMJGKca3Y/dAmZaA=
+github.com/dolthub/vitess v0.0.0-20250414165810-f0031a6472b7 h1:4Y043kZgAH1WhOER0nk+02KPKxJX8Ir6yK7cGzY04c4=
+github.com/dolthub/vitess v0.0.0-20250414165810-f0031a6472b7/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/server/ast/limit.go
+++ b/server/ast/limit.go
@@ -16,11 +16,11 @@ package ast
 
 import (
 	"github.com/cockroachdb/errors"
+	pgexprs "github.com/dolthub/doltgresql/server/expression"
 
 	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/doltgresql/postgres/parser/sem/tree"
-	pgexprs "github.com/dolthub/doltgresql/server/expression"
 )
 
 // nodeLimit handles *tree.Limit nodes.
@@ -44,31 +44,31 @@ func nodeLimit(ctx *Context, node *tree.Limit) (*vitess.Limit, error) {
 	// We need to remove the hard dependency, but for now, we'll just convert our literals to a vitess.SQLVal.
 	if injectedExpr, ok := count.(vitess.InjectedExpr); ok {
 		if literal, ok := injectedExpr.Expression.(*pgexprs.Literal); ok {
-			l := literal.Value()
+			l := literal.LiteralValue()
 			limitValue, err := int64ValueForLimit(l)
 			if err != nil {
 				return nil, err
 			}
-
+	
 			if limitValue < 0 {
 				return nil, errors.Errorf("LIMIT must be greater than or equal to 0")
 			}
-
+	
 			count = literal.ToVitessLiteral()
 		}
 	}
 	if injectedExpr, ok := offset.(vitess.InjectedExpr); ok {
 		if literal, ok := injectedExpr.Expression.(*pgexprs.Literal); ok {
-			o := literal.Value()
+			o := literal.LiteralValue()
 			offsetVal, err := int64ValueForLimit(o)
 			if err != nil {
 				return nil, err
 			}
-
+	
 			if offsetVal < 0 {
 				return nil, errors.Errorf("OFFSET must be greater than or equal to 0")
 			}
-
+	
 			offset = literal.ToVitessLiteral()
 		}
 	}

--- a/server/connection_data.go
+++ b/server/connection_data.go
@@ -113,8 +113,8 @@ func extractBindVarTypes(queryPlan sql.Node) ([]uint32, error) {
 
 	types := make([]uint32, 0)
 	var err error
-	var extractBindVars func(expr sql.Expression) bool
-	extractBindVars = func(expr sql.Expression) bool {
+	var extractBindVars func(n sql.Node, expr sql.Expression) bool
+	extractBindVars = func(n sql.Node, expr sql.Expression) bool {
 		if err != nil {
 			return false
 		}
@@ -122,11 +122,23 @@ func extractBindVarTypes(queryPlan sql.Node) ([]uint32, error) {
 		switch e := expr.(type) {
 		// Subquery doesn't walk its Node child via Expressions, so we must walk it separately here
 		case *plan.Subquery:
-			transform.InspectExpressions(e.Query, extractBindVars)
+			transform.InspectExpressionsWithNode(e.Query, extractBindVars)
 		case *expression.BindVar:
 			var typOid uint32
 			if doltgresType, ok := e.Type().(*pgtypes.DoltgresType); ok {
 				typOid = id.Cache().ToOID(doltgresType.ID.AsId())
+			} else if _, ok := e.Type().(sql.DeferredType); ok {
+				// for a deferred type, we can make a guess to its type based on the containing node
+				switch n.(type) {
+				case *plan.Limit:
+					typOid = uint32(oid.T_int4)
+				default:
+					typOid, err = VitessTypeToObjectID(e.Type().Type())
+					if err != nil {
+						err = errors.Errorf("could not determine OID for placeholder %s: %w", e.Name, err)
+						return false
+					}
+				}
 			} else {
 				// TODO: should remove usage non doltgres type
 				typOid, err = VitessTypeToObjectID(e.Type().Type())
@@ -168,7 +180,7 @@ func extractBindVarTypes(queryPlan sql.Node) ([]uint32, error) {
 		return true
 	}
 
-	transform.InspectExpressions(inspectNode, extractBindVars)
+	transform.InspectExpressionsWithNode(inspectNode, extractBindVars)
 	return types, err
 }
 

--- a/server/connection_data.go
+++ b/server/connection_data.go
@@ -118,7 +118,7 @@ func extractBindVarTypes(queryPlan sql.Node) ([]uint32, error) {
 		if err != nil {
 			return false
 		}
-		
+
 		switch e := expr.(type) {
 		// Subquery doesn't walk its Node child via Expressions, so we must walk it separately here
 		case *plan.Subquery:

--- a/server/connection_handler.go
+++ b/server/connection_handler.go
@@ -510,6 +510,9 @@ func (h *ConnectionHandler) handleParse(message *pgproto3.Parse) error {
 		// NOTE: This is used for Prepared Statement Tests only.
 		bindVarTypes, err = extractBindVarTypes(analyzedPlan)
 		if err != nil {
+			if printErrorStackTraces {
+				fmt.Printf("Error extracting bind var types: %+v\n", err)
+			}
 			return err
 		}
 	}

--- a/server/expression/literal.go
+++ b/server/expression/literal.go
@@ -41,6 +41,7 @@ type Literal struct {
 var _ vitess.Injectable = (*Literal)(nil)
 var _ sql.Expression = (*Literal)(nil)
 var _ framework.LiteralInterface = (*Literal)(nil)
+var _ sql.LiteralExpression = (*Literal)(nil)
 
 // NewNumericLiteral returns a new *Literal containing a NUMERIC value.
 func NewNumericLiteral(numericValue string) (*Literal, error) {
@@ -330,8 +331,8 @@ func (l *Literal) Type() sql.Type {
 	return l.typ
 }
 
-// Value returns the literal value.
-func (l *Literal) Value() any {
+// LiteralValue implements the sql.LiteralExpression interface
+func (l *Literal) LiteralValue() interface{} {
 	return l.value
 }
 

--- a/testing/go/enginetest/doltgres_engine_test.go
+++ b/testing/go/enginetest/doltgres_engine_test.go
@@ -611,6 +611,7 @@ func TestScripts(t *testing.T) {
 		"select * from vt where v = cast('def' as char(6));",                                 // incorrect result
 		"select * from vt where v < cast('def' as char(6));",                                 // incorrect result
 		"select * from vt where v >= cast('def' as char(6));",                                // incorrect result
+		"histogram bucket merging error for implementor buckets",                             // with recursive syntax
 	})
 	defer h.Close()
 	enginetest.TestScripts(t, h)

--- a/testing/go/prepared_statement_test.go
+++ b/testing/go/prepared_statement_test.go
@@ -31,11 +31,9 @@ func TestPreparedPgCatalog(t *testing.T) {
 }
 
 var preparedStatementTests = []ScriptTest{
-
 	{
 		Name: "Expressions without tables",
 		Assertions: []ScriptTestAssertion{
-
 			{
 				Query:    "SELECT CONCAT($1::text, $2::text)",
 				BindVars: []any{"hello", "world"},
@@ -54,15 +52,14 @@ var preparedStatementTests = []ScriptTest{
 	},
 	{
 		Name: "Expressions with tables",
+		Focus: true,
 		Assertions: []ScriptTestAssertion{
 			{
-				Skip:     true, // TODO: expected 0 arguments, got 1
 				Query:    "SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = $1);",
 				BindVars: []any{"public"},
 				Expected: []sql.Row{{1}},
 			},
 			{
-				Skip:     true, // TODO: could not determine OID for placeholder v1: unsupported type: EXPRESSION
 				Query:    "SELECT nspname FROM pg_namespace LIMIT $1;",
 				BindVars: []any{1},
 				Expected: []sql.Row{{"dolt"}},

--- a/testing/go/prepared_statement_test.go
+++ b/testing/go/prepared_statement_test.go
@@ -52,7 +52,6 @@ var preparedStatementTests = []ScriptTest{
 	},
 	{
 		Name: "Expressions with tables",
-		Focus: true,
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = $1);",


### PR DESCRIPTION
This PR fixes issues when using bindvars in a couple different places in certain queries. It introduces a new LiteralExpression so that it GMS and Doltgres implementations of literal values can be used interchangeably during planning and analysis.

Relies on https://github.com/dolthub/go-mysql-server/pull/2946