### PR TITLE
Bug fix for dolt_ tables with incompatible types

### DIFF
--- a/server/expression/gms_cast.go
+++ b/server/expression/gms_cast.go
@@ -15,6 +15,7 @@
 package expression
 
 import (
+	"encoding/json"
 	"math"
 	"time"
 
@@ -167,10 +168,14 @@ func (c *GMSCast) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 		}
 		return newVal, nil
 	case query.Type_JSON:
-		if val, ok := val.(types.JSONDocument); ok {
-			return val.JSONString()
+		if j, ok := val.(types.JSONDocument); ok {
+			return j.JSONString()
+		} else {
+			// TODO: there are particular dolt tables (dolt_constraint_violations) that return json-marshallable structs
+			//  that we need to handle here like this
+			bytes, err := json.Marshal(val)
+			return string(bytes), err
 		}
-		return nil, errors.Errorf("GMSCast expected type `JSONDocument`, got `%T`", val)
 	case query.Type_NULL_TYPE:
 		return nil, nil
 	case query.Type_GEOMETRY:

--- a/testing/go/dolt_tables_test.go
+++ b/testing/go/dolt_tables_test.go
@@ -23,7 +23,7 @@ import (
 func TestUserSpaceDoltTables(t *testing.T) {
 	RunScripts(t, []ScriptTest{
 		{
-			Name:  "dolt branches",
+			Name: "dolt branches",
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT name FROM dolt.branches`,

--- a/testing/go/dolt_tables_test.go
+++ b/testing/go/dolt_tables_test.go
@@ -23,7 +23,8 @@ import (
 func TestUserSpaceDoltTables(t *testing.T) {
 	RunScripts(t, []ScriptTest{
 		{
-			Name: "dolt branches",
+			Name:  "dolt branches",
+			Focus: true,
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT name FROM dolt.branches`,
@@ -106,7 +107,6 @@ func TestUserSpaceDoltTables(t *testing.T) {
 					Expected: []sql.Row{{1}},
 				},
 				{
-					Skip:     true, // this fails because the column type of this table is not a doltgres type, which IN requires
 					Query:    `SELECT "dolt_branches"."name" FROM "dolt_branches" WHERE "dolt_branches"."name" IN ('main') ORDER BY "dolt_branches"."name" DESC LIMIT 21;`,
 					Expected: []sql.Row{{"main"}},
 				},
@@ -1744,8 +1744,8 @@ func TestUserSpaceDoltTables(t *testing.T) {
 				},
 			},
 		},
-		//TODO: turn on statistics
-		//{
+		// TODO: turn on statistics
+		// {
 		//	Name: "dolt statistics",
 		//	SetUpScript: []string{
 		//		"CREATE TABLE horses (id int primary key, name varchar(10));",
@@ -1871,7 +1871,7 @@ func TestUserSpaceDoltTables(t *testing.T) {
 		//			Expected: []sql.Row{{"horses", "horses_name_idx"}, {"horses", "primary"}},
 		//		},
 		//	},
-		//},
+		// },
 		{
 			Name: "dolt status",
 			SetUpScript: []string{

--- a/testing/go/dolt_tables_test.go
+++ b/testing/go/dolt_tables_test.go
@@ -24,7 +24,6 @@ func TestUserSpaceDoltTables(t *testing.T) {
 	RunScripts(t, []ScriptTest{
 		{
 			Name:  "dolt branches",
-			Focus: true,
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT name FROM dolt.branches`,
@@ -555,7 +554,7 @@ func TestUserSpaceDoltTables(t *testing.T) {
 				},
 				{
 					Query:    `SELECT * FROM dolt_conflicts`,
-					Expected: []sql.Row{{"test", Numeric("1")}},
+					Expected: []sql.Row{{"test", 1}},
 				},
 				{
 					Query:    `SELECT dolt.conflicts.table FROM dolt.conflicts`,
@@ -763,7 +762,7 @@ func TestUserSpaceDoltTables(t *testing.T) {
 				},
 				{
 					Query:    `SELECT * FROM dolt_constraint_violations`,
-					Expected: []sql.Row{{"test", Numeric("2")}},
+					Expected: []sql.Row{{"test", 2}},
 				},
 				{
 					Query:    `SELECT dolt.constraint_violations.table FROM dolt.constraint_violations`,


### PR DESCRIPTION
Fixes https://github.com/dolthub/doltgresql/issues/1405

This works by placing a typecast on unconverted dolt_ table fields so that they work in any expression that requires a doltgresType.