### PR TITLE
Fixed interpretation calls within DML

### DIFF
--- a/server/plpgsql/interpreter_logic.go
+++ b/server/plpgsql/interpreter_logic.go
@@ -37,7 +37,7 @@ type InterpretedFunction interface {
 	GetParameterNames() []string
 	GetReturn() *pgtypes.DoltgresType
 	GetStatements() []InterpreterOperation
-	QueryMultiReturn(ctx *sql.Context, stack InterpreterStack, stmt string, bindings []string) (rowIter sql.RowIter, err error)
+	QueryMultiReturn(ctx *sql.Context, stack InterpreterStack, stmt string, bindings []string) (rows []sql.Row, err error)
 	QuerySingleReturn(ctx *sql.Context, stack InterpreterStack, stmt string, targetType *pgtypes.DoltgresType, bindings []string) (val any, err error)
 }
 
@@ -141,11 +141,8 @@ func Call(ctx *sql.Context, iFunc InterpretedFunction, runner analyzer.Statement
 					return nil, err
 				}
 			} else {
-				rowIter, err := iFunc.QueryMultiReturn(ctx, stack, operation.PrimaryData, operation.SecondaryData)
+				_, err := iFunc.QueryMultiReturn(ctx, stack, operation.PrimaryData, operation.SecondaryData)
 				if err != nil {
-					return nil, err
-				}
-				if _, err = sql.RowIterToRows(ctx, rowIter); err != nil {
 					return nil, err
 				}
 			}
@@ -185,11 +182,8 @@ func Call(ctx *sql.Context, iFunc InterpretedFunction, runner analyzer.Statement
 		case OpCode_InsertInto:
 			// TODO: implement
 		case OpCode_Perform:
-			rowIter, err := iFunc.QueryMultiReturn(ctx, stack, operation.PrimaryData, operation.SecondaryData)
+			_, err := iFunc.QueryMultiReturn(ctx, stack, operation.PrimaryData, operation.SecondaryData)
 			if err != nil {
-				return nil, err
-			}
-			if _, err = sql.RowIterToRows(ctx, rowIter); err != nil {
 				return nil, err
 			}
 		case OpCode_Raise:

--- a/testing/go/create_function_test.go
+++ b/testing/go/create_function_test.go
@@ -808,5 +808,33 @@ $$ LANGUAGE plpgsql;`,
 				},
 			},
 		},
+		{
+			Name: "INSERT values from function",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 TEXT);",
+				`CREATE FUNCTION insertion_text() RETURNS TEXT AS $$
+        DECLARE
+            var1 TEXT;
+        BEGIN
+            var1 := 'example';
+            RETURN var1;
+        END;
+        $$ LANGUAGE plpgsql;
+        `,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    "INSERT INTO test VALUES (insertion_text()), (insertion_text());",
+					Expected: []sql.Row{},
+				},
+				{
+					Query: "SELECT * FROM test;",
+					Expected: []sql.Row{
+						{"example"},
+						{"example"},
+					},
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
This implements the changes necessitated by the following fix:
* https://github.com/dolthub/go-mysql-server/pull/2949

We had a bug where calls to any DML statements that included an interpreted function would remove the DML's ability to actually affect the data. The GMS PR implements the core fix, and this PR implements the companion changes.