### PR TITLE
Fix dolthub/dolt#483 - add skip for remote tracking branch and table same name test

### DIFF
--- a/testing/go/enginetest/doltgres_engine_test.go
+++ b/testing/go/enginetest/doltgres_engine_test.go
@@ -1366,6 +1366,7 @@ func TestDoltCheckout(t *testing.T) {
 		"Checkout tables from commit",
 		"dolt_checkout with new branch forcefully",                        // string primary key ordering broken
 		"dolt_checkout with new branch forcefully with dirty working set", // string primary key ordering broken
+		"dolt_checkout with tracking branch and table with same name",     // UseLocalFileSystem did not create remote dir
 	})
 	denginetest.RunDoltCheckoutTests(t, h)
 }


### PR DESCRIPTION
Fixes dolthub/dolt#483
Add skip for test since `doltgres` harness does not create remote dir with `h.UseLocalFileSystem()`