### PR TITLE
Removed wasteful engine instantiation

### DIFF
--- a/server/functions/iterate.go
+++ b/server/functions/iterate.go
@@ -21,7 +21,6 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqlserver"
-	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/core"

--- a/server/functions/iterate.go
+++ b/server/functions/iterate.go
@@ -413,7 +413,7 @@ func RunCallback(ctx *sql.Context, internalID id.Id, callbacks Callbacks) error 
 	if err != nil {
 		return err
 	}
-	
+
 	if currentSchemaDatabase, ok := currentDatabase.(sql.SchemaDatabase); ok {
 		schemas, err := currentSchemaDatabase.AllSchemas(ctx)
 		if err != nil {

--- a/server/functions/iterate.go
+++ b/server/functions/iterate.go
@@ -410,10 +410,11 @@ func RunCallback(ctx *sql.Context, internalID id.Id, callbacks Callbacks) error 
 	}
 	// We know we have the relevant callback for the given section, so we'll grab the schema
 	doltSession := dsess.DSessFromSess(ctx.Session)
-	currentDatabase, err := sqle.NewDefault(doltSession.Provider()).Analyzer.Catalog.Database(ctx, ctx.GetCurrentDatabase())
+	currentDatabase, err := doltSession.Provider().Database(ctx, ctx.GetCurrentDatabase())
 	if err != nil {
 		return err
 	}
+	
 	if currentSchemaDatabase, ok := currentDatabase.(sql.SchemaDatabase); ok {
 		schemas, err := currentSchemaDatabase.AllSchemas(ctx)
 		if err != nil {


### PR DESCRIPTION
This takes 30% or more off pg_catalog accesses. Before:

<img width="1596" height="1053" alt="image" src="https://github.com/user-attachments/assets/3b904eb0-95a1-4e00-afcb-3eaf0a5ead61" />

After:
<img width="1601" height="913" alt="image" src="https://github.com/user-attachments/assets/af9432a7-3928-4ad2-a94f-bbd80b9c60f4" />
