### PR TITLE
Fix binary encoded bind vars

### DIFF
--- a/testing/go/framework.go
+++ b/testing/go/framework.go
@@ -730,6 +730,41 @@ func Numeric(str string) pgtype.Numeric {
 	return numeric
 }
 
+// Timestamp is a helper function to convert timestamp strings to pgtype.Timestamp instances. If
+// the string cannot be converted, this function will panic.
+func Timestamp(timestampStr string) (ret pgtype.Timestamp) {
+	t, err := time.Parse("2006-01-02 15:04:05", timestampStr)
+	if err != nil {
+		panic("invalid timestamp format: " + err.Error())
+	}
+	if err := ret.Scan(t); err != nil {
+		panic("failed to set pgtype.Timestamp: " + err.Error())
+	}
+	return ret
+}
+
+// Date is a helper function to convert date strings to pgtype.Date instances. If the string
+// cannot be converted, this function will panic.
+func Date(dateStr string) (d pgtype.Date) {
+	t, err := time.Parse("2006-01-02", dateStr)
+	if err != nil {
+		panic("invalid date format: " + err.Error())
+	}
+	if err := d.Scan(t); err != nil {
+		panic("failed to set pgtype.Date: " + err.Error())
+	}
+	return d
+}
+
+// UUID is a helper function to convert UUID strings to pgtype.UUID instances. If the string
+// cannot be converted, this function will panic.
+func UUID(s string) (u pgtype.UUID) {
+	if err := u.Scan(s); err != nil {
+		panic(err)
+	}
+	return u
+}
+
 // Connect replaces the Current connection with a new one, using the given username and password. If the username is
 // empty, then the default connection is used. If the username and password match the existing connection, then no new
 // connection is made.


### PR DESCRIPTION
Bind vars can be specified in a string format or a binary format. The library Doltgres uses for decoding the bind vars (`pgtype`) errors out when converting some types in binary format to string format. The error looks like: `cannot scan timestamp (OID 1114) in binary format into *string`.

As part of fixing `timestamp`, I also found that `date` and `bool` needed special handling, too, and I updated our prepared statement tests with more type coverage and to ensure we hit both the string format and binary format bind var code paths.

Fixes: https://github.com/dolthub/doltgresql/issues/1419