### PR TITLE
dolthub/doltgresql#1708 - Fix query converter crash on boolean literals

### DIFF
--- a/testing/PostgresDockerfile
+++ b/testing/PostgresDockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ubuntu:20.04
+FROM --platform=linux/amd64 ubuntu:22.04
 
 # install python, java, bats, git ruby, perl, cpan
 ENV DEBIAN_FRONTEND=noninteractive

--- a/testing/go/enginetest/query_converter_test.go
+++ b/testing/go/enginetest/query_converter_test.go
@@ -1561,7 +1561,7 @@ func TestBoolValSupport(t *testing.T) {
 	// Before the fix: panics with "unhandled type: sqlparser.BoolVal"
 	// After the fix: should convert successfully without panic
 	result := convertQuery("CREATE TABLE test_table (id INT, archived BOOLEAN DEFAULT FALSE)")
-	
+
 	// Should not panic and should return converted query
 	require.NotEmpty(t, result, "Query conversion should succeed and return converted SQL")
 	require.Len(t, result, 1, "Should return exactly one converted statement")


### PR DESCRIPTION
Fixes dolthub/doltgresql#1708
Query converter was panicking with "unhandled type: sqlparser.BoolVal" when encountering boolean literals like FALSE in CREATE TABLE statements. This was blocking UNION column mapping tests from dolthub/dolt#9628. Postgres CI docker container is also end of life, switched next LTS ver of Ubuntu 22.04.