### PR TITLE
dolthub/dolt#9641 - Add BIT type support for UNION query compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/dolthub/eventsapi_schema v0.0.0-20250725194025-a087efa1ee55
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
 	github.com/dolthub/go-icu-regex v0.0.0-20250327004329-6799764f2dad
-	github.com/dolthub/go-mysql-server v0.20.1-0.20250807172251-c76b4ab0b9c8
+	github.com/dolthub/go-mysql-server v0.20.1-0.20250808203856-b2556a731d9b
 	github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216
 	github.com/dolthub/vitess v0.0.0-20250730174048-497aebb8cea7
 	github.com/fatih/color v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -285,6 +285,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20250327004329-6799764f2dad h1:66ZPawHszN
 github.com/dolthub/go-icu-regex v0.0.0-20250327004329-6799764f2dad/go.mod h1:ylU4XjUpsMcvl/BKeRRMXSH7e7WBrPXdSLvnRJYrxEA=
 github.com/dolthub/go-mysql-server v0.20.1-0.20250807172251-c76b4ab0b9c8 h1:MRwXXSGmTxG2nNQzWeFs4AOevCpn6fTVdrDX5+1rZhM=
 github.com/dolthub/go-mysql-server v0.20.1-0.20250807172251-c76b4ab0b9c8/go.mod h1:D/E/y9q6i4mryN12JhvaKlFZnSSWD1X1tx+CFsUcgp8=
+github.com/dolthub/go-mysql-server v0.20.1-0.20250808203856-b2556a731d9b h1:tpo0kv/l8grlUujwUnZ00fL9RX3SdcWJWrqbh7LL7o4=
+github.com/dolthub/go-mysql-server v0.20.1-0.20250808203856-b2556a731d9b/go.mod h1:D/E/y9q6i4mryN12JhvaKlFZnSSWD1X1tx+CFsUcgp8=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20240701202509-2b217167d718 h1:lT7hE5k+0nkBdj/1UOSFwjWpNxf+LCApbRHgnCA17XE=


### PR DESCRIPTION
Add BIT type conversion support to doltgres query converter to enable compatibility with go-mysql-server UNION regression tests.
Companion dolthub/go-mysql-server#3148