### PR TITLE
Added SQL import testing framework

### DIFF
--- a/core/extensions/pg_extension/library_loader_windows.go
+++ b/core/extensions/pg_extension/library_loader_windows.go
@@ -85,7 +85,7 @@ func loadLibraryInternal(path string) (InternalLoadedLibrary, error) {
 					dllSha := sha256.Sum256(dllBytes)
 					extDllSha := sha256.New()
 					_, _ = io.Copy(extDllSha, extDll)
-					shouldWriteFiles = bytes.Compare(extDllSha.Sum(nil), dllSha[:]) != 0
+					shouldWriteFiles = !bytes.Equal(extDllSha.Sum(nil), dllSha[:])
 				}()
 			}
 			if shouldWriteFiles {

--- a/testing/dumps/intercept.go
+++ b/testing/dumps/intercept.go
@@ -1,0 +1,240 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dumps
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dolthub/go-mysql-server/server"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/jackc/pgx/v5/pgproto3"
+	"github.com/stretchr/testify/require"
+)
+
+// ImportQueryError contains both a query and its associated error.
+type ImportQueryError struct {
+	Query string
+	Error string
+}
+
+// InterceptImportMessages sits between PSQL and Doltgres, returning all error messages that are encountered. As we rely
+// on PSQL to handle the import process, we normally wouldn't be able to associate error messages with queries, as this
+// information is not returned by PSQL itself. Therefore, we create our own connection to Doltgres, and a server that
+// PSQL listens to. We then forward everything from PSQL to Doltgres, while inspecting the messages as they come and go.
+func InterceptImportMessages(t *testing.T, doltgresPort int, breakpointQueries []string, triggerBreakpoint func(string)) (int, chan ImportQueryError) {
+	psqlPort, err := sql.GetEmptyPort()
+	require.NoError(t, err)
+	qeChan := make(chan ImportQueryError)
+	listener, err := server.NewListener("tcp", fmt.Sprintf("127.0.0.1:%d", psqlPort), "")
+	if err != nil {
+		t.Fatal(err)
+		return psqlPort, qeChan
+	}
+	timer := time.NewTimer(5 * time.Second)
+	timer.Stop()
+	go func() {
+		<-timer.C
+		_ = listener.Close()
+	}()
+
+	go func() {
+		for {
+			psqlConn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			timer.Stop()
+			terminate := &sync.WaitGroup{}
+			terminate.Add(1)
+			psqlConnBackend := pgproto3.NewBackend(psqlConn, psqlConn)
+			doltgresConn, err := (&net.Dialer{}).Dial("tcp", fmt.Sprintf("127.0.0.1:%d", doltgresPort))
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			doltgresConnFrontend := pgproto3.NewFrontend(doltgresConn, doltgresConn)
+
+			if err = handleStartup(t, psqlConnBackend, doltgresConnFrontend, psqlConn); err != nil {
+				fmt.Println(err)
+				return
+			}
+			createPassthrough(qeChan, terminate, psqlConnBackend, doltgresConnFrontend, triggerBreakpoint, breakpointQueries)
+			terminate.Wait()
+			_ = psqlConn.Close()
+			_ = doltgresConn.Close()
+			timer.Reset(5 * time.Second)
+		}
+	}()
+	return psqlPort, qeChan
+}
+
+// handleStartup handles the startup messages.
+func handleStartup(t *testing.T, psqlConnBackend *pgproto3.Backend, doltgresConnFrontend *pgproto3.Frontend, clientConn net.Conn) error {
+StartupLoop:
+	for {
+		startupMessage, err := psqlConnBackend.ReceiveStartupMessage()
+		if err != nil {
+			return err
+		}
+		switch startupMessage := startupMessage.(type) {
+		case *pgproto3.SSLRequest:
+			if _, err = clientConn.Write([]byte{'N'}); err != nil {
+				return err
+			}
+		case *pgproto3.StartupMessage:
+			doltgresConnFrontend.Send(startupMessage)
+			if err = doltgresConnFrontend.Flush(); err != nil {
+				return err
+			}
+			response, err := doltgresConnFrontend.Receive()
+			if err != nil {
+				return err
+			}
+			if err = setAuthType(psqlConnBackend, response); err != nil {
+				return err
+			}
+			psqlConnBackend.Send(response)
+			if err = psqlConnBackend.Flush(); err != nil {
+				return err
+			}
+			break StartupLoop
+		default:
+			t.Fatalf("unexpected startup message: %v", startupMessage)
+		}
+	}
+	return nil
+}
+
+// setAuthType sets the client's authentication type depending on the message received from the server. This is
+// necessary, as the client needs the proper context to know how to parse the returned messages.
+func setAuthType(clientConnBackend *pgproto3.Backend, message pgproto3.BackendMessage) error {
+	switch message.(type) {
+	case *pgproto3.AuthenticationOk:
+		return clientConnBackend.SetAuthType(pgproto3.AuthTypeOk)
+	case *pgproto3.AuthenticationCleartextPassword:
+		return clientConnBackend.SetAuthType(pgproto3.AuthTypeCleartextPassword)
+	case *pgproto3.AuthenticationMD5Password:
+		return clientConnBackend.SetAuthType(pgproto3.AuthTypeMD5Password)
+	case *pgproto3.AuthenticationGSS:
+		return clientConnBackend.SetAuthType(pgproto3.AuthTypeGSS)
+	case *pgproto3.AuthenticationGSSContinue:
+		return clientConnBackend.SetAuthType(pgproto3.AuthTypeGSSCont)
+	case *pgproto3.AuthenticationSASL:
+		return clientConnBackend.SetAuthType(pgproto3.AuthTypeSASL)
+	case *pgproto3.AuthenticationSASLContinue:
+		return clientConnBackend.SetAuthType(pgproto3.AuthTypeSASLContinue)
+	case *pgproto3.AuthenticationSASLFinal:
+		return clientConnBackend.SetAuthType(pgproto3.AuthTypeSASLFinal)
+	default:
+		return nil
+	}
+}
+
+// createPassthrough creates the go routines that will read from and write to the connections.
+func createPassthrough(qeChan chan ImportQueryError, terminate *sync.WaitGroup, psqlConnBackend *pgproto3.Backend, doltgresConnFrontend *pgproto3.Frontend, triggerBreakpoint func(string), breakpointQueries []string) {
+	lastQuery := ""
+	writeMutex := &sync.Mutex{}
+	go func() {
+		defer terminate.Done()
+		for {
+			psqlMessage, err := psqlConnBackend.Receive()
+			if err != nil {
+				errStr := err.Error()
+				if errStr != "unexpected EOF" && !strings.HasSuffix(errStr, "use of closed network connection") {
+					fmt.Println(err)
+				}
+				return
+			}
+			switch msg := psqlMessage.(type) {
+			case *pgproto3.Query:
+				writeMutex.Lock()
+				if len(lastQuery) == 0 {
+					lastQuery = msg.String
+				}
+				writeMutex.Unlock()
+				for _, query := range breakpointQueries {
+					if strings.HasPrefix(msg.String, query) {
+						triggerBreakpoint(msg.String)
+						break
+					}
+				}
+			case *pgproto3.Terminate:
+				return
+			}
+			doltgresConnFrontend.Send(psqlMessage)
+			if err = doltgresConnFrontend.Flush(); err != nil {
+				errStr := err.Error()
+				if errStr != "unexpected EOF" && !strings.HasSuffix(errStr, "use of closed network connection") {
+					fmt.Println(err)
+				}
+				return
+			}
+		}
+	}()
+	go func() {
+		for {
+			doltgresMessage, err := doltgresConnFrontend.Receive()
+			if err != nil {
+				errStr := err.Error()
+				if errStr != "unexpected EOF" &&
+					!strings.HasSuffix(errStr, "use of closed network connection") &&
+					!strings.HasSuffix(errStr, "An existing connection was forcibly closed by the remote host.") {
+					fmt.Println(err)
+				}
+				return
+			}
+			switch msg := doltgresMessage.(type) {
+			case *pgproto3.ErrorResponse:
+				writeMutex.Lock()
+				if len(lastQuery) == 0 {
+					qeChan <- ImportQueryError{
+						Query: "UNKNOWN QUERY HAS ERRORED",
+						Error: msg.Message,
+					}
+				} else {
+					qeChan <- ImportQueryError{
+						Query: lastQuery,
+						Error: msg.Message,
+					}
+				}
+				writeMutex.Unlock()
+			case *pgproto3.ReadyForQuery:
+				writeMutex.Lock()
+				lastQuery = ""
+				writeMutex.Unlock()
+			default:
+				if err = setAuthType(psqlConnBackend, doltgresMessage); err != nil {
+					fmt.Println(err)
+					return
+				}
+			}
+			psqlConnBackend.Send(doltgresMessage)
+			if err = psqlConnBackend.Flush(); err != nil {
+				errStr := err.Error()
+				if errStr != "unexpected EOF" &&
+					!strings.HasSuffix(errStr, "use of closed network connection") &&
+					!strings.HasSuffix(errStr, "An existing connection was forcibly closed by the remote host.") {
+					fmt.Println(err)
+				}
+				return
+			}
+		}
+	}()
+}

--- a/testing/go/import_dumps_test.go
+++ b/testing/go/import_dumps_test.go
@@ -1,0 +1,179 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _go
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/doltgresql/testing/dumps"
+)
+
+func TestImportingDumps(t *testing.T) {
+	t.Skip("Currently here for demonstration")
+	RunImportTests(t, []ImportTest{
+		{
+			Name: "Example",
+			SetUpScript: []string{
+				"CREATE USER test WITH SUPERUSER PASSWORD 'password';",
+			},
+			Breakpoints: []string{"CREATE TABLE public.table_name"},
+			SQLFilename: "file.sql",
+		},
+	})
+}
+
+// TriggerImportBreakpoint exists so that a breakpoint may be set within the function, on the unused Sprintf. This
+// function is called whenever a query matches one of the breakpoint queries defined in the import test. This enables us
+// to simulate some kind of breakpoint functionality on import queries, which isn't normally possible.
+func TriggerImportBreakpoint(breakpointQuery string) {
+	// It doesn't actually matter what this function is. It's just here so we can set a breakpoint on something.
+	_ = fmt.Sprintf("__%s", breakpointQuery)
+}
+
+// ImportTest is a test for importing SQL dumps.
+type ImportTest struct {
+	Name        string
+	SetUpScript []string
+	Focus       bool
+	Skip        bool
+	SQLFilename string
+	// Breakpoints allow for triggering breakpoints when any matching queries are given. A breakpoint must be set within
+	// TriggerImportBreakpoint for this to work.
+	Breakpoints []string
+}
+
+// RunImportTests runs the given ImportTest scripts.
+func RunImportTests(t *testing.T, scripts []ImportTest) {
+	var psqlCommand string
+	switch runtime.GOOS {
+	case "windows":
+		psqlCommand = "psql.exe"
+	default:
+		psqlCommand = "psql"
+	}
+	// Check if PSQL runs directly
+	var outBuffer bytes.Buffer
+	cmd := exec.Command(psqlCommand, "--version")
+	cmd.Stdout = &outBuffer
+	if !assert.NoError(t, cmd.Run()) || !strings.Contains(outBuffer.String(), "PostgreSQL") {
+		// We could not run PSQL and get the version, so it must not be in the path.
+		// We'll check if pg_config is in the path and reference the binary directly.
+		outBuffer.Reset()
+		cmd = exec.Command("pg_config", "--bindir")
+		cmd.Stdout = &outBuffer
+		if !assert.NoError(t, cmd.Run()) {
+			require.Fail(t, "Postgres is not installed, cannot run tests")
+		}
+		psqlCommand = filepath.Join(strings.TrimSpace(outBuffer.String()), psqlCommand)
+		// pg_config is in the path, so we'll try and run PSQL by directly referencing the binary
+		outBuffer.Reset()
+		cmd = exec.Command(psqlCommand, "--version")
+		cmd.Stdout = &outBuffer
+		if !assert.NoError(t, cmd.Run()) || !strings.Contains(outBuffer.String(), "PostgreSQL") {
+			t.Fatalf("PSQL cannot be found at: `%s`", psqlCommand)
+		}
+	}
+	// Grab the folder with the files to import
+	_, currentFileLocation, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("Unable to find the folder where the files to import are located")
+	}
+	dumpsFolder := filepath.Clean(filepath.Join(filepath.Dir(currentFileLocation), "../dumps/"))
+	// Set whether we're checking Focus-only scripts or not
+	useFocus := false
+	for _, script := range scripts {
+		if script.Focus {
+			// If this is running in GitHub Actions, then we'll panic, because someone forgot to disable it before committing
+			if _, ok := os.LookupEnv("GITHUB_ACTION"); ok {
+				panic(fmt.Sprintf("The script `%s` has Focus set to `true`. GitHub Actions requires that "+
+					"all tests are run, which Focus circumvents, leading to this error. Please disable Focus on "+
+					"all tests.", script.Name))
+			}
+			useFocus = true
+			break
+		}
+	}
+	for _, script := range scripts {
+		if useFocus != script.Focus {
+			continue
+		}
+		RunImportTest(t, script, psqlCommand, dumpsFolder)
+	}
+}
+
+// RunImportTest runs the given ImportTest script.
+func RunImportTest(t *testing.T, script ImportTest, psqlCommand string, dumpsFolder string) {
+	// TODO: handle other dump types, such as those that require pg_restore
+	t.Run(script.Name, func(t *testing.T) {
+		// Mark this test as skipped if we have it set
+		if script.Skip {
+			t.Skip()
+		}
+		// Create the in-memory server that we'll test against
+		port, err := sql.GetEmptyPort()
+		require.NoError(t, err)
+		ctx, conn, controller := CreateServerWithPort(t, "postgres", port)
+		func() {
+			defer conn.Close(ctx)
+			for _, query := range script.SetUpScript {
+				_, err = conn.Exec(ctx, query)
+				require.NoError(t, err)
+			}
+		}()
+		defer func() {
+			controller.Stop()
+			err := controller.WaitForStop()
+			require.NoError(t, err)
+		}()
+		// Create the message interceptor
+		var qeChan chan dumps.ImportQueryError
+		port, qeChan = dumps.InterceptImportMessages(t, port, script.Breakpoints, TriggerImportBreakpoint)
+		defer close(qeChan)
+		var allErrors []dumps.ImportQueryError
+		go func() {
+			for chanErr := range qeChan {
+				allErrors = append(allErrors, chanErr)
+			}
+		}()
+		// Run the import
+		var outBuffer bytes.Buffer
+		var errBuffer bytes.Buffer
+		cmd := exec.Command(psqlCommand, fmt.Sprintf("postgresql://postgres:password@localhost:%d/postgres?sslmode=disable", port))
+		cmd.Stdout = &outBuffer
+		cmd.Stderr = &errBuffer
+		targetFile, err := os.Open(filepath.Join(dumpsFolder, "sql", script.SQLFilename))
+		require.NoError(t, err)
+		cmd.Stdin = targetFile
+		require.NoError(t, cmd.Run())
+		if len(allErrors) > 0 {
+			// If we have more than some threshold, then we'll only show the first few for ease of consumption
+			for i := 0; i < len(allErrors) && i < 10; i++ {
+				t.Logf("QUERY: %s\nERROR: %s", allErrors[i].Query, allErrors[i].Error)
+			}
+			t.FailNow()
+		}
+	})
+}


### PR DESCRIPTION
One thing that we'll be adding is tests to ensure that imports from all over not only work in Doltgres, but continue to work. To achieve this, this PR adds a new framework that allows us to specify files that will be imported, as well as allowing for any needed setup that an import may need (such as user creation). Additionally, as import files may be very, very large, we needed a good way to attach errors to their origin queries. This framework gives an experience that is as close to standard Go debugging as we can get, considering imports must be done through PSQL (or `pg_restore`, which isn't supported yet, but would function _very_ similarly to the PSQL path).

To reiterate, this gives us:
* Focus capability on specific dumps
* Error reporting for associating errors with queries
* Breakpoint triggers for specific queries
* Repeatable testing to ensure import compatibility doesn't regress