### PR TITLE
Fixed INDEX reservation

### DIFF
--- a/postgres/parser/parser/sql.y
+++ b/postgres/parser/parser/sql.y
@@ -15305,7 +15305,6 @@ reserved_keyword:
 // Adding keywords here creates non-resolvable incompatibilities with
 // postgres clients.
 cockroachdb_extra_reserved_keyword:
-  INDEX
-| NOTHING
+  NOTHING
 
 %%

--- a/testing/go/import_dumps_test.go
+++ b/testing/go/import_dumps_test.go
@@ -169,6 +169,7 @@ func RunImportTest(t *testing.T, script ImportTest, psqlCommand string, dumpsFol
 		cmd.Stdin = targetFile
 		require.NoError(t, cmd.Run())
 		if len(allErrors) > 0 {
+			t.Logf("COUNT: %d", len(allErrors))
 			// If we have more than some threshold, then we'll only show the first few for ease of consumption
 			for i := 0; i < len(allErrors) && i < 10; i++ {
 				t.Logf("QUERY: %s\nERROR: %s", allErrors[i].Query, allErrors[i].Error)

--- a/testing/go/smoke_test.go
+++ b/testing/go/smoke_test.go
@@ -792,5 +792,34 @@ func TestSmokeTests(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "INDEX as column name",
+			SetUpScript: []string{
+				`CREATE TABLE test1 (index INT4, CONSTRAINT index_constraint1 CHECK ((index >= 0)));`,
+				`CREATE TABLE test2 ("IndeX" INT4, CONSTRAINT index_constraint2 CHECK (("IndeX" >= 0)));`,
+				`INSERT INTO test1 VALUES (1);`,
+				`INSERT INTO test2 VALUES (2);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:            `SELECT * FROM test1;`,
+					ExpectedColNames: []string{"index"},
+					Expected:         []sql.Row{{1}},
+				},
+				{
+					Query:            `SELECT * FROM test2;`,
+					ExpectedColNames: []string{"IndeX"},
+					Expected:         []sql.Row{{2}},
+				},
+				{
+					Query:       `INSERT INTO test1 VALUES (-1);`,
+					ExpectedErr: "index_constraint1",
+				},
+				{
+					Query:       `INSERT INTO test2 VALUES (-1);`,
+					ExpectedErr: "index_constraint2",
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
This removes the reservation on `INDEX`. Postgres doesn't have it and we have customers who have columns named `index`, so this allows them to import those tables without modifying their dumps.