### PR TITLE
Fixed INDEX reservation

### DIFF
--- a/postgres/parser/parser/sql.y
+++ b/postgres/parser/parser/sql.y
@@ -10902,21 +10902,6 @@ sortby:
       NullsOrder: nullsOrder,
     }
   }
-| PRIMARY KEY table_name opt_asc_desc
-  {
-    name := $3.unresolvedObjectName().ToTableName()
-    $$.val = &tree.Order{OrderType: tree.OrderByIndex, Direction: $4.dir(), Table: name}
-  }
-| INDEX table_name '@' index_name opt_asc_desc
-  {
-    name := $2.unresolvedObjectName().ToTableName()
-    $$.val = &tree.Order{
-      OrderType: tree.OrderByIndex,
-      Direction: $5.dir(),
-      Table:     name,
-      Index:     tree.UnrestrictedName($4),
-    }
-  }
 
 opt_nulls_order:
   NULLS FIRST
@@ -15131,6 +15116,7 @@ col_name_keyword:
 | IF
 | IFERROR
 | IFNULL
+| INDEX
 | INOUT
 | INT
 | INTEGER
@@ -15305,7 +15291,6 @@ reserved_keyword:
 // Adding keywords here creates non-resolvable incompatibilities with
 // postgres clients.
 cockroachdb_extra_reserved_keyword:
-  INDEX
-| NOTHING
+  NOTHING
 
 %%

--- a/postgres/parser/sem/tree/pretty.go
+++ b/postgres/parser/sem/tree/pretty.go
@@ -1174,22 +1174,6 @@ func (node *Order) doc(p *PrettyCfg) pretty.Doc {
 	var d pretty.Doc
 	if node.OrderType == OrderByColumn {
 		d = p.Doc(node.Expr)
-	} else {
-		if node.Index == "" {
-			d = pretty.ConcatSpace(
-				pretty.Keyword("PRIMARY KEY"),
-				p.Doc(&node.Table),
-			)
-		} else {
-			d = pretty.ConcatSpace(
-				pretty.Keyword("INDEX"),
-				pretty.Fold(pretty.Concat,
-					p.Doc(&node.Table),
-					pretty.Text("@"),
-					p.Doc(&node.Index),
-				),
-			)
-		}
 	}
 	if node.Direction != DefaultDirection {
 		d = p.nestUnder(d, pretty.Text(node.Direction.String()))

--- a/postgres/parser/sem/tree/select.go
+++ b/postgres/parser/sem/tree/select.go
@@ -659,8 +659,6 @@ type OrderType int
 const (
 	// OrderByColumn is the regular "by expression/column" ORDER BY specification.
 	OrderByColumn OrderType = iota
-	// OrderByIndex enables the user to specify a given index' columns implicitly.
-	OrderByIndex
 )
 
 // Order represents an ordering expression.
@@ -669,26 +667,12 @@ type Order struct {
 	Expr       Expr
 	Direction  Direction
 	NullsOrder NullsOrder
-	// Table/Index replaces Expr when OrderType = OrderByIndex.
-	Table TableName
-	// If Index is empty, then the order should use the primary key.
-	Index UnrestrictedName
 }
 
 // Format implements the NodeFormatter interface.
 func (node *Order) Format(ctx *FmtCtx) {
 	if node.OrderType == OrderByColumn {
 		ctx.FormatNode(node.Expr)
-	} else {
-		if node.Index == "" {
-			ctx.WriteString("PRIMARY KEY ")
-			ctx.FormatNode(&node.Table)
-		} else {
-			ctx.WriteString("INDEX ")
-			ctx.FormatNode(&node.Table)
-			ctx.WriteByte('@')
-			ctx.FormatNode(&node.Index)
-		}
 	}
 	if node.Direction != DefaultDirection {
 		ctx.WriteByte(' ')
@@ -703,8 +687,7 @@ func (node *Order) Format(ctx *FmtCtx) {
 // Equal checks if the node ordering is equivalent to other.
 func (node *Order) Equal(other *Order) bool {
 	return node.Expr.String() == other.Expr.String() && node.Direction == other.Direction &&
-		node.Table == other.Table && node.OrderType == other.OrderType &&
-		node.NullsOrder == other.NullsOrder
+		node.OrderType == other.OrderType && node.NullsOrder == other.NullsOrder
 }
 
 // Limit represents a LIMIT clause.

--- a/testing/go/import_dumps_test.go
+++ b/testing/go/import_dumps_test.go
@@ -169,6 +169,7 @@ func RunImportTest(t *testing.T, script ImportTest, psqlCommand string, dumpsFol
 		cmd.Stdin = targetFile
 		require.NoError(t, cmd.Run())
 		if len(allErrors) > 0 {
+			t.Logf("COUNT: %d", len(allErrors))
 			// If we have more than some threshold, then we'll only show the first few for ease of consumption
 			for i := 0; i < len(allErrors) && i < 10; i++ {
 				t.Logf("QUERY: %s\nERROR: %s", allErrors[i].Query, allErrors[i].Error)

--- a/testing/go/smoke_test.go
+++ b/testing/go/smoke_test.go
@@ -792,5 +792,34 @@ func TestSmokeTests(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "INDEX as column name",
+			SetUpScript: []string{
+				`CREATE TABLE test1 (index INT4, CONSTRAINT index_constraint1 CHECK ((index >= 0)));`,
+				`CREATE TABLE test2 ("IndeX" INT4, CONSTRAINT index_constraint2 CHECK (("IndeX" >= 0)));`,
+				`INSERT INTO test1 VALUES (1);`,
+				`INSERT INTO test2 VALUES (2);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:            `SELECT * FROM test1;`,
+					ExpectedColNames: []string{"index"},
+					Expected:         []sql.Row{{1}},
+				},
+				{
+					Query:            `SELECT * FROM test2;`,
+					ExpectedColNames: []string{"IndeX"},
+					Expected:         []sql.Row{{2}},
+				},
+				{
+					Query:       `INSERT INTO test1 VALUES (-1);`,
+					ExpectedErr: "index_constraint1",
+				},
+				{
+					Query:       `INSERT INTO test2 VALUES (-1);`,
+					ExpectedErr: "index_constraint2",
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
Some dumps include columns that are named `"index"`, which is forbidden in CockroachDB. Our parser was initially based on an open-licensed version of CockroachDB's parser (https://github.com/dolthub/doltgresql/pull/19#issuecomment-1761392474), and we therefore inherited some of the restrictions that CockroachDB has. We want our customers to be able to use standard Postgres dumps, so this removes the CockroachDB extensions and restores the functionality expected of Postgres users. We didn't implement functionality for the extensions anyway, so this should be a harmless removal.

For reference, this is the page discussing the extensions:
https://www.cockroachlabs.com/docs/stable/order-by