### PR TITLE
More dump-related fixes

### DIFF
--- a/server/ast/alter_database.go
+++ b/server/ast/alter_database.go
@@ -26,9 +26,9 @@ func nodeAlterDatabase(ctx *Context, node *tree.AlterDatabase) (vitess.Statement
 		return nil, nil
 	}
 
-	// We can handle the common ALTER DATABASE .. TO OWNER case since it's a no-op
-	if node.Owner != "" {
-		return NewNoOp("owners are unsupported"), nil
+	// We intentionally don't support OWNER TO since we don't support owning objects
+	if node.Owner != "" && len(node.Options) == 0 {
+		return NewNoOp("OWNER TO is unsupported and ignored"), nil
 	}
 
 	return NotYetSupportedError("ALTER DATABASE is not yet supported")

--- a/server/ast/alter_function.go
+++ b/server/ast/alter_function.go
@@ -27,9 +27,9 @@ func nodeAlterFunction(ctx *Context, node *tree.AlterFunction) (vitess.Statement
 		return nil, err
 	}
 
-	// We can handle the common ALTER FUNCTION .. TO OWNER case since it's a no-op
-	if node.Owner != "" {
-		return NewNoOp("owners are unsupported"), nil
+	// We intentionally don't support OWNER TO since we don't support owning objects
+	if node.Owner != "" && len(node.Options) == 0 {
+		return NewNoOp("OWNER TO is unsupported and ignored"), nil
 	}
 
 	return NotYetSupportedError("ALTER FUNCTION statement is not yet supported")

--- a/server/ast/alter_schema.go
+++ b/server/ast/alter_schema.go
@@ -26,9 +26,9 @@ func nodeAlterSchema(ctx *Context, node *tree.AlterSchema) (vitess.Statement, er
 		return nil, nil
 	}
 
-	// We can handle the common ALTER SCHEMA .. TO OWNER case since it's a no-op
+	// We intentionally don't support OWNER TO since we don't support owning objects
 	if _, ok := node.Cmd.(*tree.AlterSchemaOwner); ok {
-		return NewNoOp("owners are unsupported"), nil
+		return NewNoOp("OWNER TO is unsupported and ignored"), nil
 	}
 
 	return NotYetSupportedError("ALTER SCHEMA is not yet supported")

--- a/server/ast/alter_sequence.go
+++ b/server/ast/alter_sequence.go
@@ -32,6 +32,7 @@ func nodeAlterSequence(ctx *Context, node *tree.AlterSequence) (vitess.Statement
 
 	var warnings []string
 	if len(node.Owner) > 0 {
+		// We intentionally don't support OWNER TO since we don't support owning objects
 		if len(node.Options) == 0 {
 			return NewNoOp("OWNER TO is unsupported and ignored"), nil
 		} else {

--- a/server/ast/alter_type.go
+++ b/server/ast/alter_type.go
@@ -26,9 +26,9 @@ func nodeAlterType(ctx *Context, node *tree.AlterType) (vitess.Statement, error)
 		return nil, nil
 	}
 
-	// We can handle the common ALTER TYPE .. TO OWNER case since it's a no-op
+	// We intentionally don't support OWNER TO since we don't support owning objects
 	if _, ok := node.Cmd.(*tree.AlterTypeOwner); ok {
-		return NewNoOp("owners are unsupported"), nil
+		return NewNoOp("OWNER TO is unsupported and ignored"), nil
 	}
 
 	return NotYetSupportedError("ALTER TYPE is not yet supported")

--- a/server/ast/alter_view.go
+++ b/server/ast/alter_view.go
@@ -26,9 +26,9 @@ func nodeAlterView(ctx *Context, stmt *tree.AlterView) (sqlparser.Statement, err
 		return nil, nil
 	}
 
-	// We can handle the common ALTER VIEW .. TO OWNER case since it's a no-op
+	// We intentionally don't support OWNER TO since we don't support owning objects
 	if _, ok := stmt.Cmd.(*tree.AlterViewOwnerTo); ok {
-		return NewNoOp("owners are unsupported"), nil
+		return NewNoOp("OWNER TO is unsupported and ignored"), nil
 	}
 
 	return NotYetSupportedError("ALTER VIEW is not yet supported")

--- a/server/cast/timestamp.go
+++ b/server/cast/timestamp.go
@@ -37,7 +37,11 @@ func timestampAssignment() {
 		FromType: pgtypes.Timestamp,
 		ToType:   pgtypes.Date,
 		Function: func(ctx *sql.Context, val any, targetType *pgtypes.DoltgresType) (any, error) {
-			return pgdate.MakeDateFromTime(val.(time.Time))
+			d, err := pgdate.MakeDateFromTime(val.(time.Time))
+			if err != nil {
+				return nil, err
+			}
+			return d.ToTime()
 		},
 	})
 	framework.MustAddAssignmentTypeCast(framework.TypeCast{

--- a/server/cast/timestamptz.go
+++ b/server/cast/timestamptz.go
@@ -37,7 +37,11 @@ func timestampTZAssignment() {
 		FromType: pgtypes.TimestampTZ,
 		ToType:   pgtypes.Date,
 		Function: func(ctx *sql.Context, val any, targetType *pgtypes.DoltgresType) (any, error) {
-			return pgdate.MakeDateFromTime(val.(time.Time))
+			d, err := pgdate.MakeDateFromTime(val.(time.Time))
+			if err != nil {
+				return nil, err
+			}
+			return d.ToTime()
 		},
 	})
 	framework.MustAddAssignmentTypeCast(framework.TypeCast{

--- a/testing/go/alter_test.go
+++ b/testing/go/alter_test.go
@@ -28,7 +28,7 @@ func TestAlterStatements(t *testing.T) {
 					ExpectedNotices: []ExpectedNotice{
 						{
 							Severity: "WARNING",
-							Message:  "owners are unsupported",
+							Message:  "OWNER TO is unsupported and ignored",
 						},
 					},
 				},
@@ -62,7 +62,7 @@ func TestAlterStatements(t *testing.T) {
 					ExpectedNotices: []ExpectedNotice{
 						{
 							Severity: "WARNING",
-							Message:  "owners are unsupported",
+							Message:  "OWNER TO is unsupported and ignored",
 						},
 					},
 				},
@@ -79,7 +79,7 @@ func TestAlterStatements(t *testing.T) {
 					ExpectedNotices: []ExpectedNotice{
 						{
 							Severity: "WARNING",
-							Message:  "owners are unsupported",
+							Message:  "OWNER TO is unsupported and ignored",
 						},
 					},
 				},
@@ -96,7 +96,7 @@ func TestAlterStatements(t *testing.T) {
 					ExpectedNotices: []ExpectedNotice{
 						{
 							Severity: "WARNING",
-							Message:  "owners are unsupported",
+							Message:  "OWNER TO is unsupported and ignored",
 						},
 					},
 				},
@@ -113,7 +113,7 @@ func TestAlterStatements(t *testing.T) {
 					ExpectedNotices: []ExpectedNotice{
 						{
 							Severity: "WARNING",
-							Message:  "owners are unsupported",
+							Message:  "OWNER TO is unsupported and ignored",
 						},
 					},
 				},


### PR DESCRIPTION
These are more fixes related to failing imports. In a nutshell, our function testing is fairly barebones, and there were several panics occurring due to incorrect assumptions and a lack of test variety (for example, the date `2025-01-02` being taken as integer subtraction rather than a date, exceptions not handling variables correctly, etc.). Still too many imports failing overall to enable them in CI, but this gets us a step closer.