### PR TITLE
[no-release-notes] Attempting to fix Release building

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -97,6 +97,15 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - name: Free up disk space
+        shell: bash
+        run: |
+          sudo find /opt -maxdepth 1 -mindepth 1 \
+            ! -path /opt/containerd \
+            ! -path /opt/actionarchivecache \
+            ! -path /opt/runner \
+            ! -path /opt/runner-cache \
+            -exec rm -rf {} \;
       - name: Build Binaries
         id: build_binaries
         run: |


### PR DESCRIPTION
Right now, we cannot build Doltgres as the GitHub Action runner is running out of disk space. It used to work if I ran it enough times, but I think that was due to some slight variance allowing it to just barely fit on disk. Now, it seems to always run out.

https://github.com/dolthub/doltgresql/actions/runs/18652410524/job/53173520808
```
# github.com/dolthub/doltgresql/cmd/doltgres
/usr/local/go/pkg/tool/linux_amd64/link: mapping output file failed: no space left on device
```

This is taken from a community post, where a user mentioned that there are some files in `/opt` that aren't necessary for all GitHub Actions, and can be removed to free up disk space.
https://github.com/orgs/community/discussions/25678#discussioncomment-9017167
This PR adds this cleanup step right before we build the binaries, so I'm hoping it will work. Sadly we cannot test without merging, but it's easy to revert if it doesn't work.

There also doesn't seem to be a way to upgrade the disk space of a runner, as mentioned in an earlier comment in that same thread:
```
...GitHub-hosted runners only have 14GB of free space available, and there isn’t a way to increase that I’m afraid.
```
Other than hosting our own runners, I think this is the best step forward.