### PR TITLE
Fixed Issue #2049

### DIFF
--- a/server/functions/jsonb.go
+++ b/server/functions/jsonb.go
@@ -51,7 +51,10 @@ var jsonb_in = framework.Function1{
 			doc, err := pgtypes.UnmarshalToJsonDocument(inputBytes)
 			return doc, err
 		}
-		return nil, pgtypes.ErrInvalidSyntaxForType.New("jsonb", input[:10]+"...")
+		if len(input) > 10 {
+			input = input[:10] + "..."
+		}
+		return nil, pgtypes.ErrInvalidSyntaxForType.New("jsonb", input)
 	},
 }
 

--- a/server/types/json_document.go
+++ b/server/types/json_document.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"bytes"
 	"sort"
 	"strings"
 
@@ -339,6 +340,11 @@ func JsonValueFormatter(sb *strings.Builder, value JsonValue) {
 
 // UnmarshalToJsonDocument converts a JSON document byte slice into the actual JSON document.
 func UnmarshalToJsonDocument(val []byte) (JsonDocument, error) {
+	// The JSON unmarshaller incorrectly replaces the two ASCII characters for a newline (92 & 110) with a single ASCII
+	// newline character (10). We also handle \t and \r.
+	val = bytes.ReplaceAll(val, []byte{'\\', 'n'}, []byte{'\\', '\\', 'n'})
+	val = bytes.ReplaceAll(val, []byte{'\\', 'r'}, []byte{'\\', '\\', 'r'})
+	val = bytes.ReplaceAll(val, []byte{'\\', 't'}, []byte{'\\', '\\', 't'})
 	var decoded interface{}
 	if err := json.Unmarshal(val, &decoded); err != nil {
 		return JsonDocument{}, err

--- a/testing/generation/command_docs/create_row_tests.go
+++ b/testing/generation/command_docs/create_row_tests.go
@@ -127,5 +127,6 @@ func GetRowResults(query string) ([]sql.Row, error) {
 	if err != nil {
 		return nil, err
 	}
-	return framework.ReadRows(pgxRows, true)
+	readRows, _, err := framework.ReadRows(pgxRows, true)
+	return readRows, err
 }

--- a/testing/go/prepared_statement_test.go
+++ b/testing/go/prepared_statement_test.go
@@ -1432,7 +1432,7 @@ func RunScriptN(t *testing.T, script ScriptTest, n int) {
 	for _, query := range script.SetUpScript {
 		rows, err := conn.Query(ctx, query)
 		require.NoError(t, err)
-		_, err = ReadRows(rows, true)
+		_, _, err = ReadRows(rows, true)
 		assert.NoError(t, err)
 	}
 
@@ -1458,10 +1458,14 @@ func RunScriptN(t *testing.T, script ScriptTest, n int) {
 					}
 
 					if errorSeen == "" {
-						foundRows, err := ReadRows(rows, true)
+						foundRows, foundRawRows, err := ReadRows(rows, true)
 						if assertion.ExpectedErr == "" {
 							require.NoError(t, err)
-							assert.Equal(t, NormalizeExpectedRow(rows.FieldDescriptions(), assertion.Expected), foundRows)
+							if assertion.ExpectedRaw != nil {
+								assert.Equal(t, assertion.ExpectedRaw, foundRawRows)
+							} else {
+								assert.Equal(t, NormalizeExpectedRow(rows.FieldDescriptions(), assertion.Expected), foundRows)
+							}
 						} else if err != nil {
 							errorSeen = err.Error()
 						}

--- a/testing/go/replication_test.go
+++ b/testing/go/replication_test.go
@@ -51,7 +51,7 @@ type ReplicationTest struct {
 	// The SQL statements to execute as setup, in order. Results are not checked, but statements must not error.
 	// An initial comment can be used to Setup is always run on the primary.
 	SetUpScript []string
-	// The set of assertions to make after setup, in order
+	// The set of assertions to make after setup, in order. These should not use ExpectedRaw, as it is not handled.
 	Assertions []ScriptTestAssertion
 	// When using RunScripts, setting this on one (or more) tests causes RunScripts to ignore all tests that have this
 	// set to false (which is the default value). This allows a developer to easily "focus" on a specific test without
@@ -581,7 +581,8 @@ func newReplicator(t *testing.T, walFilePath string, replicaConn *pgx.Conn, prim
 	return r
 }
 
-// runReplicationScript runs the script given on the postgres connection provided
+// runReplicationScript runs the script given on the postgres connection provided. This does not handle assertions that
+// use ExpectedRaw.
 func runReplicationScript(
 	ctx context.Context,
 	t *testing.T,
@@ -652,7 +653,7 @@ func runReplicationScript(
 				} else {
 					rows, err := conn.Query(ctx, assertion.Query, assertion.BindVars...)
 					require.NoError(t, err)
-					readRows, err := ReadRows(rows, true)
+					readRows, _, err := ReadRows(rows, true)
 					require.NoError(t, err)
 					normalizedRows := NormalizeExpectedRow(rows.FieldDescriptions(), assertion.Expected)
 

--- a/testing/go/ssl_test.go
+++ b/testing/go/ssl_test.go
@@ -92,7 +92,7 @@ func TestSSL(t *testing.T) {
 	require.NoError(t, err)
 	rows, err := conn.Query(ctx, "SELECT * FROM test;")
 	require.NoError(t, err)
-	readRows, err := ReadRows(rows, true)
+	readRows, _, err := ReadRows(rows, true)
 	require.NoError(t, err)
 	assert.Equal(t, NormalizeExpectedRow(rows.FieldDescriptions(), []sql.Row{{3645, 37643}}), readRows)
 }


### PR DESCRIPTION
This fixes the following PR:
* https://github.com/dolthub/doltgresql/issues/2049

At its core, our JSON parsing libraries (both `go-json` and the internal `json` packages) replace binary escape sequences (`\n`, `\t`, `\r`) with their ASCII byte replacements, which doesn't mirror what Postgres clients expect (that the binary representation is preserved). This extends to our testing framework as well, so this also adds raw byte comparisons for testing.