### PR TITLE
Fixed timestamp replication

### DIFF
--- a/server/config/parameters.go
+++ b/server/config/parameters.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -39,6 +40,12 @@ func Init() {
 	if sql.SystemVariables == nil {
 		// unlikely this would happen since init() in gms package is executed first
 		variables.InitSystemVariables()
+	}
+	// Regression tests assume the Los Angeles timezone, so we'll set that here if the env var is set
+	if _, ok := os.LookupEnv("REGRESSION_TESTING"); ok {
+		timezone := postgresConfigParameters["timezone"].(*Parameter)
+		timezone.Default = "America/Los_Angeles"
+		timezone.ResetVal = "America/Los_Angeles"
 	}
 	params := make([]sql.SystemVariable, len(postgresConfigParameters))
 	i := 0

--- a/server/config/parameters_list.go
+++ b/server/config/parameters_list.go
@@ -3529,22 +3529,21 @@ var postgresConfigParameters = map[string]sql.SystemVariable{
 	},
 	"timezone": &Parameter{
 		Name:      "TimeZone",
-		Default:   "America/Los_Angeles",
+		Default:   time.Local.String(),
 		Category:  "Client Connection Defaults / Locale and Formatting",
 		ShortDesc: "Sets the time zone for displaying and interpreting time stamps.",
 		Context:   ParameterContextUser,
 		Type:      types.NewSystemStringType("timezone"),
 		Source:    ParameterSourceConfigurationFile,
-		// BootVal: "GMT",
-		ResetVal: "America/Los_Angeles",
-		Scope:    GetPgsqlScope(PsqlScopeSession),
+		ResetVal:  time.Local.String(),
+		Scope:     GetPgsqlScope(PsqlScopeSession),
 		ValidateFunc: func(_, new any) (any, bool) {
 			switch v := new.(type) {
 			case string:
 				if strings.ToLower(v) == "local" {
-					// TODO: fix this
+					// TODO: this should be the IANA name, not whatever Go decides to use
 					//   https://pkg.go.dev/github.com/thlib/go-timezone-local/tzlocal seems useful in this case.
-					return "America/Los_Angeles", true
+					return time.Local.String(), true
 				} else {
 					if strings.ToLower(v) == "utc" {
 						v = "UTC"

--- a/testing/go/merge_test.go
+++ b/testing/go/merge_test.go
@@ -70,6 +70,7 @@ func TestMerge(t *testing.T) {
 		{
 			Name: "merge with check expressions and column defaults",
 			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
 				"CREATE TABLE t1 (a INT, b timestamptz default '2020-01-01 00:00:00'::timestamptz, PRIMARY KEY (a))",
 				"ALTER TABLE t1 ADD CONSTRAINT check_b CHECK (b >= '2020-01-01 00:00:00'::timestamptz)",
 				"INSERT INTO t1 VALUES (1, '2020-01-02 00:00:00'), (2, '2020-01-03 00:00:00')",
@@ -90,10 +91,10 @@ func TestMerge(t *testing.T) {
 				{
 					Query: "SELECT * FROM t1 order by a",
 					Expected: []sql.Row{
-						{1, "2020-01-02 00:00:00-08"},
-						{2, "2020-01-03 00:00:00-08"},
-						{3, "2020-01-04 00:00:00-08"},
-						{4, "2020-01-05 00:00:00-08"},
+						{1, "2020-01-02 00:00:00+00"},
+						{2, "2020-01-03 00:00:00+00"},
+						{3, "2020-01-04 00:00:00+00"},
+						{4, "2020-01-05 00:00:00+00"},
 					},
 				},
 				{

--- a/testing/go/operators_test.go
+++ b/testing/go/operators_test.go
@@ -24,6 +24,9 @@ func TestOperators(t *testing.T) {
 	RunScriptsWithoutNormalization(t, []ScriptTest{
 		{
 			Name: "Addition",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT 1::float4 + 2::float4;`,
@@ -191,12 +194,15 @@ func TestOperators(t *testing.T) {
 				},
 				{
 					Query:    `select interval '2 days' + timestamp with time zone '2021-04-08 12:23:45-0700';`,
-					Expected: []sql.Row{{"2021-04-10 12:23:45-07"}},
+					Expected: []sql.Row{{"2021-04-10 19:23:45+00"}},
 				},
 			},
 		},
 		{
 			Name: "Subtraction",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT 1::float4 - 2::float4;`,
@@ -350,6 +356,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Multiplication",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT 1::float4 * 2::float4;`,
@@ -503,6 +512,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Division",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT 8::float4 / 2::float4;`,
@@ -656,6 +668,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Mod",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT 11::int2 % 3::int2;`,
@@ -725,6 +740,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Shift Left",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT 5::int2 << 2::int2;`,
@@ -766,6 +784,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Shift Right",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT 17::int2 >> 2::int2;`,
@@ -807,6 +828,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Less Than",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT false < true;`,
@@ -1108,6 +1132,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Greater Than",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT false > true;`,
@@ -1413,6 +1440,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Less Or Equal",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT false <= true;`,
@@ -1862,6 +1892,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Greater Or Equal",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT false >= true;`,
@@ -2311,6 +2344,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Equal",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT true = true;`,
@@ -2616,6 +2652,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Not Equal Standard Syntax (<>)",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT true <> true;`,
@@ -2917,6 +2956,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Not Equal Alternate Syntax (!=)", // This should be exactly equivalent to <>, so this is only a subset
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT 10::int2 != 10::int2;`,
@@ -2994,6 +3036,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Bit And",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT 13::int2 & 7::int2;`,
@@ -3035,6 +3080,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Bit Or",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT 13::int2 | 7::int2;`,
@@ -3076,6 +3124,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Bit Xor",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT 13::int2 # 7::int2;`,
@@ -3117,6 +3168,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Negate",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT -(7::float4);`,
@@ -3150,6 +3204,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Unary Plus",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT +(7::float4);`,
@@ -3179,6 +3236,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Binary JSON",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT '[{"a":"foo"},{"b":"bar"},{"c":"baz"}]'::json -> 2;`,
@@ -3356,6 +3416,9 @@ func TestOperators(t *testing.T) {
 		},
 		{
 			Name: "Concatenate",
+			SetUpScript: []string{
+				"SET timezone TO 'UTC';",
+			},
 			Assertions: []ScriptTestAssertion{
 				{
 					Query:    `SELECT 'Hello, ' || 'World!';`,
@@ -3403,11 +3466,11 @@ func TestOperators(t *testing.T) {
 				},
 				{
 					Query:    `SELECT '2000-01-01 00:00:00-08'::timestamptz || ' happy new year';`,
-					Expected: []sql.Row{{"2000-01-01 00:00:00-08 happy new year"}},
+					Expected: []sql.Row{{"2000-01-01 08:00:00+00 happy new year"}},
 				},
 				{
 					Query:    `SELECT 'hello ' || '2000-01-01 00:00:00-08'::timestamptz;`,
-					Expected: []sql.Row{{"hello 2000-01-01 00:00:00-08"}},
+					Expected: []sql.Row{{"hello 2000-01-01 08:00:00+00"}},
 				},
 				{
 					Query:    `SELECT '00:00:00'::time || ' midnight';`,

--- a/testing/go/replication_test.go
+++ b/testing/go/replication_test.go
@@ -474,7 +474,6 @@ var replicationTests = []ReplicationTest{
 	},
 	{
 		Name: "all types",
-		Skip: true, // some types don't work yet: DATE and DATETIME not round-tripping correctly
 		SetUpScript: []string{
 			dropReplicationSlot,
 			createReplicationSlot,
@@ -493,7 +492,7 @@ var replicationTests = []ReplicationTest{
 			{
 				Query: "/* replica */ SELECT * FROM public.test order by id",
 				Expected: []sql.Row{
-					{int32(2), "three", int32(2), false, 2.2, "2021-02-02", "2021-02-02 13:00:00"},
+					{int32(2), "three", int32(2), "f", 2.2, "2021-02-02", "2021-02-02 13:00:00"},
 				},
 			},
 		},

--- a/testing/go/set_test.go
+++ b/testing/go/set_test.go
@@ -37,7 +37,7 @@ var setStmts = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "SHOW timezone",
-				Expected: []sql.Row{{"America/Los_Angeles"}},
+				Expected: []sql.Row{{"Local"}},
 			},
 			{
 				Query:    "SET timezone TO '+00:00';",
@@ -53,7 +53,7 @@ var setStmts = []ScriptTest{
 			},
 			{
 				Query:    "SHOW timezone",
-				Expected: []sql.Row{{"America/Los_Angeles"}},
+				Expected: []sql.Row{{"Local"}},
 			},
 			{
 				Query:    "SET TIME ZONE '+00:00';",
@@ -69,11 +69,11 @@ var setStmts = []ScriptTest{
 			},
 			{
 				Query:    "SHOW timezone",
-				Expected: []sql.Row{{"America/Los_Angeles"}},
+				Expected: []sql.Row{{"Local"}},
 			},
 			{
 				Query:    "SELECT current_setting('timezone')",
-				Expected: []sql.Row{{"America/Los_Angeles"}},
+				Expected: []sql.Row{{"Local"}},
 			},
 		},
 	},
@@ -7387,7 +7387,7 @@ var setStmts = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "SHOW TimeZone",
-				Expected: []sql.Row{{"America/Los_Angeles"}},
+				Expected: []sql.Row{{"Local"}},
 			},
 			{
 				Query:    "SET TimeZone TO 'UTC'",
@@ -7403,11 +7403,11 @@ var setStmts = []ScriptTest{
 			},
 			{
 				Query:    "SHOW TimeZone",
-				Expected: []sql.Row{{"America/Los_Angeles"}},
+				Expected: []sql.Row{{"Local"}},
 			},
 			{
 				Query:    "SELECT current_setting('TimeZone')",
-				Expected: []sql.Row{{"America/Los_Angeles"}},
+				Expected: []sql.Row{{"Local"}},
 			},
 		},
 	},


### PR DESCRIPTION
This fixes the two issues found in
* https://github.com/dolthub/doltgresql/issues/2060

The first was that replication was incorrectly formatting timestamp values, so now we bypass it and use the returned time strings directly. The second was that we had `America/Los_Angeles` hardcoded as the parameter value, and in some cases we would ignore the local timezone and use the parameter value. Now, we default the parameter value to the local as well.