### PR TITLE
Add tests for `SHOW TABLES` bug

### DIFF
--- a/testing/go/show_test.go
+++ b/testing/go/show_test.go
@@ -159,6 +159,8 @@ func TestShowTables(t *testing.T) {
 		{
 			Name: "show tables in single schema",
 			SetUpScript: []string{
+				// Create a sequence to ensure it isn't included
+				`CREATE SEQUENCE seq1;`,
 				`CREATE TABLE t1 (a INT PRIMARY KEY, name TEXT)`,
 				`CREATE TABLE t2 (b INT PRIMARY KEY, name TEXT)`,
 				`create schema schema2`,


### PR DESCRIPTION
Adds a test for a bug in `SHOW TABLES` behavior that caused sequences to be included in returned results. 

Depends on: https://github.com/dolthub/dolt/pull/10220

Fixes: https://github.com/dolthub/doltgresql/issues/1743