### PR TITLE
dolthub/doltgresql#1057 allow unquoted STATUS keyword in DESCRIBE statements

### DIFF
--- a/postgres/parser/parser/sql.y
+++ b/postgres/parser/parser/sql.y
@@ -14549,6 +14549,7 @@ complex_db_object_name_no_keywords:
 simple_ident:
   IDENT
 | PUBLIC // PUBLIC is a keyword, but its use as the default schema makes it nice to include here
+| STATUS // STATUS is a keyword, but needed for dolt.status system table (issue #1057)
 
 // DB object name component -- this cannot not include any reserved
 // keyword because of ambiguity after FROM, but we've been too lax

--- a/testing/go/dolt_tables_test.go
+++ b/testing/go/dolt_tables_test.go
@@ -1910,7 +1910,6 @@ func TestUserSpaceDoltTables(t *testing.T) {
 					},
 				},
 				{
-					Skip:  true, // TODO: ERROR: at or near "status": syntax error
 					Query: `DESCRIBE dolt.status`,
 					Expected: []sql.Row{
 						{"table_name", "text", "NO", "PRI", nil, ""},


### PR DESCRIPTION
## IMPORTANT

Below is the summary of the cause of the bug in #1057 and the simple fix, but I want to clarify this is the desired fix.

## Summary

- Fixes `DESCRIBE dolt.status` failing with "at or near 'status': syntax error"
- Adds `STATUS` to the `simple_ident` grammar rule in `sql.y`, following the pattern established for `PUBLIC` in PR #828
- Enables the previously skipped test for this functionality

## Background

The `simple_ident` rule is used for parsing table name components in DESCRIBE statements. It only allowed `IDENT` tokens and the explicitly added `PUBLIC` keyword. Since `STATUS` is an unreserved keyword (not a regular identifier), the parser rejected it unless quoted.

**Before:** `DESCRIBE dolt.status` fails, `DESCRIBE dolt."status"` works
**After:** Both work

## Test Plan

`DESCRIBE dolt.status` test now passes (`TestUserSpaceDoltTables/dolt_status`)

Fixes #1057