### PR TITLE
dolthub/doltgresql#1361: unskip dolt_clean zero-argument tests

### DIFF
--- a/testing/go/dolt_functions_test.go
+++ b/testing/go/dolt_functions_test.go
@@ -2746,12 +2746,19 @@ func TestDoltFunctionSmokeTests(t *testing.T) {
 					},
 				},
 				{
-					Skip:     true, // TODO: function dolt_clean() does not exist
-					Query:    "SELECT DOLT_CLEAN();",
+					Query:    "SELECT DOLT_CLEAN('t1');",
 					Expected: []sql.Row{{"{0}"}},
 				},
 				{
-					Query:    "SELECT DOLT_CLEAN('t1');",
+					Query:    "SELECT * FROM dolt.status;",
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    "CREATE TABLE t1 (pk int primary key);",
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    "SELECT DOLT_CLEAN();",
 					Expected: []sql.Row{{"{0}"}},
 				},
 				{
@@ -2769,12 +2776,10 @@ func TestDoltFunctionSmokeTests(t *testing.T) {
 					},
 				},
 				{
-					Skip:     true, // TODO: function dolt_clean() does not exist
 					Query:    "SELECT DOLT_CLEAN();",
 					Expected: []sql.Row{{"{0}"}},
 				},
 				{
-					Skip:     true,
 					Query:    "SELECT * FROM dolt.status;",
 					Expected: []sql.Row{},
 				},


### PR DESCRIPTION
## Summary

- Unskips the `SELECT DOLT_CLEAN()` zero-argument smoke tests that were added in #1373 
- I believe the underlying issue was resolved in #1763 which added `Function0` registration for all Dolt procedures
- Reorders test assertions so `DOLT_CLEAN('t1')` runs before `DOLT_CLEAN()` to properly test both

Note: #1373 also added skipped tests in `prepared_statement_test.go`, but those were already unskipped in commit 62569c79.

## Tests to verify


- Run `go test ./testing/go/... -run "TestDoltClean"` to verify existing dolt_clean tests pass
- Run `go test ./testing/go/... -run "TestDoltFunctionSmokeTests/smoke_test_select_dolt_clean"` to verify unskipped smoke tests pass

Fixes #1361