### PR TITLE
dolthub/doltgresql#1863: validate database exists before CREATE SCHEMA

### DIFF
--- a/server/analyzer/init.go
+++ b/server/analyzer/init.go
@@ -46,6 +46,7 @@ const (
 	ruleId_OptimizeFunctions                                             // optimizeFunctions
 	ruleId_ValidateColumnDefaults                                        // validateColumnDefaults
 	ruleId_ValidateCreateTable                                           // validateCreateTable
+	ruleId_ValidateCreateSchema                                          // validateCreateSchema
 	ruleId_ResolveAlterColumn                                            // resolveAlterColumn
 	ruleId_ValidateCreateFunction
 )
@@ -62,6 +63,7 @@ func Init() {
 		analyzer.Rule{Id: ruleId_AssignUpdateCasts, Apply: AssignUpdateCasts},
 		analyzer.Rule{Id: ruleId_AssignTriggers, Apply: AssignTriggers},
 		analyzer.Rule{Id: ruleId_ValidateCreateFunction, Apply: ValidateCreateFunction},
+		analyzer.Rule{Id: ruleId_ValidateCreateSchema, Apply: ValidateCreateSchema},
 	)
 
 	analyzer.OnceBeforeDefault = append([]analyzer.Rule{

--- a/server/analyzer/validate_create_schema.go
+++ b/server/analyzer/validate_create_schema.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzer
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/analyzer"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/transform"
+
+	"github.com/dolthub/doltgresql/core"
+)
+
+// ValidateCreateSchema validates that CREATE SCHEMA is executed with a valid database context.
+// In PostgreSQL, schemas exist within databases, so CREATE SCHEMA requires an active database.
+// See: https://github.com/dolthub/doltgresql/issues/1863
+func ValidateCreateSchema(
+	ctx *sql.Context,
+	a *analyzer.Analyzer,
+	n sql.Node,
+	scope *plan.Scope,
+	sel analyzer.RuleSelector,
+	qFlags *sql.QueryFlags,
+) (sql.Node, transform.TreeIdentity, error) {
+	cs, ok := n.(*plan.CreateSchema)
+	if !ok {
+		return n, transform.SameTree, nil
+	}
+
+	// Check if the current database actually has a working root.
+	// GetRootFromContext will return sql.ErrDatabaseNotFound if the database
+	// is not properly initialized.
+	_, _, err := core.GetRootFromContext(ctx)
+	if err != nil {
+		if sql.ErrDatabaseNotFound.Is(err) {
+			return nil, transform.SameTree, sql.ErrNoDatabaseSelected.New()
+		}
+		return nil, transform.SameTree, err
+	}
+
+	return cs, transform.SameTree, nil
+}

--- a/testing/go/create_schema_no_db_test.go
+++ b/testing/go/create_schema_no_db_test.go
@@ -1,0 +1,107 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _go
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dserver "github.com/dolthub/doltgresql/server"
+	"github.com/dolthub/doltgresql/servercfg"
+	"github.com/dolthub/doltgresql/servercfg/cfgdetails"
+)
+
+// TestCreateSchemaWithNonExistentDatabase tests that connecting to a non-existent
+// database fails with the appropriate error at the connection level.
+// This is the PostgreSQL-compliant behavior where database validation happens
+// during connection establishment.
+//
+// NOTE: This test cannot use RunScripts because RunScripts auto-creates the
+// database before running assertions. We need to test the connection-level
+// failure when connecting to a non-existent database.
+//
+// See: https://github.com/dolthub/doltgresql/issues/1863
+func TestCreateSchemaWithNonExistentDatabase(t *testing.T) {
+	port, err := sql.GetEmptyPort()
+	require.NoError(t, err)
+
+	// Start server using the same pattern as CreateServerWithPort
+	controller, err := dserver.RunInMemory(
+		&servercfg.DoltgresConfig{
+			DoltgresConfig: cfgdetails.DoltgresConfig{
+				ListenerConfig: &cfgdetails.DoltgresListenerConfig{
+					PortNumber: &port,
+					HostStr:    &serverHost,
+				},
+				LogLevelStr: &testServerLogLevel,
+			},
+		}, dserver.NewListener,
+	)
+	require.NoError(t, err)
+	defer func() {
+		controller.Stop()
+		require.NoError(t, controller.WaitForStop())
+	}()
+
+	ctx := context.Background()
+
+	t.Run(
+		"connection to non-existent database fails", func(t *testing.T) {
+			// Attempt to connect to a database that doesn't exist
+			connStr := fmt.Sprintf(
+				"postgres://postgres:password@%s:%d/nonexistent_db?sslmode=disable",
+				serverHost,
+				port,
+			)
+			_, err := pgx.Connect(ctx, connStr)
+
+			require.Error(t, err, "connection should fail when database doesn't exist")
+			assert.Contains(
+				t, err.Error(), "does not exist",
+				"expected 'does not exist' error, got: %v", err,
+			)
+		},
+	)
+
+	t.Run(
+		"connection to existing database succeeds", func(t *testing.T) {
+			// Verify that connecting to the default "postgres" database works
+			connStr := fmt.Sprintf("postgres://postgres:password@%s:%d/postgres?sslmode=disable", serverHost, port)
+			conn, err := pgx.Connect(ctx, connStr)
+			require.NoError(t, err)
+			defer conn.Close(ctx)
+
+			// Verify we can create a schema on the valid database
+			_, err = conn.Exec(ctx, "CREATE SCHEMA test_schema_1863")
+			require.NoError(t, err)
+
+			// Verify the schema was created
+			rows, err := conn.Query(
+				ctx,
+				"SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'test_schema_1863'",
+			)
+			require.NoError(t, err)
+			defer rows.Close()
+
+			require.True(t, rows.Next(), "expected to find test_schema_1863")
+		},
+	)
+}


### PR DESCRIPTION
## Summary

Adds a `ValidateCreateSchema` analyzer rule to ensure `CREATE SCHEMA` fails that appropriately when executed against a non-existent or invalid database context.

- Adds analyzer rule that checks if the current database has a valid root before allowing `CREATE SCHEMA` to proceed
- Ensures PostgreSQL-compliant behavior where schemas must be created within an existing database
- Adds integration and bats tests

## Note

I wasn't 100% sure if adding an analyzer rule was the right approach here, but it seemed like the cleanest way to validate database context before schema creation. The rule follows the same pattern as existing validation rules like `ValidateCreateTable`.

The connection-level validation (rejecting connections to non-existent databases) already handles most cases, but this analyzer rule acts as an additional safety net for edge cases where a query might run with an invalid database context (also not sure how realistic this is 😕 ).

Open to feedback on whether there's a better approach!

## Testing

- Integrationt: TestCreateSchemaWithNonExistentDatabase
- Bats: `bats --filter "non-existent database|CREATE SCHEMA works" testing/bats/doltgres.bats`
- Existing schema tests pass: `go test ./testing/go/... -run TestSchemas -v`

Closes: #1863
