### PR TITLE
Initial support for UDFs with `RETURNS SETOF`

### DIFF
--- a/server/functions/framework/functions.go
+++ b/server/functions/framework/functions.go
@@ -39,8 +39,8 @@ type FunctionInterface interface {
 	// IsStrict returns whether the function is STRICT, which means if any parameter is NULL, then it returns NULL.
 	// Otherwise, if it's not, the NULL input must be handled by user.
 	IsStrict() bool
-	// IsSRF returns whether the function is set returning function, meaning whether the function returns one or more
-	// rows as a result.
+	// IsSRF returns whether the function is a set returning function, meaning whether the
+	// function returns one or more rows as a result.
 	IsSRF() bool
 	// InternalID returns the ID associated with this function.
 	InternalID() id.Id

--- a/server/plpgsql/interpreter_operation.go
+++ b/server/plpgsql/interpreter_operation.go
@@ -19,24 +19,29 @@ package plpgsql
 type OpCode uint16
 
 const (
-	OpCode_Alias      OpCode = iota // https://www.postgresql.org/docs/15/plpgsql-declarations.html#PLPGSQL-DECLARATION-ALIAS
-	OpCode_Assign                   // https://www.postgresql.org/docs/15/plpgsql-statements.html#PLPGSQL-STATEMENTS-ASSIGNMENT
-	OpCode_Case                     // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-CONDITIONALS
-	OpCode_Declare                  // https://www.postgresql.org/docs/15/plpgsql-declarations.html
-	OpCode_DeleteInto               // https://www.postgresql.org/docs/15/plpgsql-statements.html
-	OpCode_Exception                // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-ERROR-TRAPPING
-	OpCode_Execute                  // Executing a standard SQL statement (expects no rows returned unless Target is specified)
-	OpCode_Get                      // https://www.postgresql.org/docs/15/plpgsql-statements.html#PLPGSQL-STATEMENTS-DIAGNOSTICS
-	OpCode_Goto                     // All control-flow structures can be represented using Goto
-	OpCode_If                       // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-CONDITIONALS
-	OpCode_InsertInto               // https://www.postgresql.org/docs/15/plpgsql-statements.html
-	OpCode_Perform                  // https://www.postgresql.org/docs/15/plpgsql-statements.html
-	OpCode_Raise                    // https://www.postgresql.org/docs/15/plpgsql-errors-and-messages.html
-	OpCode_Return                   // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-STATEMENTS-RETURNING
-	OpCode_ScopeBegin               // This is used for scope control, specific to Doltgres
-	OpCode_ScopeEnd                 // This is used for scope control, specific to Doltgres
-	OpCode_SelectInto               // https://www.postgresql.org/docs/15/plpgsql-statements.html
-	OpCode_UpdateInto               // https://www.postgresql.org/docs/15/plpgsql-statements.html
+	// New OpCode values MUST be added to the END of this list!
+	// Function OpCodes are persisted to disk, so these values MUST be stable across Doltgres versions.
+	OpCode_Alias       OpCode = 0  // https://www.postgresql.org/docs/15/plpgsql-declarations.html#PLPGSQL-DECLARATION-ALIAS
+	OpCode_Assign      OpCode = 1  // https://www.postgresql.org/docs/15/plpgsql-statements.html#PLPGSQL-STATEMENTS-ASSIGNMENT
+	OpCode_Case        OpCode = 2  // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-CONDITIONALS
+	OpCode_Declare     OpCode = 3  // https://www.postgresql.org/docs/15/plpgsql-declarations.html
+	OpCode_DeleteInto  OpCode = 4  // https://www.postgresql.org/docs/15/plpgsql-statements.html
+	OpCode_Exception   OpCode = 5  // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-ERROR-TRAPPING
+	OpCode_Execute     OpCode = 6  // Executing a standard SQL statement (expects no rows returned unless Target is specified)
+	OpCode_Get         OpCode = 7  // https://www.postgresql.org/docs/15/plpgsql-statements.html#PLPGSQL-STATEMENTS-DIAGNOSTICS
+	OpCode_Goto        OpCode = 8  // All control-flow structures can be represented using Goto
+	OpCode_If          OpCode = 9  // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-CONDITIONALS
+	OpCode_InsertInto  OpCode = 10 // https://www.postgresql.org/docs/15/plpgsql-statements.html
+	OpCode_Perform     OpCode = 11 // https://www.postgresql.org/docs/15/plpgsql-statements.html
+	OpCode_Raise       OpCode = 12 // https://www.postgresql.org/docs/15/plpgsql-errors-and-messages.html
+	OpCode_Return      OpCode = 13 // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-STATEMENTS-RETURNING
+	OpCode_ScopeBegin  OpCode = 14 // This is used for scope control, specific to Doltgres
+	OpCode_ScopeEnd    OpCode = 15 // This is used for scope control, specific to Doltgres
+	OpCode_SelectInto  OpCode = 16 // https://www.postgresql.org/docs/15/plpgsql-statements.html
+	OpCode_UpdateInto  OpCode = 17 // https://www.postgresql.org/docs/15/plpgsql-statements.html
+	OpCode_ReturnQuery OpCode = 18 // https://www.postgresql.org/docs/current/plpgsql-control-structures.html#PLPGSQL-STATEMENTS-RETURNING-RETURN-NEXT
+	// New OpCode values MUST be added to the END of this list!
+	// Function OpCodes are persisted to disk, so these values MUST be stable across Doltgres versions.
 )
 
 // InterpreterOperation is an operation that will be performed by the interpreter.

--- a/server/plpgsql/json.go
+++ b/server/plpgsql/json.go
@@ -203,6 +203,12 @@ type plpgSQL_stmt_return struct {
 	LineNumber int32 `json:"lineno"`
 }
 
+// plpgSQL_stmt_return_query exists to match the expected JSON format.
+type plpgSQL_stmt_return_query struct {
+	Query      expr  `json:"query"`
+	LineNumber int32 `json:"lineno"`
+}
+
 // plpgSQL_stmt_while exists to match the expected JSON format.
 type plpgSQL_stmt_while struct {
 	Condition  cond        `json:"cond"`
@@ -231,17 +237,18 @@ type sqlstmt struct {
 // statement exists to match the expected JSON format. Unlike other structs, this is used like a union rather than
 // having a singular expected implementation.
 type statement struct {
-	Assignment *plpgSQL_stmt_assign  `json:"PLpgSQL_stmt_assign"`
-	Case       *plpgSQL_stmt_case    `json:"PLpgSQL_stmt_case"`
-	ExecSQL    *plpgSQL_stmt_execsql `json:"PLpgSQL_stmt_execsql"`
-	Exit       *plpgSQL_stmt_exit    `json:"PLpgSQL_stmt_exit"`
-	If         *plpgSQL_stmt_if      `json:"PLpgSQL_stmt_if"`
-	Loop       *plpgSQL_stmt_loop    `json:"PLpgSQL_stmt_loop"`
-	Perform    *plpgSQL_stmt_perform `json:"PLpgSQL_stmt_perform"`
-	Raise      *plpgSQL_stmt_raise   `json:"PLpgSQL_stmt_raise"`
-	Return     *plpgSQL_stmt_return  `json:"PLpgSQL_stmt_return"`
-	When       *plpgSQL_case_when    `json:"PLpgSQL_case_when"`
-	While      *plpgSQL_stmt_while   `json:"PLpgSQL_stmt_while"`
+	Assignment  *plpgSQL_stmt_assign       `json:"PLpgSQL_stmt_assign"`
+	Case        *plpgSQL_stmt_case         `json:"PLpgSQL_stmt_case"`
+	ExecSQL     *plpgSQL_stmt_execsql      `json:"PLpgSQL_stmt_execsql"`
+	Exit        *plpgSQL_stmt_exit         `json:"PLpgSQL_stmt_exit"`
+	If          *plpgSQL_stmt_if           `json:"PLpgSQL_stmt_if"`
+	Loop        *plpgSQL_stmt_loop         `json:"PLpgSQL_stmt_loop"`
+	Perform     *plpgSQL_stmt_perform      `json:"PLpgSQL_stmt_perform"`
+	Raise       *plpgSQL_stmt_raise        `json:"PLpgSQL_stmt_raise"`
+	Return      *plpgSQL_stmt_return       `json:"PLpgSQL_stmt_return"`
+	ReturnQuery *plpgSQL_stmt_return_query `json:"PLpgSQL_stmt_return_query"`
+	When        *plpgSQL_case_when         `json:"PLpgSQL_case_when"`
+	While       *plpgSQL_stmt_while        `json:"PLpgSQL_stmt_while"`
 }
 
 // Convert converts the JSON statement into its output form.
@@ -519,6 +526,13 @@ func (stmt *plpgSQL_stmt_raise) Convert() Raise {
 func (stmt *plpgSQL_stmt_return) Convert() Return {
 	return Return{
 		Expression: stmt.Expression.Expression.Query,
+	}
+}
+
+// Convert converts the JSON statement into its output form.
+func (stmt *plpgSQL_stmt_return_query) Convert() ReturnQuery {
+	return ReturnQuery{
+		Query: stmt.Query.Expression.Query,
 	}
 }
 

--- a/server/plpgsql/json_convert.go
+++ b/server/plpgsql/json_convert.go
@@ -86,6 +86,8 @@ func jsonConvertStatement(stmt statement) (Statement, error) {
 		return stmt.Raise.Convert(), nil
 	case stmt.Return != nil:
 		return stmt.Return.Convert(), nil
+	case stmt.ReturnQuery != nil:
+		return stmt.ReturnQuery.Convert(), nil
 	case stmt.While != nil:
 		return stmt.While.Convert()
 	default:

--- a/server/plpgsql/statements.go
+++ b/server/plpgsql/statements.go
@@ -298,6 +298,33 @@ type Record struct {
 	Fields []string
 }
 
+// ReturnQuery represents a RETURN QUERY statement.
+type ReturnQuery struct {
+	Query string
+}
+
+var _ Statement = ReturnQuery{}
+
+// OperationSize implements the interface Statement.
+func (r ReturnQuery) OperationSize() int32 {
+	return 1
+}
+
+// AppendOperations implements the interface Statement.
+func (r ReturnQuery) AppendOperations(ops *[]InterpreterOperation, stack *InterpreterStack) error {
+	query, referencedVariables, err := substituteVariableReferences(r.Query, stack)
+	if err != nil {
+		return err
+	}
+
+	*ops = append(*ops, InterpreterOperation{
+		OpCode:        OpCode_ReturnQuery,
+		PrimaryData:   query,
+		SecondaryData: referencedVariables,
+	})
+	return nil
+}
+
 // Return represents a RETURN statement.
 type Return struct {
 	Expression string


### PR DESCRIPTION
Adds support for user-defined functions that use `RETURNS SETOF` to return values of a composite type. 

Support for UDFs that use `RETURNS TABLE` to return an anonymous composite type will be added as a follow up. 