### PR TITLE
Fixed issue 2206

### DIFF
--- a/postgres/parser/parser/sql.y
+++ b/postgres/parser/parser/sql.y
@@ -9460,6 +9460,10 @@ index_elem:
   {
     $$.val = tree.IndexElem{Expr: $2.expr(), Collation: $4.unresolvedObjectName().UnquotedString(), OpClass: $5.opClass(), Direction: $6.dir(), NullsOrder: $7.nullsOrder()}
   }
+| func_expr opt_collate opt_opclass opt_asc_desc opt_nulls_order
+  {
+    $$.val = tree.IndexElem{Expr: $1.expr(), Collation: $2.unresolvedObjectName().UnquotedString(), OpClass: $3.opClass(), Direction: $4.dir(), NullsOrder: $5.nullsOrder()}
+  }
 
 opt_opclass:
   /* EMPTY */


### PR DESCRIPTION
This is a fix for:
* https://github.com/dolthub/doltgresql/issues/2206

 I've added a skipped test to verify that the syntax error portion is fixed, however we don't yet support expression index attributes, so the test overall fails. However, the issue only covers the syntax portion which we're addressing here.