### PR TITLE
sqlAlchemy integration tests

### DIFF
--- a/testing/PostgresDockerfile
+++ b/testing/PostgresDockerfile
@@ -78,6 +78,9 @@ COPY ./testing/postgres-client-tests/ruby/Gemfile.lock /postgres-client-tests/ru
 WORKDIR /postgres-client-tests/ruby
 RUN gem install bundler -v 2.1.4 && bundle install
 
+# install sqlalchemy
+RUN pip3 install --no-cache-dir sqlalchemy==2.0.46
+
 # install doltgres from source
 WORKDIR /root/building
 COPY go.mod doltgresql/

--- a/testing/postgres-client-tests/postgres-client-tests.bats
+++ b/testing/postgres-client-tests/postgres-client-tests.bats
@@ -72,3 +72,8 @@ teardown() {
     cd $BATS_TEST_DIRNAME/python
     python3 psycopg2_test.py $USER $PORT
 }
+
+@test "python postgres: sqlalcchemy client" {
+    cd $BATS_TEST_DIRNAME/python
+    python3 sqlalchemy-test.py $USER $PORT
+}

--- a/testing/postgres-client-tests/python/sqlalchemy-test.py
+++ b/testing/postgres-client-tests/python/sqlalchemy-test.py
@@ -1,0 +1,67 @@
+import sqlalchemy
+import psycopg2
+
+from sqlalchemy.engine import Engine
+from sqlalchemy import create_engine
+from sqlalchemy import text
+
+import sys
+
+QUERY_RESPONSE = [
+    {"create table test (pk int, \"value\" int, primary key(pk))": []},
+    {"describe test": [
+        ('pk', 'integer', 'NO', 'PRI', None, ''),
+        ('value', 'integer', 'YES', '', None, '')
+    ]},
+    {"insert into test (pk, value) values (0,0)": ()},
+    {"select * from test": [(0, 0)]},
+    {"select dolt_add('-A');": [(['0'],)]},
+    {"select dolt_commit('-m', 'my commit')": [('',)]},
+    {"select COUNT(*) FROM dolt_log": [(3,)]},
+    {"select dolt_checkout('-b', 'mybranch')": [(['0', "Switched to branch 'mybranch'"],)]},
+    {"insert into test (pk, value) values (1,1)": []},
+    {"select dolt_commit('-a', '-m', 'my commit2')": [('',)]},
+    {"select dolt_checkout('main')": [(['0', "Switched to branch 'main'"],)]},
+    {"select dolt_merge('mybranch')": [('',1,0,)]},
+    {"select COUNT(*) FROM dolt_log": [(4,)]},
+]
+
+
+def main():
+    user = sys.argv[1]
+    port = int(sys.argv[2])
+
+    conn_string_base = "postgresql+psycopg2://"
+
+    engine = create_engine(conn_string_base +
+                           "{user}:password@127.0.0.1:{port}/postgres".format(user=user,
+                                                                 port=port)
+                           )
+
+    with engine.connect() as con:
+        for query_response in QUERY_RESPONSE:
+            query = list(query_response.keys())[0]
+            exp_results = query_response[query]
+
+            result_proxy = con.execute(text(query))
+
+            try:
+                results = result_proxy.fetchall()
+                if (results != exp_results) and ("dolt_commit" not in query) and ("dolt_merge" not in query):
+                    print("Query:")
+                    print(query)
+                    print("Expected:")
+                    print(exp_results)
+                    print("Received:")
+                    print(results)
+                    sys.exit(1)
+            # You can't call fetchall on an insert
+            # so we'll just ignore the exception
+            except sqlalchemy.exc.ResourceClosedError:
+                pass
+
+    con.close()
+    sys.exit(0)
+
+
+main()


### PR DESCRIPTION
Integration tests for sqlAlchemy.

Pretty similar to our standard dolt sqlAlchemy tests, with a couple of differences. I used the newer version of sqlAlchemy (2.0.46) and had to make some setup changes using features that were introduced in 2.x builds. 

psycopg2 seems to convert row results into python lists as well so the expected results had to be changed. I couldn't find confirmation but it seems like that would be the expected behavior (from what claude found).