### PR TITLE
Fixed issues 2316 and 2318

### DIFF
--- a/server/functions/make_timestamp.go
+++ b/server/functions/make_timestamp.go
@@ -42,11 +42,7 @@ var make_timestamp = framework.Function6{
 	IsNonDeterministic: true,
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [7]*pgtypes.DoltgresType, val1, val2, val3, val4, val5, val6 any) (any, error) {
-		loc, err := GetServerLocation(ctx)
-		if err != nil {
-			return time.Time{}, err
-		}
-		return getTimestampInServerLocation(val1.(int32), val2.(int32), val3.(int32), val4.(int32), val5.(int32), val6.(float64), loc)
+		return getTimestampInServerLocation(val1.(int32), val2.(int32), val3.(int32), val4.(int32), val5.(int32), val6.(float64), time.UTC)
 	},
 }
 

--- a/server/functions/to_date.go
+++ b/server/functions/to_date.go
@@ -15,6 +15,8 @@
 package functions
 
 import (
+	"time"
+
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -37,6 +39,8 @@ var to_date_text_text = framework.Function2{
 		format := val2.(string)
 
 		// Parse the date using PostgreSQL format patterns
-		return getDateTimeFromFormat(ctx, input, format)
+		t, err := getDateTimeFromFormat(ctx, input, format)
+		// We return a version of the time but with the timezone completely stripped since they do not use timezones
+		return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC), err
 	},
 }

--- a/testing/postgres-client-tests/postgres-client-tests.bats
+++ b/testing/postgres-client-tests/postgres-client-tests.bats
@@ -103,5 +103,5 @@ teardown() {
 
 @test "rust sqlx" {
     cd $BATS_TEST_DIRNAME/rust
-    cargo run -- $USER $PORT
+    RUSTFLAGS=-Awarnings cargo run -- $USER $PORT
 }

--- a/testing/postgres-client-tests/rust/Cargo.toml
+++ b/testing/postgres-client-tests/rust/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 
 [dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "tls-native-tls"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "tls-native-tls", "uuid", "chrono"] }

--- a/testing/postgres-client-tests/rust/src/main.rs
+++ b/testing/postgres-client-tests/rust/src/main.rs
@@ -1,4 +1,15 @@
 use sqlx::postgres::PgPoolOptions;
+use sqlx::types::Uuid;
+use sqlx::types::chrono::Utc;
+use sqlx::types::chrono::DateTime;
+use sqlx::types::chrono::NaiveDate;
+
+#[derive(sqlx::FromRow)]
+struct Event {
+	id: sqlx::types::Uuid,
+	created_at: DateTime<Utc>,
+	event_date: Option<NaiveDate>,
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -15,12 +26,50 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		.max_connections(5)
 		.connect(&database_url)
 		.await?;
-	let exists: bool = sqlx::query_scalar(
-		"SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_tables WHERE tablename = $1);"
-	)
-	.bind("test_table")
-	.fetch_one(&pool)
-	.await?;
+ 
+	let exists: bool = sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_tables WHERE tablename = $1);")
+		.bind("test_table")
+		.fetch_one(&pool)
+		.await?;
 	println!("exists={exists}");
+
+	sqlx::query("DROP TABLE IF EXISTS users, events;")
+		.execute(&pool)
+		.await?;
+
+	sqlx::query("CREATE TABLE users (id uuid default gen_random_uuid(), name text, email text);")
+		.execute(&pool)
+		.await?;
+
+	sqlx::query("INSERT INTO users (name, email) VALUES ($1, $2)")
+		.bind("Alice")
+		.bind("alice@example.com")
+		.execute(&pool)
+		.await?;
+
+	let some_uuid: Uuid = sqlx::query_scalar("SELECT id FROM users WHERE email = $1 LIMIT 1")
+		.bind("alice@example.com")
+		.fetch_one(&pool)
+		.await?;
+
+	sqlx::query("UPDATE users SET name = $1 WHERE id = $2")
+		.bind("Bob")
+		.bind(some_uuid)
+		.execute(&pool)
+		.await?;
+
+	sqlx::query("CREATE TABLE events (id UUID PRIMARY KEY, created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(), event_date DATE);")
+		.execute(&pool)
+		.await?;
+
+	let some_id: Uuid = sqlx::query_scalar("INSERT INTO events (id, event_date) VALUES (gen_random_uuid(), '2026-02-12') RETURNING id;")
+		.fetch_one(&pool)
+		.await?;
+
+	let __event = sqlx::query_as::<_, Event>("SELECT * FROM events WHERE id = $1")
+		.bind(some_id)
+		.fetch_one(&pool)
+		.await?;
+
 	Ok(())
 }


### PR DESCRIPTION
This fixes:
* https://github.com/dolthub/doltgresql/issues/2316
* https://github.com/dolthub/doltgresql/issues/2318

For [2316](https://github.com/dolthub/doltgresql/issues/2316), clients may only send a single format code that should apply to multiple values, but we assumed that their lengths always matched. This is fixed by extending the format code slice length to the same as the value slice if there is a single format code provided.

For [2318](https://github.com/dolthub/doltgresql/issues/2318), it appears that Rust wants these values in binary format, so now we're returning them in binary format. I'm not sure why Rust doesn't accept text format like everything else does, but perhaps it's the default in Postgres so some ORMs only work with the default.

It's worth mentioning that tests for these exist only within the client tests, as I could not replicate the errors within our standard testing framework. As mentioned with the binary format, it seems that Rust isn't as permissive as other ORMs, so we have to test with Rust specifically.