### PR TITLE
Fix ALTER TABLE ... DROP CONSTRAINT for UNIQUE constraints

### DIFF
--- a/server/analyzer/convert_drop_unique_constraint.go
+++ b/server/analyzer/convert_drop_unique_constraint.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzer
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/analyzer"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/transform"
+)
+
+// convertDropUniqueConstraint converts a DropConstraint node dropping a unique constraint into
+// an AlterIndex node with IndexAction_Drop that GMS can process to remove the unique index.
+func convertDropUniqueConstraint(ctx *sql.Context, _ *analyzer.Analyzer, n sql.Node, _ *plan.Scope, _ analyzer.RuleSelector, _ *sql.QueryFlags) (sql.Node, transform.TreeIdentity, error) {
+	return transform.Node(n, func(n sql.Node) (sql.Node, transform.TreeIdentity, error) {
+		dropConstraint, ok := n.(*plan.DropConstraint)
+		if !ok {
+			return n, transform.SameTree, nil
+		}
+
+		rt, ok := dropConstraint.Child.(*plan.ResolvedTable)
+		if !ok {
+			return nil, transform.SameTree, analyzer.ErrInAnalysis.New(
+				"Expected a TableNode for ALTER TABLE DROP CONSTRAINT statement")
+		}
+
+		table := rt.Table
+		if it, ok := table.(sql.IndexAddressableTable); ok {
+			indexes, err := it.GetIndexes(ctx)
+			if err != nil {
+				return nil, transform.SameTree, err
+			}
+			for _, index := range indexes {
+				if index.IsUnique() && index.ID() != "PRIMARY" && index.ID() == dropConstraint.Name {
+					alterDropIndex := plan.NewAlterDropIndex(rt.Database(), rt, dropConstraint.IfExists, dropConstraint.Name)
+					newNode, err := alterDropIndex.WithTargetSchema(rt.Schema())
+					if err != nil {
+						return n, transform.SameTree, err
+					}
+					return newNode, transform.NewTree, nil
+				}
+			}
+		}
+
+		return n, transform.SameTree, nil
+	})
+}

--- a/server/analyzer/init.go
+++ b/server/analyzer/init.go
@@ -36,6 +36,7 @@ const (
 	ruleId_AssignTriggers                                                // assignTriggers
 	ruleId_AssignUpdateCasts                                             // assignUpdateCasts
 	ruleId_ConvertDropPrimaryKeyConstraint                               // convertDropPrimaryKeyConstraint
+	ruleId_ConvertDropUniqueConstraint                                   // convertDropUniqueConstraint
 	ruleId_GenerateForeignKeyName                                        // generateForeignKeyName
 	ruleId_ReplaceIndexedTables                                          // replaceIndexedTables
 	ruleId_ReplaceNode                                                   // replaceNode
@@ -68,7 +69,8 @@ func Init() {
 
 	analyzer.OnceBeforeDefault = append([]analyzer.Rule{
 		{Id: ruleId_ApplyTablesForAnalyzeAllTables, Apply: applyTablesForAnalyzeAllTables},
-		{Id: ruleId_ConvertDropPrimaryKeyConstraint, Apply: convertDropPrimaryKeyConstraint}},
+		{Id: ruleId_ConvertDropPrimaryKeyConstraint, Apply: convertDropPrimaryKeyConstraint},
+		{Id: ruleId_ConvertDropUniqueConstraint, Apply: convertDropUniqueConstraint}},
 		analyzer.OnceBeforeDefault...)
 
 	// We remove several validation rules and substitute our own


### PR DESCRIPTION
## Summary

`ALTER TABLE ... DROP CONSTRAINT "name"` fails with `Constraint "name" does not exist` when the constraint is a UNIQUE constraint. This affects both inline (`CREATE TABLE ... UNIQUE(...)`) and ALTER-added (`ALTER TABLE ADD CONSTRAINT ... UNIQUE(...)`) UNIQUE constraints.

DROP CONSTRAINT works correctly for CHECK, FOREIGN KEY, and PRIMARY KEY. Only UNIQUE is broken.

**Impact:** Blocks any ORM/migration tool (Drizzle, Prisma, Knex) that generates standard PostgreSQL `DROP CONSTRAINT` for UNIQUE constraint changes.

## Root cause

The existing `convertDropPrimaryKeyConstraint` analyzer rule intercepts `plan.DropConstraint` and converts PK drops to `plan.AlterDropPk`. No equivalent rule exists for UNIQUE constraints. GMS's default `DropConstraint` handler checks `GetChecks()` and `GetDeclaredForeignKeys()` but never calls `GetIndexes()`, so UNIQUE constraints (stored as `sql.Index` with `IsUnique()=true`) are never found.

## Fix

Added `convertDropUniqueConstraint` analyzer rule mirroring the PK handler:
- Intercepts `plan.DropConstraint` nodes
- Looks up indexes via `sql.IndexAddressableTable.GetIndexes()`
- If a matching unique (non-PK) index is found, converts to `plan.NewAlterDropIndex`
- Handles `IF EXISTS` correctly

## Files changed

- **New:** `server/analyzer/convert_drop_unique_constraint.go`
- **Modified:** `server/analyzer/init.go` (rule ID + registration)
- **Modified:** `testing/go/alter_table_test.go` (5 new test cases)

## Test coverage

- Drop unique constraint added via ALTER TABLE
- Drop unique constraint defined inline in CREATE TABLE
- Drop unique constraint with IF EXISTS
- Drop unique constraint on single column
- Drop and re-add unique constraint with different columns

## Reproduction

```sql
CREATE TABLE t1 (pk int PRIMARY KEY, c1 int, c2 int);
ALTER TABLE t1 ADD CONSTRAINT uniq_c1c2 UNIQUE (c1, c2);

-- Verify constraint exists:
SELECT conname, contype FROM pg_constraint WHERE conrelid = 't1'::regclass;
--  conname   | contype
-- -----------+---------
--  t1_pkey   | p
--  uniq_c1c2 | u

-- Before fix: ERROR: Constraint "uniq_c1c2" does not exist
-- After fix: ALTER TABLE (succeeds)
ALTER TABLE t1 DROP CONSTRAINT uniq_c1c2;
```