### PR TITLE
Fix exec_sql to use configured credentials instead of hardcoded defaults

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -92,15 +92,21 @@ exec_sql() {
   echo "running psql command found in: "
   echo $(which psql)
   
+  local pg_user pg_password
+  pg_user=$(get_env_var "USER")
+  pg_password=$(get_env_var "PASSWORD")
+  pg_user="${pg_user:-postgres}"
+  pg_password="${pg_password:-password}"
+
   while true; do
       if [ -n "$query" ]; then
           set +e
-          output=$(PGPASSWORD=password psql -h 127.0.0.1 -U postgres -c "$query" 2>&1)
+          output=$(PGPASSWORD="$pg_password" psql -h 127.0.0.1 -U "$pg_user" -c "$query" 2>&1)
           status=$?
           set -e
     else
       set +e # tmp disabled to initdb.d/ file err
-      output=$(PGPASSWORD=password psql -h 127.0.0.1 -U postgres < /dev/stdin 2>&1)
+      output=$(PGPASSWORD="$pg_password" psql -h 127.0.0.1 -U "$pg_user" < /dev/stdin 2>&1)
       status=$?
       set -e
     fi


### PR DESCRIPTION
## Summary

- `exec_sql` in `docker-entrypoint.sh` hardcoded `PGPASSWORD=password` and `-U postgres`, causing init scripts in `/docker-entrypoint-initdb.d/` to silently fail when `DOLTGRES_USER`/`DOLTGRES_PASSWORD` are set to custom values
- Now uses the existing `get_env_var` helper to read configured credentials, falling back to `postgres`/`password` only when neither env var is set

## Test plan

- [ ] `docker run` with default credentials — init scripts should still work
- [ ] `docker run` with `DOLTGRES_USER=myuser DOLTGRES_PASSWORD=mypass` — init scripts should connect as `myuser`
- [ ] `docker run` with `POSTGRES_USER=myuser POSTGRES_PASSWORD=mypass` — same behavior via POSTGRES_* compat

Fixes #2300