### PR TITLE
Added proper support for receiving binary formatted values

### DIFF
--- a/core/typecollection/collection_funcs.go
+++ b/core/typecollection/collection_funcs.go
@@ -168,9 +168,18 @@ func (*TypeCollection) Serializer() objinterface.RootObjectSerializer {
 
 // UpdateRoot implements the interface objinterface.Collection.
 func (pgs *TypeCollection) UpdateRoot(ctx context.Context, root objinterface.RootValue) (objinterface.RootValue, error) {
+	initialCount, initialCountErr := pgs.underlyingMap.Count()
 	m, err := pgs.Map(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if initialCountErr == nil && initialCount == 0 {
+		if currentCount, currentCountErr := m.Count(); currentCountErr == nil && currentCount == 0 {
+			// In this specific case, we can guarantee that we haven't updated anything, so we won't write to the root.
+			// This preserves that the collection is only written when there's a meaningful data change, otherwise
+			// writing an empty collection will change the hash of a root if it previously had no collection.
+			return root, nil
+		}
 	}
 	return storage.WriteProllyMap(ctx, root, m)
 }

--- a/server/doltgres_handler.go
+++ b/server/doltgres_handler.go
@@ -17,16 +17,12 @@ package server
 import (
 	"context"
 	"encoding/base64"
-	"encoding/binary"
-	"encoding/hex"
 	goerrors "errors"
 	"fmt"
 	"io"
 	"os"
 	"regexp"
 	"runtime/trace"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -44,8 +40,8 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/sirupsen/logrus"
 
+	"github.com/dolthub/doltgresql/core"
 	"github.com/dolthub/doltgresql/core/id"
-	"github.com/dolthub/doltgresql/postgres/parser/uuid"
 	"github.com/dolthub/doltgresql/server/auth"
 	pgexprs "github.com/dolthub/doltgresql/server/expression"
 	pgtransform "github.com/dolthub/doltgresql/server/transform"
@@ -303,142 +299,39 @@ func (h *DoltgresHandler) InitSessionParameterDefault(ctx context.Context, c *my
 func (h *DoltgresHandler) convertBindParameters(ctx *sql.Context, types []uint32, formatCodes []int16, values [][]byte) (map[string]sqlparser.Expr, error) {
 	bindings := make(map[string]sqlparser.Expr, len(values))
 	// It's valid to send just one format code that should be used by all values, so we extend the slice in that case
-	if len(formatCodes) > 0 && len(formatCodes) < len(values) {
-		if len(formatCodes) > 1 {
-			return nil, errors.Errorf(`format codes have length "%d" but values have length "%d"`, len(formatCodes), len(values))
-		}
-		formatCode := formatCodes[0]
-		formatCodes = make([]int16, len(values))
-		formatCodes[0] = formatCode
-		for i := 1; i < len(values); i++ {
-			formatCodes[i] = formatCode
-		}
+	formatCodes, err := extendFormatCodes(len(values), formatCodes)
+	if err != nil {
+		return nil, err
+	}
+	typeColl, err := core.GetTypesCollectionFromContext(ctx)
+	if err != nil {
+		return nil, err
 	}
 	for i := range values {
-		formatCode := int16(0)
-		if formatCodes != nil {
-			formatCode = formatCodes[i]
-		}
-		bindVarString, err := h.convertBindParameterToString(types[i], values[i], formatCode)
+		formatCode := formatCodes[i]
+		dgType, err := typeColl.GetType(ctx, id.Type(id.Cache().ToInternal(types[i])))
 		if err != nil {
 			return nil, err
 		}
-
-		pgTyp, ok := pgtypes.IDToBuiltInDoltgresType[id.Type(id.Cache().ToInternal(types[i]))]
-		if !ok {
-			return nil, errors.Errorf("unhandled oid type: %v", types[i])
-		}
-		if bindVarString == nil {
-			bindings[fmt.Sprintf("v%d", i+1)] = sqlparser.InjectedExpr{Expression: pgexprs.NewUnsafeLiteral(nil, pgTyp)}
-		} else {
-			v, err := pgTyp.IoInput(ctx, *bindVarString)
-			if err != nil {
-				return nil, err
+		if values[i] != nil {
+			if formatCode == 0 {
+				v, err := dgType.IoInput(ctx, string(values[i]))
+				if err != nil {
+					return nil, err
+				}
+				bindings[fmt.Sprintf("v%d", i+1)] = sqlparser.InjectedExpr{Expression: pgexprs.NewUnsafeLiteral(v, dgType)}
+			} else {
+				v, err := dgType.CallReceive(ctx, values[i])
+				if err != nil {
+					return nil, err
+				}
+				bindings[fmt.Sprintf("v%d", i+1)] = sqlparser.InjectedExpr{Expression: pgexprs.NewUnsafeLiteral(v, dgType)}
 			}
-			bindings[fmt.Sprintf("v%d", i+1)] = sqlparser.InjectedExpr{Expression: pgexprs.NewUnsafeLiteral(v, pgTyp)}
+		} else {
+			bindings[fmt.Sprintf("v%d", i+1)] = sqlparser.InjectedExpr{Expression: pgexprs.NewUnsafeLiteral(nil, dgType)}
 		}
 	}
 	return bindings, nil
-}
-
-// convertBindParameterToString converts a bind parameter to its string representation.
-// It handles both text and binary format parameters, with special handling for certain types
-// that cannot be directly scanned into strings when in binary format. |typ| is the PostgreSQL
-// type OID, |value| is the raw param value in bytes, and |formatCode| indicates text (0) or
-// binary (1) format.
-//
-// This function relies on the pgtype library to decode values, in text and binary formats,
-// however, a few types cannot be scanned directly into strings from the binary format by this
-// library, so there is special handling for them.
-func (h *DoltgresHandler) convertBindParameterToString(typ uint32, value []byte, formatCode int16) (bindVarString *string, err error) {
-	isBinaryFormat := formatCode == pgtype.BinaryFormatCode
-
-	switch {
-	case (typ == pgtype.TimestampOID || typ == pgtype.TimestamptzOID) && isBinaryFormat:
-		var t *time.Time
-		if err := h.pgTypeMap.Scan(typ, formatCode, value, &t); err != nil {
-			return nil, err
-		}
-		if t != nil {
-			format := t.Format("2006-01-02 15:04:05")
-			bindVarString = &format
-		}
-	case typ == pgtype.DateOID && isBinaryFormat:
-		var d *pgtype.Date
-		if err := h.pgTypeMap.Scan(typ, formatCode, value, &d); err != nil {
-			return nil, err
-		}
-		if d != nil {
-			format := d.Time.Format("2006-01-02")
-			bindVarString = &format
-		}
-	case typ == pgtype.BoolOID && isBinaryFormat:
-		var b *bool
-		if err := h.pgTypeMap.Scan(typ, formatCode, value, &b); err != nil {
-			return nil, err
-		}
-		if b != nil {
-			if *b {
-				var t = "true"
-				bindVarString = &t
-			} else {
-				var f = "false"
-				bindVarString = &f
-			}
-		}
-	case typ == pgtype.ByteaOID && isBinaryFormat:
-		if value != nil {
-			s := `\x` + hex.EncodeToString(value)
-			bindVarString = &s
-		}
-	case typ == pgtype.Int2OID && isBinaryFormat:
-		if value != nil {
-			formatInt := strconv.FormatInt(int64(binary.BigEndian.Uint16(value)), 10)
-			bindVarString = &formatInt
-		}
-	case typ == pgtype.Int4OID && isBinaryFormat:
-		if value != nil {
-			formatInt := strconv.FormatInt(int64(binary.BigEndian.Uint32(value)), 10)
-			bindVarString = &formatInt
-		}
-	case typ == pgtype.Int8OID && isBinaryFormat:
-		if value != nil {
-			formatInt := strconv.FormatInt(int64(binary.BigEndian.Uint64(value)), 10)
-			bindVarString = &formatInt
-		}
-	case typ == pgtype.UUIDOID && isBinaryFormat:
-		if value != nil {
-			u, err := uuid.FromBytes(value)
-			if err != nil {
-				return nil, err
-			}
-			s := u.String()
-			bindVarString = &s
-		}
-	case typ == pgtype.TextArrayOID && isBinaryFormat:
-		if value != nil {
-			m := pgtype.NewMap()
-			var textArray []string
-			scanPlan := m.PlanScan(pgtype.TextArrayOID, pgtype.BinaryFormatCode, &textArray)
-			err = scanPlan.Scan(value, &textArray)
-			if err != nil {
-				return nil, err
-			}
-			quotedArray := make([]string, len(textArray))
-			for i, v := range textArray {
-				quotedArray[i] = `"` + strings.ReplaceAll(v, `"`, `\"`) + `"`
-			}
-			formattedArray := "{" + strings.Join(quotedArray, ",") + "}"
-			bindVarString = &formattedArray
-		}
-	default:
-		// For text format or types that can handle binary-to-string conversion
-		if err := h.pgTypeMap.Scan(typ, formatCode, value, &bindVarString); err != nil {
-			return nil, err
-		}
-	}
-
-	return bindVarString, nil
 }
 
 var queryLoggingRegex = regexp.MustCompile(`[\r\n\t ]+`)

--- a/server/functions/array.go
+++ b/server/functions/array.go
@@ -15,12 +15,12 @@
 package functions
 
 import (
-	"encoding/binary"
 	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
+	"github.com/dolthub/doltgresql/core"
 	"github.com/dolthub/doltgresql/core/id"
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
@@ -162,14 +162,53 @@ var array_recv = framework.Function3{
 	Return:     pgtypes.AnyArray,
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Internal, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
-	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		data := val1.([]byte)
-		baseTypeOid := val2.(id.Id)
-		baseType := pgtypes.IDToBuiltInDoltgresType[id.Type(baseTypeOid)]
-		typmod := val3.(int32)
-		baseType = baseType.WithAttTypMod(typmod)
-		return deserializeArray(ctx, data, baseType)
-	},
+	Callable:   array_recv_callable,
+}
+
+// array_recv_callable is the function definition of array_recv.
+func array_recv_callable(ctx *sql.Context, t [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
+	data := val1.([]byte)
+	if data == nil {
+		return nil, nil
+	}
+	typeColl, err := core.GetTypesCollectionFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	reader := utils.NewWireReader(data)
+	dimensions := reader.ReadInt32()
+	_ = reader.ReadInt32() // Whether the array has a null, doesn't seem useful
+	baseTypeID := id.Type(id.Cache().ToInternal(reader.ReadUint32()))
+	baseType, err := typeColl.GetType(ctx, baseTypeID)
+	if err != nil {
+		return nil, err
+	}
+	if baseType == nil {
+		return nil, pgtypes.ErrTypeDoesNotExist.New(baseTypeID.TypeName())
+	}
+	// TODO: handle more than 1 dimension
+	if dimensions > 1 {
+		return nil, errors.Errorf("array dimensions greater than 1 are not yet supported")
+	}
+	var vals []any
+	for dimensionIdx := int32(0); dimensionIdx < dimensions; dimensionIdx++ {
+		elementsCount := reader.ReadInt32()
+		_ = reader.ReadInt32() // Lower bound, not sure what to do with this
+		for i := int32(0); i < elementsCount; i++ {
+			elementLen := reader.ReadInt32()
+			if elementLen != -1 {
+				valBytes := reader.ReadBytes(uint32(elementLen))
+				val, err := baseType.CallReceive(ctx, valBytes)
+				if err != nil {
+					return nil, err
+				}
+				vals = append(vals, val)
+			} else {
+				vals = append(vals, nil)
+			}
+		}
+	}
+	return vals, nil
 }
 
 // array_send represents the PostgreSQL function of array type IO send.
@@ -291,36 +330,4 @@ var array_subscript_handler = framework.Function1{
 		// TODO
 		return []byte{}, nil
 	},
-}
-
-// deserializeArray deserializes an array of given base type.
-func deserializeArray(ctx *sql.Context, data []byte, baseType *pgtypes.DoltgresType) ([]any, error) {
-	// Check for the nil value, then ensure the minimum length of the slice
-	if len(data) == 0 {
-		return nil, nil
-	}
-	if len(data) < 4 {
-		return nil, errors.Errorf("deserializing non-nil array value has invalid length of %d", len(data))
-	}
-	// Grab the number of elements and construct an output slice of the appropriate size
-	elementCount := binary.LittleEndian.Uint32(data)
-	output := make([]any, elementCount)
-	// Read all elements
-	for i := uint32(0); i < elementCount; i++ {
-		// We read from i+1 to account for the element count at the beginning
-		offset := binary.LittleEndian.Uint32(data[(i+1)*4:])
-		// If the value is null, then we can skip it, since the output slice default initializes all values to nil
-		if data[offset] == 1 {
-			continue
-		}
-		// The element data is everything from the offset to the next offset, excluding the null determinant
-		nextOffset := binary.LittleEndian.Uint32(data[(i+2)*4:])
-		o, err := baseType.DeserializeValue(ctx, data[offset+1:nextOffset])
-		if err != nil {
-			return nil, err
-		}
-		output[i] = o
-	}
-	// Returns all read elements
-	return output, nil
 }

--- a/server/functions/bit.go
+++ b/server/functions/bit.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/jackc/pgtype"
 
 	"github.com/dolthub/doltgresql/postgres/parser/sem/tree"
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -82,11 +83,24 @@ var bitrecv = framework.Function3{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
 		data := val1.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		reader := utils.NewReader(data)
-		return reader.String(), nil
+		typmod := val3.(int32)
+		var out pgtype.Bit
+		err := out.DecodeBinary(nil, data)
+		if err != nil {
+			return nil, err
+		}
+		var str string
+		for _, b := range out.Bytes {
+			str += fmt.Sprintf("%08b", b)
+		}
+		str = str[:out.Len]
+		if typmod != -1 {
+			str = str[:typmod]
+		}
+		return str, nil
 	},
 }
 

--- a/server/functions/bpchar.go
+++ b/server/functions/bpchar.go
@@ -96,14 +96,12 @@ var bpcharrecv = framework.Function3{
 	Return:     pgtypes.BpChar,
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Internal, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
-	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
+	Callable: func(ctx *sql.Context, t [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
 		data := val1.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		// TODO: use typmod?
-		reader := utils.NewReader(data)
-		return reader.String(), nil
+		return t[3].IoInput(ctx, string(data))
 	},
 }
 

--- a/server/functions/bytea.go
+++ b/server/functions/bytea.go
@@ -69,12 +69,7 @@ var bytearecv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
-		if len(data) == 0 {
-			return nil, nil
-		}
-		reader := utils.NewReader(data)
-		return reader.ByteSlice(), nil
+		return val, nil
 	},
 }
 

--- a/server/functions/char.go
+++ b/server/functions/char.go
@@ -73,11 +73,13 @@ var charrecv = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		data := val.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		reader := utils.NewReader(data)
-		return reader.String(), nil
+		if len(data) == 0 {
+			return "", nil
+		}
+		return string(data[0]), nil
 	},
 }
 

--- a/server/functions/date.go
+++ b/server/functions/date.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/jackc/pgtype"
 
 	"github.com/dolthub/doltgresql/postgres/parser/pgdate"
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -75,14 +76,15 @@ var date_recv = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		data := val.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		t := time.Time{}
-		if err := t.UnmarshalBinary(data); err != nil {
+		var out pgtype.Date
+		err := out.DecodeBinary(nil, data)
+		if err != nil {
 			return nil, err
 		}
-		return t, nil
+		return out.Time, nil
 	},
 }
 

--- a/server/functions/enum.go
+++ b/server/functions/enum.go
@@ -78,28 +78,11 @@ var enum_recv = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Internal, pgtypes.Oid},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		// TODO: should return the index instead of label?
 		data := val1.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		reader := utils.NewReader(data)
-		value := reader.String()
-		if ctx == nil {
-			// TODO: currently, in some places we use nil context, should fix it.
-			return value, nil
-		}
-		typ, err := getDoltgresTypeFromId(ctx, val2.(id.Id))
-		if err != nil {
-			return nil, err
-		}
-		if typ.TypCategory != pgtypes.TypeCategory_EnumTypes {
-			return nil, errors.Errorf(`"%s" is not an enum type`, typ.Name())
-		}
-		if _, exists := typ.EnumLabels[value]; !exists {
-			return nil, pgtypes.ErrInvalidInputValueForEnum.New(typ.Name(), value)
-		}
-		return value, nil
+		return string(data), nil
 	},
 }
 

--- a/server/functions/float4.go
+++ b/server/functions/float4.go
@@ -15,8 +15,6 @@
 package functions
 
 import (
-	"encoding/binary"
-	"math"
 	"strconv"
 	"strings"
 
@@ -72,13 +70,11 @@ var float4recv = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		data := val.([]byte)
-		unsignedBits := binary.BigEndian.Uint32(data)
-		if unsignedBits&(1<<31) != 0 {
-			unsignedBits ^= 1 << 31
-		} else {
-			unsignedBits = ^unsignedBits
+		if data == nil {
+			return nil, nil
 		}
-		return math.Float32frombits(unsignedBits), nil
+		reader := utils.NewWireReader(data)
+		return reader.ReadFloat32(), nil
 	},
 }
 

--- a/server/functions/float8.go
+++ b/server/functions/float8.go
@@ -15,8 +15,6 @@
 package functions
 
 import (
-	"encoding/binary"
-	"math"
 	"strconv"
 	"strings"
 
@@ -72,16 +70,11 @@ var float8recv = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		data := val.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		unsignedBits := binary.BigEndian.Uint64(data)
-		if unsignedBits&(1<<63) != 0 {
-			unsignedBits ^= 1 << 63
-		} else {
-			unsignedBits = ^unsignedBits
-		}
-		return math.Float64frombits(unsignedBits), nil
+		reader := utils.NewWireReader(data)
+		return reader.ReadFloat64(), nil
 	},
 }
 

--- a/server/functions/int2.go
+++ b/server/functions/int2.go
@@ -15,7 +15,6 @@
 package functions
 
 import (
-	"encoding/binary"
 	"strconv"
 	"strings"
 
@@ -75,10 +74,11 @@ var int2recv = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		data := val.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		return int16(binary.BigEndian.Uint16(data) - (1 << 15)), nil
+		reader := utils.NewWireReader(data)
+		return reader.ReadInt16(), nil
 	},
 }
 

--- a/server/functions/int2vector.go
+++ b/server/functions/int2vector.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/dolthub/go-mysql-server/sql"
 
+	"github.com/dolthub/doltgresql/core/id"
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
@@ -69,9 +70,9 @@ var int2vectorrecv = framework.Function1{
 	Return:     pgtypes.Int16vector,
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
-	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
-		return deserializeArray(ctx, data, pgtypes.Int16)
+	Callable: func(ctx *sql.Context, t [2]*pgtypes.DoltgresType, val any) (any, error) {
+		tArr := [4]*pgtypes.DoltgresType{t[0], pgtypes.Oid, pgtypes.Int32, t[1]}
+		return array_recv.Callable(ctx, tArr, val, id.Cache().ToOID(t[1].ID.AsId()), -1)
 	},
 }
 

--- a/server/functions/int4.go
+++ b/server/functions/int4.go
@@ -15,7 +15,6 @@
 package functions
 
 import (
-	"encoding/binary"
 	"strconv"
 	"strings"
 
@@ -75,10 +74,11 @@ var int4recv = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		data := val.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		return int32(binary.BigEndian.Uint32(data) - (1 << 31)), nil
+		reader := utils.NewWireReader(data)
+		return reader.ReadInt32(), nil
 	},
 }
 

--- a/server/functions/int8.go
+++ b/server/functions/int8.go
@@ -15,7 +15,6 @@
 package functions
 
 import (
-	"encoding/binary"
 	"strconv"
 	"strings"
 
@@ -75,10 +74,11 @@ var int8recv = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		data := val.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		return int64(binary.BigEndian.Uint64(data) - (1 << 63)), nil
+		reader := utils.NewWireReader(data)
+		return reader.ReadInt64(), nil
 	},
 }
 

--- a/server/functions/interval.go
+++ b/server/functions/interval.go
@@ -16,6 +16,7 @@ package functions
 
 import (
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/jackc/pgtype"
 
 	"github.com/dolthub/doltgresql/utils"
 
@@ -73,16 +74,15 @@ var interval_recv = framework.Function3{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
 		data := val1.([]byte)
-		//oid := val2.(id.Id)
-		//typmod := val3.(int32) // precision
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		reader := utils.NewReader(data)
-		sortNanos := reader.Int64()
-		months := reader.Int32()
-		days := reader.Int32()
-		return duration.Decode(sortNanos, int64(months), int64(days))
+		var out pgtype.Interval
+		err := out.DecodeBinary(nil, data)
+		if err != nil {
+			return nil, err
+		}
+		return duration.MakeDuration(out.Microseconds*1000, int64(out.Days), int64(out.Months)), nil
 	},
 }
 

--- a/server/functions/json.go
+++ b/server/functions/json.go
@@ -70,7 +70,7 @@ var json_recv = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		data := val.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
 		return string(data), nil

--- a/server/functions/jsonb.go
+++ b/server/functions/jsonb.go
@@ -82,14 +82,15 @@ var jsonb_recv = framework.Function1{
 	Return:     pgtypes.JsonB,
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
-	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
+	Callable: func(ctx *sql.Context, t [2]*pgtypes.DoltgresType, val any) (any, error) {
 		data := val.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		reader := utils.NewReader(data)
-		jsonValue, err := pgtypes.JsonValueDeserialize(reader)
-		return pgtypes.JsonDocument{Value: jsonValue}, err
+		if len(data) <= 1 {
+			return "", nil
+		}
+		return t[1].IoInput(ctx, string(data[1:]))
 	},
 }
 

--- a/server/functions/name.go
+++ b/server/functions/name.go
@@ -66,11 +66,11 @@ var namerecv = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		data := val.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		reader := utils.NewReader(data)
-		return reader.String(), nil
+		out, _ := truncateString(string(data), pgtypes.NameLength)
+		return out, nil
 	},
 }
 

--- a/server/functions/numeric.go
+++ b/server/functions/numeric.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/jackc/pgtype"
 	"github.com/shopspring/decimal"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -82,14 +83,16 @@ var numeric_recv = framework.Function3{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
 		data := val1.([]byte)
-		//typmod := val3.(int32)
-		//precision, scale := getPrecisionAndScaleFromTypmod(typmod)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		retVal := decimal.NewFromInt(0)
-		err := retVal.UnmarshalBinary(data)
-		return retVal, err
+		typmod := val3.(int32)
+		var out pgtype.Numeric
+		err := out.DecodeBinary(nil, data)
+		if err != nil {
+			return nil, err
+		}
+		return pgtypes.GetNumericValueWithTypmod(decimal.NewFromBigInt(out.Int, out.Exp), typmod)
 	},
 }
 

--- a/server/functions/oid.go
+++ b/server/functions/oid.go
@@ -80,10 +80,16 @@ var oidrecv = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		data := val.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		return id.Id(data), nil
+		reader := utils.NewWireReader(data)
+		readValue := reader.ReadUint32()
+		cachedID := id.Cache().ToInternal(readValue)
+		if cachedID.IsValid() {
+			return cachedID, nil
+		}
+		return id.NewOID(readValue).AsId(), nil
 	},
 }
 

--- a/server/functions/oidvector.go
+++ b/server/functions/oidvector.go
@@ -71,9 +71,9 @@ var oidvectorrecv = framework.Function1{
 	Return:     pgtypes.Oidvector,
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
-	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
-		return deserializeArray(ctx, data, pgtypes.Oid)
+	Callable: func(ctx *sql.Context, t [2]*pgtypes.DoltgresType, val any) (any, error) {
+		tArr := [4]*pgtypes.DoltgresType{t[0], pgtypes.Oid, pgtypes.Int32, t[1]}
+		return array_recv.Callable(ctx, tArr, val, id.Cache().ToOID(t[1].ID.AsId()), -1)
 	},
 }
 

--- a/server/functions/record.go
+++ b/server/functions/record.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/doltgresql/core"
+
 	"github.com/dolthub/doltgresql/core/id"
 	pgexprs "github.com/dolthub/doltgresql/server/expression"
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -70,49 +71,46 @@ var record_recv = framework.Function3{
 	Return:     pgtypes.Record,
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Internal, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
-	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		data, ok := val1.([]byte)
-		if !ok {
-			return nil, errors.Errorf("expected []byte, but got `%T`", val1)
-		}
-		typeColl, err := core.GetTypesCollectionFromContext(ctx)
+	Callable:   record_recv_callable,
+}
+
+// record_recv_callable is the function definition of record_recv.
+func record_recv_callable(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
+	data := val1.([]byte)
+	if data == nil {
+		return nil, nil
+	}
+	typeColl, err := core.GetTypesCollectionFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	reader := utils.NewWireReader(data)
+	count := reader.ReadInt32()
+	recordVals := make([]pgtypes.RecordValue, count)
+	for i := range recordVals {
+		typeID := id.Type(id.Cache().ToInternal(reader.ReadUint32()))
+		recordType, err := typeColl.GetType(ctx, typeID)
 		if err != nil {
 			return nil, err
 		}
-		reader := utils.NewReader(data)
-		version := reader.Byte()
-		switch version {
-		case 0:
-			valuesLen := reader.VariableUint()
-			values := make([]pgtypes.RecordValue, valuesLen)
-			for i := uint64(0); i < valuesLen; i++ {
-				typeId := id.Type(reader.Id())
-				valueData := reader.ByteSlice()
-				dgtype, err := typeColl.GetType(ctx, typeId)
-				if err != nil {
-					return nil, err
-				}
-				if dgtype == nil {
-					return nil, errors.Errorf("record_recv encountered type `%s.%s` which could not be found",
-						typeId.SchemaName(), typeId.TypeName())
-				}
-				value, err := dgtype.DeserializeValue(ctx, valueData)
-				if err != nil {
-					return nil, err
-				}
-				values[i] = pgtypes.RecordValue{
-					Value: value,
-					Type:  dgtype,
-				}
-			}
-			if reader.RemainingBytes() > 0 {
-				return nil, errors.New("record_recv encountered extra data during deserialization")
-			}
-			return values, nil
-		default:
-			return nil, errors.Errorf("version %d of record serialization is not supported, please upgrade the server", version)
+		if recordType == nil {
+			return nil, pgtypes.ErrTypeDoesNotExist.New(typeID.TypeName())
 		}
-	},
+		valLen := reader.ReadInt32()
+		var recordVal any
+		if valLen != -1 {
+			valBytes := reader.ReadBytes(uint32(valLen))
+			recordVal, err = recordType.CallReceive(ctx, valBytes)
+			if err != nil {
+				return nil, err
+			}
+		}
+		recordVals[i] = pgtypes.RecordValue{
+			Value: recordVal,
+			Type:  recordType,
+		}
+	}
+	return recordVals, nil
 }
 
 // record_send represents the PostgreSQL function of record type IO send. The output of this function is expected to

--- a/server/functions/regclass.go
+++ b/server/functions/regclass.go
@@ -206,10 +206,12 @@ var regclassrecv = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		data := val.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		return id.Id(data), nil
+		reader := utils.NewWireReader(data)
+		cachedID := id.Cache().ToInternal(reader.ReadUint32())
+		return cachedID, nil
 	},
 }
 

--- a/server/functions/regproc.go
+++ b/server/functions/regproc.go
@@ -94,10 +94,12 @@ var regprocrecv = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		data := val.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		return id.Id(data), nil
+		reader := utils.NewWireReader(data)
+		cachedID := id.Cache().ToInternal(reader.ReadUint32())
+		return cachedID, nil
 	},
 }
 

--- a/server/functions/regtype.go
+++ b/server/functions/regtype.go
@@ -119,10 +119,12 @@ var regtyperecv = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		data := val.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		return id.Id(data), nil
+		reader := utils.NewWireReader(data)
+		cachedID := id.Cache().ToInternal(reader.ReadUint32())
+		return cachedID, nil
 	},
 }
 

--- a/server/functions/text.go
+++ b/server/functions/text.go
@@ -62,11 +62,10 @@ var textrecv = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		data := val.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		reader := utils.NewReader(data)
-		return reader.String(), nil
+		return string(data), nil
 	},
 }
 

--- a/server/functions/time.go
+++ b/server/functions/time.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/jackc/pgtype"
 
 	"github.com/dolthub/doltgresql/postgres/parser/sem/tree"
 	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
@@ -79,17 +80,15 @@ var time_recv = framework.Function3{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
 		data := val1.([]byte)
-		//oid := val2.(id.Id)
-		//typmod := val3.(int32)
-		// TODO: decode typmod to precision
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		t := time.Time{}
-		if err := t.UnmarshalBinary(data); err != nil {
+		var out pgtype.Time
+		err := out.DecodeBinary(nil, data)
+		if err != nil {
 			return nil, err
 		}
-		return t, nil
+		return time.UnixMicro(out.Microseconds).UTC(), nil
 	},
 }
 

--- a/server/functions/timestamp.go
+++ b/server/functions/timestamp.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/jackc/pgtype"
 
 	"github.com/dolthub/doltgresql/postgres/parser/sem/tree"
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -78,17 +79,15 @@ var timestamp_recv = framework.Function3{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
 		data := val1.([]byte)
-		//oid := val2.(id.Id)
-		//typmod := val3.(int32)
-		// TODO: decode typmod to precision
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		t := time.Time{}
-		if err := t.UnmarshalBinary(data); err != nil {
+		var out pgtype.Timestamp
+		err := out.DecodeBinary(nil, data)
+		if err != nil {
 			return nil, err
 		}
-		return t, nil
+		return out.Time, nil
 	},
 }
 

--- a/server/functions/timestamptz.go
+++ b/server/functions/timestamptz.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/jackc/pgtype"
 
 	"github.com/dolthub/doltgresql/postgres/parser/sem/tree"
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -86,17 +87,15 @@ var timestamptz_recv = framework.Function3{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
 		data := val1.([]byte)
-		//oid := val2.(id.Id)
-		//typmod := val3.(int32)
-		// TODO: decode typmod to precision
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		t := time.Time{}
-		if err := t.UnmarshalBinary(data); err != nil {
+		var out pgtype.Timestamptz
+		err := out.DecodeBinary(nil, data)
+		if err != nil {
 			return nil, err
 		}
-		return t, nil
+		return out.Time, nil
 	},
 }
 

--- a/server/functions/timetz.go
+++ b/server/functions/timetz.go
@@ -81,18 +81,15 @@ var timetz_recv = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Internal, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		data := val1.([]byte)
-		//oid := val2.(id.Id)
-		//typmod := val3.(int32)
 		// TODO: decode typmod to precision
-		if len(data) == 0 {
+		data := val1.([]byte)
+		if data == nil {
 			return nil, nil
 		}
-		t := time.Time{}
-		if err := t.UnmarshalBinary(data); err != nil {
-			return nil, err
-		}
-		return t, nil
+		reader := utils.NewWireReader(data)
+		micro := reader.ReadInt64()
+		timezoneMicro := int64(reader.ReadInt32()) * 1000000
+		return time.UnixMicro(micro + timezoneMicro), nil
 	},
 }
 

--- a/server/functions/uuid.go
+++ b/server/functions/uuid.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/jackc/pgtype"
 
 	"github.com/dolthub/doltgresql/postgres/parser/uuid"
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -64,10 +65,15 @@ var uuid_recv = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		data := val.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		return uuid.FromBytes(data)
+		var out pgtype.UUID
+		err := out.DecodeBinary(nil, data)
+		if err != nil {
+			return nil, err
+		}
+		return uuid.UUID(out.Bytes), nil
 	},
 }
 

--- a/server/functions/varbit.go
+++ b/server/functions/varbit.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/jackc/pgtype"
 
 	"github.com/dolthub/doltgresql/postgres/parser/sem/tree"
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -91,11 +92,24 @@ var varbitrecv = framework.Function3{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
 		data := val1.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		reader := utils.NewReader(data)
-		return reader.String(), nil
+		typmod := val3.(int32)
+		var out pgtype.Varbit
+		err := out.DecodeBinary(nil, data)
+		if err != nil {
+			return nil, err
+		}
+		var str string
+		for _, b := range out.Bytes {
+			str += fmt.Sprintf("%08b", b)
+		}
+		str = str[:out.Len]
+		if typmod != -1 {
+			str = str[:typmod]
+		}
+		return str, nil
 	},
 }
 

--- a/server/functions/varchar.go
+++ b/server/functions/varchar.go
@@ -88,13 +88,12 @@ var varcharrecv = framework.Function3{
 	Return:     pgtypes.VarChar,
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Internal, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
-	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
+	Callable: func(ctx *sql.Context, t [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
 		data := val1.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		reader := utils.NewReader(data)
-		return reader.String(), nil
+		return t[3].IoInput(ctx, string(data))
 	},
 }
 

--- a/server/functions/xid.go
+++ b/server/functions/xid.go
@@ -15,7 +15,6 @@
 package functions
 
 import (
-	"encoding/binary"
 	"strconv"
 	"strings"
 
@@ -69,10 +68,11 @@ var xidrecv = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		data := val.([]byte)
-		if len(data) == 0 {
+		if data == nil {
 			return nil, nil
 		}
-		return binary.BigEndian.Uint32(data), nil
+		reader := utils.NewWireReader(data)
+		return reader.ReadUint32(), nil
 	},
 }
 

--- a/testing/go/wire_test.go
+++ b/testing/go/wire_test.go
@@ -31,10 +31,10 @@ import (
 	"github.com/xdg-go/scram"
 )
 
-// TestWireTypes allows us to directly test what is received on the wire regarding types, ensuring that the wire
+// TestWireTypesSending allows us to directly test what is sent on the wire regarding types, ensuring that the wire
 // protocol is correctly implemented. ANY changes made to ANY test must be validated against an external Postgres server
 // using the `ExternalServerPort` field.
-func TestWireTypes(t *testing.T) {
+func TestWireTypesSending(t *testing.T) {
 	RunWireScripts(t, []WireScriptTest{
 		{
 			Name: "Smoke Test",
@@ -697,6 +697,172 @@ func TestWireTypes(t *testing.T) {
 			},
 		},
 		{
+			Name: "BYTEA returning text format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 BYTEA, v2 BYTEA);",
+				"INSERT INTO test VALUES ('', E'\\\\xDEADBEEF'), ('\\xC0FFEE', NULL);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test ORDER BY v1;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          17,
+									DataTypeSize:         -1,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          17,
+									DataTypeSize:         -1,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(`\x`),
+								[]byte(`\xdeadbeef`),
+							},
+						},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(`\xc0ffee`),
+								nil,
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 2")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "BYTEA returning binary format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 BYTEA, v2 BYTEA);",
+				"INSERT INTO test VALUES ('', E'\\\\xDEADBEEF'), ('\\xC0FFEE', NULL);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test ORDER BY v1;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          17,
+									DataTypeSize:         -1,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          17,
+									DataTypeSize:         -1,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{1},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								{},
+								{222, 173, 190, 239},
+							},
+						},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								{192, 255, 238},
+								nil,
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 2")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
 			Name: `"char" returning text format`,
 			SetUpScript: []string{
 				`CREATE TABLE test (v1 "char", v2 "char");`,
@@ -841,6 +1007,163 @@ func TestWireTypes(t *testing.T) {
 							Values: [][]byte{
 								{'1'},
 								{'v'},
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "DATE returning text format",
+			Skip: true, // TODO: datestyle isn't working for DATE
+			SetUpScript: []string{
+				"SET datestyle TO 'ISO, YMD';",
+				"CREATE TABLE test (v1 DATE, v2 DATE);",
+				"INSERT INTO test VALUES ('1999-01-08', 'April 17, 2025');",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          1082,
+									DataTypeSize:         4,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          1082,
+									DataTypeSize:         4,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("1999-01-08"),
+								[]byte("2025-04-17"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "DATE returning binary format",
+			SetUpScript: []string{
+				"SET datestyle TO 'ISO, YMD';",
+				"CREATE TABLE test (v1 DATE, v2 DATE);",
+				"INSERT INTO test VALUES ('1999-01-08', 'April 17, 2025');",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          1082,
+									DataTypeSize:         4,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          1082,
+									DataTypeSize:         4,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{1},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								{255, 255, 254, 154},
+								{0, 0, 36, 22},
 							},
 						},
 						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
@@ -997,6 +1320,930 @@ func TestWireTypes(t *testing.T) {
 							Values: [][]byte{
 								[]byte("eval1"),
 								[]byte("eval3"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "FLOAT4 returning text format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 FLOAT4, v2 FLOAT4);",
+				"INSERT INTO test VALUES (-0.5, 26.015625);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          700,
+									DataTypeSize:         4,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          700,
+									DataTypeSize:         4,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("-0.5"),
+								[]byte("26.015625"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "FLOAT4 returning binary format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 FLOAT4, v2 FLOAT4);",
+				"INSERT INTO test VALUES (-0.5, 26.015625);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          700,
+									DataTypeSize:         4,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          700,
+									DataTypeSize:         4,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{1},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								{191, 0, 0, 0},
+								{65, 208, 32, 0},
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "FLOAT8 returning text format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 FLOAT8, v2 FLOAT8);",
+				"INSERT INTO test VALUES (-0.5, 26.015625);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          701,
+									DataTypeSize:         8,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          701,
+									DataTypeSize:         8,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("-0.5"),
+								[]byte("26.015625"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "FLOAT8 returning binary format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 FLOAT8, v2 FLOAT8);",
+				"INSERT INTO test VALUES (-0.5, 26.015625);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          701,
+									DataTypeSize:         8,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          701,
+									DataTypeSize:         8,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{1},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								{191, 224, 0, 0, 0, 0, 0, 0},
+								{64, 58, 4, 0, 0, 0, 0, 0},
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "INT2 returning text format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 INT2, v2 INT2);",
+				"INSERT INTO test VALUES (3, 12646);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          21,
+									DataTypeSize:         2,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          21,
+									DataTypeSize:         2,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("3"),
+								[]byte("12646"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "INT2 returning binary format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 INT2, v2 INT2);",
+				"INSERT INTO test VALUES (3, 12646);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          21,
+									DataTypeSize:         2,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          21,
+									DataTypeSize:         2,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{1},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								{0, 3},
+								{49, 102},
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "INT2VECTOR returning text format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 int2vector, v2 int2vector);",
+				"INSERT INTO test VALUES ('1 2 4 5', '5 87 991');",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          22,
+									DataTypeSize:         -1,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          22,
+									DataTypeSize:         -1,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("1 2 4 5"),
+								[]byte("5 87 991"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "INT2VECTOR returning binary format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 int2vector, v2 int2vector);",
+				"INSERT INTO test VALUES ('1 2 4 5', '5 87 991');",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          22,
+									DataTypeSize:         -1,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          22,
+									DataTypeSize:         -1,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{1},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 2, 0, 1, 0, 0, 0, 2, 0, 2, 0, 0, 0, 2, 0, 4, 0, 0, 0, 2, 0, 5},
+								{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 5, 0, 0, 0, 2, 0, 87, 0, 0, 0, 2, 3, 223},
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "INT4 returning text format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 INT4, v2 INT4);",
+				"INSERT INTO test VALUES (-5, 3578457);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          23,
+									DataTypeSize:         4,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          23,
+									DataTypeSize:         4,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("-5"),
+								[]byte("3578457"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "INT4 returning binary format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 INT4, v2 INT4);",
+				"INSERT INTO test VALUES (-5, 3578457);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          23,
+									DataTypeSize:         4,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          23,
+									DataTypeSize:         4,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{1},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								{255, 255, 255, 251},
+								{0, 54, 154, 89},
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "INT8 returning text format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 INT8, v2 INT8);",
+				"INSERT INTO test VALUES (-44, 2578457279345);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          20,
+									DataTypeSize:         8,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          20,
+									DataTypeSize:         8,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("-44"),
+								[]byte("2578457279345"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "INT8 returning binary format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 INT8, v2 INT8);",
+				"INSERT INTO test VALUES (-44, 2578457279345);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          20,
+									DataTypeSize:         8,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          20,
+									DataTypeSize:         8,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{1},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								{255, 255, 255, 255, 255, 255, 255, 212},
+								{0, 0, 2, 88, 88, 7, 187, 113},
 							},
 						},
 						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
@@ -1992,6 +3239,160 @@ func TestWireTypes(t *testing.T) {
 							Values: [][]byte{
 								{0, 0, 0, 1},
 								{148, 8, 88, 129},
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "OIDVECTOR returning text format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 oidvector, v2 oidvector);",
+				"INSERT INTO test VALUES ('1234 2489', '2483 574 913');",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          30,
+									DataTypeSize:         -1,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          30,
+									DataTypeSize:         -1,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("1234 2489"),
+								[]byte("2483 574 913"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "OIDVECTOR returning binary format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 oidvector, v2 oidvector);",
+				"INSERT INTO test VALUES ('1234 2489', '2483 574 913');",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          30,
+									DataTypeSize:         -1,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          30,
+									DataTypeSize:         -1,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{1},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 26, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 4, 210, 0, 0, 0, 4, 0, 0, 9, 185},
+								{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 26, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 9, 179, 0, 0, 0, 4, 0, 0, 2, 62, 0, 0, 0, 4, 0, 0, 3, 145},
 							},
 						},
 						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
@@ -3314,6 +4715,160 @@ func TestWireTypes(t *testing.T) {
 			},
 		},
 		{
+			Name: "UUID returning text format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 UUID, v2 UUID);",
+				"INSERT INTO test VALUES ('fdabf03d-9b21-4531-b900-c6f6cff8386c', '0730791c-c0dd-4972-9e72-11ead9317a5a');",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          2950,
+									DataTypeSize:         16,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          2950,
+									DataTypeSize:         16,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("fdabf03d-9b21-4531-b900-c6f6cff8386c"),
+								[]byte("0730791c-c0dd-4972-9e72-11ead9317a5a"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "UUID returning binary format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 UUID, v2 UUID);",
+				"INSERT INTO test VALUES ('fdabf03d-9b21-4531-b900-c6f6cff8386c', '0730791c-c0dd-4972-9e72-11ead9317a5a');",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Describe{
+							ObjectType: 'S',
+							Name:       "stmt_name",
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("v1"),
+									TableOID:             0,
+									TableAttributeNumber: 1,
+									DataTypeOID:          2950,
+									DataTypeSize:         16,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+								{
+									Name:                 []byte("v2"),
+									TableOID:             0,
+									TableAttributeNumber: 2,
+									DataTypeOID:          2950,
+									DataTypeSize:         16,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{1},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								{253, 171, 240, 61, 155, 33, 69, 49, 185, 0, 198, 246, 207, 248, 56, 108},
+								{7, 48, 121, 28, 192, 221, 73, 114, 158, 114, 17, 234, 217, 49, 122, 90},
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
 			Name: "VARCHAR returning text format",
 			SetUpScript: []string{
 				"CREATE TABLE test (v1 VARCHAR, v2 VARCHAR(5));",
@@ -3633,58 +5188,59 @@ func TestWireTypes(t *testing.T) {
 				},
 			},
 		},
+	})
+}
+
+// TestWireTypesReceiving allows us to directly test what is received on the wire regarding types, ensuring that the
+// wire protocol is correctly implemented. ANY changes made to ANY test must be validated against an external Postgres
+// server using the `ExternalServerPort` field.
+func TestWireTypesReceiving(t *testing.T) {
+	RunWireScripts(t, []WireScriptTest{
 		{
-			Name: "OIDVECTOR returning text format",
+			Name: "BIT receiving binary format",
 			SetUpScript: []string{
-				"CREATE TABLE test (v1 oidvector, v2 oidvector);",
-				"INSERT INTO test VALUES ('1234 2489', '2483 574 913');",
+				"CREATE TABLE test (v1 BIT(65), v2 BIT(3));",
 			},
 			Assertions: []WireScriptTestAssertion{
 				{
 					Send: []pgproto3.FrontendMessage{
 						&pgproto3.Parse{
-							Name:  "stmt_name",
-							Query: "SELECT * FROM test;",
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
 						},
-						&pgproto3.Describe{
-							ObjectType: 'S',
-							Name:       "stmt_name",
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1, 1},
+							Parameters: [][]byte{
+								{0, 0, 0, 65, 170, 35, 108, 179, 21, 106, 150, 172, 128},
+								{0, 0, 0, 3, 160},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
 						},
 						&pgproto3.Sync{},
 					},
 					Receive: []pgproto3.BackendMessage{
 						&pgproto3.ParseComplete{},
-						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
-						&pgproto3.RowDescription{
-							Fields: []pgproto3.FieldDescription{
-								{
-									Name:                 []byte("v1"),
-									TableOID:             0,
-									TableAttributeNumber: 1,
-									DataTypeOID:          30,
-									DataTypeSize:         -1,
-									TypeModifier:         -1,
-									Format:               0,
-								},
-								{
-									Name:                 []byte("v2"),
-									TableOID:             0,
-									TableAttributeNumber: 2,
-									DataTypeOID:          30,
-									DataTypeSize:         -1,
-									TypeModifier:         -1,
-									Format:               0,
-								},
-							},
-						},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
 						&pgproto3.ReadyForQuery{TxStatus: 'I'},
 					},
 				},
 				{
 					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
 						&pgproto3.Bind{
 							DestinationPortal:    "",
-							PreparedStatement:    "stmt_name",
+							PreparedStatement:    "stmt_name2",
 							ParameterFormatCodes: nil,
 							Parameters:           nil,
 							ResultFormatCodes:    []int16{0},
@@ -3696,11 +5252,12 @@ func TestWireTypes(t *testing.T) {
 						&pgproto3.Sync{},
 					},
 					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
 						&pgproto3.BindComplete{},
 						&pgproto3.DataRow{
 							Values: [][]byte{
-								[]byte("1234 2489"),
-								[]byte("2483 574 913"),
+								[]byte("10101010001000110110110010110011000101010110101010010110101011001"),
+								[]byte("101"),
 							},
 						},
 						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
@@ -3711,57 +5268,335 @@ func TestWireTypes(t *testing.T) {
 			},
 		},
 		{
-			Name: "OIDVECTOR returning binary format",
+			Name: "BIT VARYING receiving binary format",
 			SetUpScript: []string{
-				"CREATE TABLE test (v1 oidvector, v2 oidvector);",
-				"INSERT INTO test VALUES ('1234 2489', '2483 574 913');",
+				"CREATE TABLE test (v1 BIT VARYING, v2 BIT VARYING(5));",
 			},
 			Assertions: []WireScriptTestAssertion{
 				{
 					Send: []pgproto3.FrontendMessage{
 						&pgproto3.Parse{
-							Name:  "stmt_name",
-							Query: "SELECT * FROM test;",
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
 						},
-						&pgproto3.Describe{
-							ObjectType: 'S',
-							Name:       "stmt_name",
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{0, 0, 0, 18, 149, 102, 64},
+								{0, 0, 0, 3, 192},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
 						},
 						&pgproto3.Sync{},
 					},
 					Receive: []pgproto3.BackendMessage{
 						&pgproto3.ParseComplete{},
-						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
-						&pgproto3.RowDescription{
-							Fields: []pgproto3.FieldDescription{
-								{
-									Name:                 []byte("v1"),
-									TableOID:             0,
-									TableAttributeNumber: 1,
-									DataTypeOID:          30,
-									DataTypeSize:         -1,
-									TypeModifier:         -1,
-									Format:               0,
-								},
-								{
-									Name:                 []byte("v2"),
-									TableOID:             0,
-									TableAttributeNumber: 2,
-									DataTypeOID:          30,
-									DataTypeSize:         -1,
-									TypeModifier:         -1,
-									Format:               0,
-								},
-							},
-						},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
 						&pgproto3.ReadyForQuery{TxStatus: 'I'},
 					},
 				},
 				{
 					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
 						&pgproto3.Bind{
 							DestinationPortal:    "",
-							PreparedStatement:    "stmt_name",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("100101010110011001"),
+								[]byte("110"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "BOOL receiving binary format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 BOOL, v2 BOOL);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{1},
+								{0},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("t"),
+								[]byte("f"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "BYTEA receiving binary format",
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 BYTEA, v2 BYTEA);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{222, 173, 190, 239},
+								{192, 255, 238},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(`\xdeadbeef`),
+								[]byte(`\xc0ffee`),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `"char" receiving binary format`,
+			SetUpScript: []string{
+				`CREATE TABLE test (v1 "char", v2 "char");`,
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{'1'},
+								{'v'},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								{'1'},
+								{'v'},
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `DATE receiving binary format`,
+			SetUpScript: []string{
+				"SET datestyle TO 'ISO, YMD';",
+				"CREATE TABLE test (v1 DATE, v2 DATE);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{255, 255, 254, 154},
+								{0, 0, 36, 22},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
 							ParameterFormatCodes: nil,
 							Parameters:           nil,
 							ResultFormatCodes:    []int16{1},
@@ -3773,11 +5608,12 @@ func TestWireTypes(t *testing.T) {
 						&pgproto3.Sync{},
 					},
 					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
 						&pgproto3.BindComplete{},
 						&pgproto3.DataRow{
 							Values: [][]byte{
-								{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 26, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 4, 210, 0, 0, 0, 4, 0, 0, 9, 185},
-								{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 26, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 9, 179, 0, 0, 0, 4, 0, 0, 2, 62, 0, 0, 0, 4, 0, 0, 3, 145},
+								{255, 255, 254, 154},
+								{0, 0, 36, 22},
 							},
 						},
 						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
@@ -3788,57 +5624,51 @@ func TestWireTypes(t *testing.T) {
 			},
 		},
 		{
-			Name: "INT2VECTOR returning text format",
+			Name: `ENUM receiving binary format`,
 			SetUpScript: []string{
-				"CREATE TABLE test (v1 int2vector, v2 int2vector);",
-				"INSERT INTO test VALUES ('1 2 4 5', '5 87 991');",
+				"CREATE TYPE enumType AS ENUM ('eval1', 'eval2', 'eval3');",
+				"CREATE TABLE test (v1 enumType, v2 enumType);",
 			},
 			Assertions: []WireScriptTestAssertion{
 				{
 					Send: []pgproto3.FrontendMessage{
 						&pgproto3.Parse{
-							Name:  "stmt_name",
-							Query: "SELECT * FROM test;",
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
 						},
-						&pgproto3.Describe{
-							ObjectType: 'S',
-							Name:       "stmt_name",
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								[]byte("eval1"),
+								[]byte("eval3"),
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
 						},
 						&pgproto3.Sync{},
 					},
 					Receive: []pgproto3.BackendMessage{
 						&pgproto3.ParseComplete{},
-						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
-						&pgproto3.RowDescription{
-							Fields: []pgproto3.FieldDescription{
-								{
-									Name:                 []byte("v1"),
-									TableOID:             0,
-									TableAttributeNumber: 1,
-									DataTypeOID:          22,
-									DataTypeSize:         -1,
-									TypeModifier:         -1,
-									Format:               0,
-								},
-								{
-									Name:                 []byte("v2"),
-									TableOID:             0,
-									TableAttributeNumber: 2,
-									DataTypeOID:          22,
-									DataTypeSize:         -1,
-									TypeModifier:         -1,
-									Format:               0,
-								},
-							},
-						},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
 						&pgproto3.ReadyForQuery{TxStatus: 'I'},
 					},
 				},
 				{
 					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
 						&pgproto3.Bind{
 							DestinationPortal:    "",
-							PreparedStatement:    "stmt_name",
+							PreparedStatement:    "stmt_name2",
 							ParameterFormatCodes: nil,
 							Parameters:           nil,
 							ResultFormatCodes:    []int16{0},
@@ -3850,6 +5680,291 @@ func TestWireTypes(t *testing.T) {
 						&pgproto3.Sync{},
 					},
 					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("eval1"),
+								[]byte("eval3"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `FLOAT4 receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 FLOAT4, v2 FLOAT4);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{191, 0, 0, 0},
+								{65, 208, 32, 0},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("-0.5"),
+								[]byte("26.015625"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `FLOAT8 receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 FLOAT8, v2 FLOAT8);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{191, 224, 0, 0, 0, 0, 0, 0},
+								{64, 58, 4, 0, 0, 0, 0, 0},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("-0.5"),
+								[]byte("26.015625"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `INT2 receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 INT2, v2 INT2);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{0, 3},
+								{49, 102},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("3"),
+								[]byte("12646"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `INT2VECTOR receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 INT2VECTOR, v2 INT2VECTOR);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 2, 0, 1, 0, 0, 0, 2, 0, 2, 0, 0, 0, 2, 0, 4, 0, 0, 0, 2, 0, 5},
+								{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 5, 0, 0, 0, 2, 0, 87, 0, 0, 0, 2, 3, 223},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
 						&pgproto3.BindComplete{},
 						&pgproto3.DataRow{
 							Values: [][]byte{
@@ -3865,57 +5980,192 @@ func TestWireTypes(t *testing.T) {
 			},
 		},
 		{
-			Name: "INT2VECTOR returning binary format",
+			Name: `INT4 receiving binary format`,
 			SetUpScript: []string{
-				"CREATE TABLE test (v1 int2vector, v2 int2vector);",
-				"INSERT INTO test VALUES ('1 2 4 5', '5 87 991');",
+				"CREATE TABLE test (v1 INT4, v2 INT4);",
 			},
 			Assertions: []WireScriptTestAssertion{
 				{
 					Send: []pgproto3.FrontendMessage{
 						&pgproto3.Parse{
-							Name:  "stmt_name",
-							Query: "SELECT * FROM test;",
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
 						},
-						&pgproto3.Describe{
-							ObjectType: 'S',
-							Name:       "stmt_name",
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{255, 255, 255, 251},
+								{0, 54, 154, 89},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
 						},
 						&pgproto3.Sync{},
 					},
 					Receive: []pgproto3.BackendMessage{
 						&pgproto3.ParseComplete{},
-						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{}},
-						&pgproto3.RowDescription{
-							Fields: []pgproto3.FieldDescription{
-								{
-									Name:                 []byte("v1"),
-									TableOID:             0,
-									TableAttributeNumber: 1,
-									DataTypeOID:          22,
-									DataTypeSize:         -1,
-									TypeModifier:         -1,
-									Format:               0,
-								},
-								{
-									Name:                 []byte("v2"),
-									TableOID:             0,
-									TableAttributeNumber: 2,
-									DataTypeOID:          22,
-									DataTypeSize:         -1,
-									TypeModifier:         -1,
-									Format:               0,
-								},
-							},
-						},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
 						&pgproto3.ReadyForQuery{TxStatus: 'I'},
 					},
 				},
 				{
 					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
 						&pgproto3.Bind{
 							DestinationPortal:    "",
-							PreparedStatement:    "stmt_name",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("-5"),
+								[]byte("3578457"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `INT8 receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 INT8, v2 INT8);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{255, 255, 255, 255, 255, 255, 255, 212},
+								{0, 0, 2, 88, 88, 7, 187, 113},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("-44"),
+								[]byte("2578457279345"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `INTERVAL receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 INTERVAL, v2 INTERVAL);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{0, 0, 0, 0, 3, 147, 135, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+								{0, 0, 0, 111, 185, 177, 134, 8, 0, 0, 2, 188, 0, 0, 0, 39},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
 							ParameterFormatCodes: nil,
 							Parameters:           nil,
 							ResultFormatCodes:    []int16{1},
@@ -3927,11 +6177,1226 @@ func TestWireTypes(t *testing.T) {
 						&pgproto3.Sync{},
 					},
 					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
 						&pgproto3.BindComplete{},
 						&pgproto3.DataRow{
 							Values: [][]byte{
-								{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 2, 0, 1, 0, 0, 0, 2, 0, 2, 0, 0, 0, 2, 0, 4, 0, 0, 0, 2, 0, 5},
-								{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 2, 0, 5, 0, 0, 0, 2, 0, 87, 0, 0, 0, 2, 3, 223},
+								{0, 0, 0, 0, 3, 147, 135, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+								{0, 0, 0, 111, 185, 177, 134, 8, 0, 0, 2, 188, 0, 0, 0, 39},
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `JSON receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 JSON, v2 JSON);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								[]byte(`{"key1": {"key": "value"}}`),
+								[]byte(`{}`),
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{1},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(`{"key1": {"key": "value"}}`),
+								[]byte(`{}`),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `JSONB receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 JSONB, v2 JSONB);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								append([]byte{1}, []byte(`{"key1": {"key": [2, 3]}}`)...),
+								{1, 91, 93},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(`{"key1": {"key": [2, 3]}}`),
+								[]byte(`[]`),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `NAME receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 NAME, v2 NAME);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								[]byte(""),
+								[]byte("abc"),
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(""),
+								[]byte("abc"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `NUMERIC receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 NUMERIC, v2 NUMERIC(5,2), v3 NUMERIC(14,5));",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2, $3);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{0, 8, 0, 1, 0, 0, 0, 21, 4, 211, 28, 64, 17, 215, 33, 217, 12, 152, 30, 7, 21, 203, 35, 40},
+								{0, 2, 0, 0, 0, 0, 0, 2, 0, 235, 26, 44},
+								{0, 2, 0, 0, 0, 0, 0, 5, 16, 182, 0, 90},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(`12357232.456786653224768755799`),
+								[]byte(`235.67`),
+								[]byte(`4278.00900`),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `OID receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 OID, v2 OID);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{0, 0, 0, 1},
+								{148, 8, 88, 129},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("1"),
+								[]byte("2483574913"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `OIDVECTOR receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 OIDVECTOR, v2 OIDVECTOR);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 26, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 4, 210, 0, 0, 0, 4, 0, 0, 9, 185},
+								{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 26, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 9, 179, 0, 0, 0, 4, 0, 0, 2, 62, 0, 0, 0, 4, 0, 0, 3, 145},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("1234 2489"),
+								[]byte("2483 574 913"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `RECORD receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE pre1 (v1 TEXT, v2 INT8, v3 NUMERIC(6,1));",
+				"CREATE TABLE pre2 (v1 VARCHAR, v2 OID, v3 BOOL);",
+				"CREATE TABLE test (v1 pre1, v2 pre2);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{0, 0, 0, 3, 0, 0, 0, 25, 0, 0, 0, 3, 97, 98, 99, 0, 0, 0, 20, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 6, 164, 0, 0, 0, 14, 0, 3, 0, 1, 0, 0, 0, 1, 0, 1, 9, 41, 23, 112},
+								{0, 0, 0, 3, 0, 0, 4, 19, 0, 0, 0, 3, 100, 101, 102, 0, 0, 0, 26, 0, 0, 0, 4, 0, 0, 0, 2, 0, 0, 0, 16, 0, 0, 0, 1, 1},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(`(abc,1,12345.6)`),
+								[]byte(`(def,2,t)`),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `REGTYPE receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 REGTYPE, v2 REGTYPE);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{0, 0, 6, 164},
+								{0, 0, 0, 25},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("numeric"),
+								[]byte("text"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `TEXT receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 TEXT, v2 TEXT);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								[]byte(""),
+								[]byte("abc"),
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(""),
+								[]byte("abc"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `TEXT ARRAY receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 TEXT[], v2 TEXT[]);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25},
+								{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 25, 0, 0, 0, 3, 0, 0, 0, 1, 0, 0, 0, 1, 97, 0, 0, 0, 2, 98, 98, 0, 0, 0, 3, 99, 99, 99},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("{}"),
+								[]byte("{a,bb,ccc}"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `TIME receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 TIME, v2 TIME);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{0, 0, 0, 17, 250, 171, 177, 0},
+								{0, 0, 0, 10, 57, 214, 4, 0},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(`21:27:00`),
+								[]byte(`12:12:00`),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `TIMETZ receiving binary format`,
+			Skip: true, // TODO: need to consider daylight savings
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 TIMETZ, v2 TIMETZ);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{0, 0, 0, 17, 250, 171, 177, 0, 0, 0, 112, 128},
+								{0, 0, 0, 10, 57, 214, 4, 0, 0, 0, 112, 128},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(`21:27:00-08`),
+								[]byte(`12:12:00-08`),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `TIMESTAMP receiving binary format`,
+			SetUpScript: []string{
+				"SET datestyle TO 'Postgres, MDY';",
+				"CREATE TABLE test (v1 TIMESTAMP, v2 TIMESTAMP);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{0, 2, 62, 228, 207, 3, 128, 0},
+								{0, 2, 94, 46, 160, 114, 138, 136},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(`Sun Jan 12 00:00:00 2020`),
+								[]byte(`Sat Feb 13 04:05:06.789 2021`),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `TIMESTAMPTZ receiving binary format`,
+			SetUpScript: []string{
+				"SET datestyle TO 'Postgres, MDY';",
+				"CREATE TABLE test (v1 TIMESTAMPTZ, v2 TIMESTAMPTZ);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{0, 2, 62, 235, 131, 160, 160, 0},
+								{0, 2, 94, 52, 126, 124, 6, 136},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(`Sun Jan 12 00:00:00 2020 PST`),
+								[]byte(`Sat Feb 13 03:05:06.789 2021 PST`),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `UUID receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 UUID, v2 UUID);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{253, 171, 240, 61, 155, 33, 69, 49, 185, 0, 198, 246, 207, 248, 56, 108},
+								{7, 48, 121, 28, 192, 221, 73, 114, 158, 114, 17, 234, 217, 49, 122, 90},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("fdabf03d-9b21-4531-b900-c6f6cff8386c"),
+								[]byte("0730791c-c0dd-4972-9e72-11ead9317a5a"),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `VARCHAR receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 VARCHAR, v2 VARCHAR(5));",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								[]byte(""),
+								[]byte(`a",c`),
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(""),
+								[]byte(`a",c`),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: `XID receiving binary format`,
+			SetUpScript: []string{
+				"CREATE TABLE test (v1 XID, v2 XID);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: "INSERT INTO test VALUES ($1, $2);",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name1",
+							ParameterFormatCodes: []int16{1},
+							Parameters: [][]byte{
+								{0, 0, 0, 1},
+								{148, 8, 88, 129},
+							},
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.CommandComplete{CommandTag: []byte("INSERT 0 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: "SELECT * FROM test;",
+						},
+						&pgproto3.Bind{
+							DestinationPortal:    "",
+							PreparedStatement:    "stmt_name2",
+							ParameterFormatCodes: nil,
+							Parameters:           nil,
+							ResultFormatCodes:    []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte("1"),
+								[]byte("2483574913"),
 							},
 						},
 						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},


### PR DESCRIPTION
This is the `receive` counterpart to the following PR:
* https://github.com/dolthub/doltgresql/pull/2394

All new tests were validated against a live Postgres 15 server to ensure that we're processing client input properly. In addition, I've added a little more testing on the `send` side as well, as there were a couple of small gaps in coverage.