### PR TITLE
Fixed DST handling by moving to `timeofday`

### DIFF
--- a/postgres/parser/timeofday/time_of_day.go
+++ b/postgres/parser/timeofday/time_of_day.go
@@ -139,6 +139,22 @@ func (t TimeOfDay) Add(d duration.Duration) TimeOfDay {
 	return FromInt(int64(t) + d.Nanos()/nanosPerMicro)
 }
 
+// Sub subtracts a Duration to a TimeOfDay, wrapping into the previous day if necessary.
+func (t TimeOfDay) Sub(d duration.Duration) TimeOfDay {
+	return FromInt(int64(t) - d.Nanos()/nanosPerMicro)
+}
+
+// Compare compares the calling TimeOfDay with the given one, returning a comparison integer.
+func (t TimeOfDay) Compare(other TimeOfDay) int {
+	if t < other {
+		return -1
+	} else if t == other {
+		return 0
+	} else {
+		return 1
+	}
+}
+
 // Difference returns the interval between t1 and t2, which may be negative.
 func Difference(t1 TimeOfDay, t2 TimeOfDay) duration.Duration {
 	return duration.MakeDuration(int64(t1-t2)*nanosPerMicro, 0, 0)

--- a/postgres/parser/timetz/timetz.go
+++ b/postgres/parser/timetz/timetz.go
@@ -215,13 +215,24 @@ func (t TimeTZ) Before(other TimeTZ) bool {
 }
 
 // After returns whether the TimeTZ is after the other TimeTZ.
-func (t *TimeTZ) After(other TimeTZ) bool {
+func (t TimeTZ) After(other TimeTZ) bool {
 	return t.ToTime().After(other.ToTime()) || (t.ToTime().Equal(other.ToTime()) && t.OffsetSecs > other.OffsetSecs)
 }
 
 // Equal returns whether the TimeTZ is equal to the other TimeTZ.
 func (t TimeTZ) Equal(other TimeTZ) bool {
 	return t.TimeOfDay == other.TimeOfDay && t.OffsetSecs == other.OffsetSecs
+}
+
+// Compare compares the calling TimeTZ with the given one, returning a comparison integer.
+func (t TimeTZ) Compare(other TimeTZ) int {
+	if t.Before(other) {
+		return -1
+	} else if t.After(other) {
+		return 1
+	} else {
+		return 0
+	}
 }
 
 // ReplaceLibPQTimePrefix replaces unparsable lib/pq dates used for timestamps

--- a/server/ast/expr.go
+++ b/server/ast/expr.go
@@ -568,11 +568,11 @@ func nodeExpr(ctx *Context, node tree.Expr) (vitess.Expr, error) {
 		}, nil
 	case *tree.DTime:
 		return vitess.InjectedExpr{
-			Expression: pgexprs.NewRawLiteralTime(timeofday.TimeOfDay(*node).ToTime()),
+			Expression: pgexprs.NewRawLiteralTime(timeofday.TimeOfDay(*node)),
 		}, nil
 	case *tree.DTimeTZ:
 		return vitess.InjectedExpr{
-			Expression: pgexprs.NewRawLiteralTimeTZ(node.TimeTZ.ToTime()),
+			Expression: pgexprs.NewRawLiteralTimeTZ(node.TimeTZ),
 		}, nil
 	case *tree.DTimestamp:
 		return vitess.InjectedExpr{

--- a/server/cast/interval.go
+++ b/server/cast/interval.go
@@ -39,7 +39,7 @@ func intervalAssignment() {
 		Function: func(ctx *sql.Context, val any, targetType *pgtypes.DoltgresType) (any, error) {
 			dur := val.(duration.Duration)
 			// the month and day of the duration are excluded
-			return timeofday.FromInt(dur.Nanos() / functions.NanosPerMicro).ToTime(), nil
+			return timeofday.FromInt(dur.Nanos() / functions.NanosPerMicro), nil
 		},
 	})
 }

--- a/server/cast/time.go
+++ b/server/cast/time.go
@@ -15,9 +15,9 @@
 package cast
 
 import (
-	"time"
-
 	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
 
 	"github.com/dolthub/doltgresql/server/functions"
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -35,8 +35,8 @@ func timeImplicit() {
 		FromType: pgtypes.Time,
 		ToType:   pgtypes.Interval,
 		Function: func(ctx *sql.Context, val any, targetType *pgtypes.DoltgresType) (any, error) {
-			t := val.(time.Time)
-			dur := functions.GetIntervalDurationFromTimeComponents(0, 0, 0, int64(t.Hour()), int64(t.Minute()), int64(t.Second()), 0)
+			t := val.(timeofday.TimeOfDay)
+			dur := functions.GetIntervalDurationFromTimeComponents(0, 0, 0, int64(t.Hour()), int64(t.Minute()), int64(t.Second()), int64(t.Microsecond())*1000)
 			return dur, nil
 		},
 	})

--- a/server/cast/timestamp.go
+++ b/server/cast/timestamp.go
@@ -48,7 +48,7 @@ func timestampAssignment() {
 		FromType: pgtypes.Timestamp,
 		ToType:   pgtypes.Time,
 		Function: func(ctx *sql.Context, val any, targetType *pgtypes.DoltgresType) (any, error) {
-			return timeofday.FromTime(val.(time.Time)).ToTime(), nil
+			return timeofday.FromTime(val.(time.Time)), nil
 		},
 	})
 }

--- a/server/cast/timestamptz.go
+++ b/server/cast/timestamptz.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/dolthub/doltgresql/postgres/parser/pgdate"
 	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
+	"github.com/dolthub/doltgresql/postgres/parser/timetz"
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
@@ -48,7 +49,7 @@ func timestampTZAssignment() {
 		FromType: pgtypes.TimestampTZ,
 		ToType:   pgtypes.Time,
 		Function: func(ctx *sql.Context, val any, targetType *pgtypes.DoltgresType) (any, error) {
-			return timeofday.FromTime(val.(time.Time)).ToTime(), nil
+			return timeofday.FromTime(val.(time.Time)), nil
 		},
 	})
 	framework.MustAddAssignmentTypeCast(framework.TypeCast{
@@ -63,7 +64,7 @@ func timestampTZAssignment() {
 		FromType: pgtypes.TimestampTZ,
 		ToType:   pgtypes.TimeTZ,
 		Function: func(ctx *sql.Context, val any, targetType *pgtypes.DoltgresType) (any, error) {
-			return val.(time.Time), nil
+			return timetz.MakeTimeTZFromTime(val.(time.Time)), nil
 		},
 	})
 }

--- a/server/cast/timetz.go
+++ b/server/cast/timetz.go
@@ -15,9 +15,9 @@
 package cast
 
 import (
-	"time"
-
 	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/postgres/parser/timetz"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
@@ -35,7 +35,7 @@ func timeTZAssignment() {
 		FromType: pgtypes.TimeTZ,
 		ToType:   pgtypes.Time,
 		Function: func(ctx *sql.Context, val any, targetType *pgtypes.DoltgresType) (any, error) {
-			return val.(time.Time), nil
+			return val.(timetz.TimeTZ).TimeOfDay, nil
 		},
 	})
 }
@@ -46,7 +46,7 @@ func timeTZImplicit() {
 		FromType: pgtypes.TimeTZ,
 		ToType:   pgtypes.TimeTZ,
 		Function: func(ctx *sql.Context, val any, targetType *pgtypes.DoltgresType) (any, error) {
-			return val.(time.Time), nil
+			return val.(timetz.TimeTZ), nil
 		},
 	})
 }

--- a/server/expression/literal.go
+++ b/server/expression/literal.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/dolthub/doltgresql/core/id"
 	"github.com/dolthub/doltgresql/postgres/parser/duration"
+	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
+	"github.com/dolthub/doltgresql/postgres/parser/timetz"
 	"github.com/dolthub/doltgresql/postgres/parser/uuid"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
@@ -113,12 +115,12 @@ func NewRawLiteralDate(date time.Time) *expression.Literal {
 }
 
 // NewRawLiteralTime returns a new *expression.Literal containing a TIME value.
-func NewRawLiteralTime(t time.Time) *expression.Literal {
+func NewRawLiteralTime(t timeofday.TimeOfDay) *expression.Literal {
 	return expression.NewLiteral(t, pgtypes.Time)
 }
 
 // NewRawLiteralTimeTZ returns a new *expression.Literal containing a TIMETZ value.
-func NewRawLiteralTimeTZ(ttz time.Time) *expression.Literal {
+func NewRawLiteralTimeTZ(ttz timetz.TimeTZ) *expression.Literal {
 	return expression.NewLiteral(ttz, pgtypes.TimeTZ)
 }
 

--- a/server/functions/binary/equal.go
+++ b/server/functions/binary/equal.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/dolthub/doltgresql/core/id"
 	"github.com/dolthub/doltgresql/postgres/parser/duration"
+	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
+	"github.com/dolthub/doltgresql/postgres/parser/timetz"
 	"github.com/dolthub/doltgresql/postgres/parser/uuid"
 	"github.com/dolthub/doltgresql/server/compare"
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -572,7 +574,7 @@ var record_eq = framework.Function2{
 
 // time_eq_callable is the callable logic for the time_eq function.
 func time_eq_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-	res, err := pgtypes.Time.Compare(ctx, val1.(time.Time), val2.(time.Time))
+	res, err := pgtypes.Time.Compare(ctx, val1.(timeofday.TimeOfDay), val2.(timeofday.TimeOfDay))
 	return res == 0, err
 }
 
@@ -677,7 +679,7 @@ var timestamptz_eq = framework.Function2{
 
 // timetz_eq_callable is the callable logic for the timetz_eq function.
 func timetz_eq_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-	res, err := pgtypes.TimeTZ.Compare(ctx, val1.(time.Time), val2.(time.Time))
+	res, err := pgtypes.TimeTZ.Compare(ctx, val1.(timetz.TimeTZ), val2.(timetz.TimeTZ))
 	return res == 0, err
 }
 

--- a/server/functions/binary/greater.go
+++ b/server/functions/binary/greater.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/dolthub/doltgresql/core/id"
 	"github.com/dolthub/doltgresql/postgres/parser/duration"
+	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
+	"github.com/dolthub/doltgresql/postgres/parser/timetz"
 	"github.com/dolthub/doltgresql/postgres/parser/uuid"
 	"github.com/dolthub/doltgresql/server/compare"
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -443,7 +445,7 @@ var time_gt = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Time.Compare(ctx, val1.(time.Time), val2.(time.Time))
+		res, err := pgtypes.Time.Compare(ctx, val1.(timeofday.TimeOfDay), val2.(timeofday.TimeOfDay))
 		return res == 1, err
 	},
 }
@@ -527,7 +529,7 @@ var timetz_gt = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.TimeTZ.Compare(ctx, val1.(time.Time), val2.(time.Time))
+		res, err := pgtypes.TimeTZ.Compare(ctx, val1.(timetz.TimeTZ), val2.(timetz.TimeTZ))
 		return res == 1, err
 	},
 }

--- a/server/functions/binary/greater_equal.go
+++ b/server/functions/binary/greater_equal.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/dolthub/doltgresql/core/id"
 	"github.com/dolthub/doltgresql/postgres/parser/duration"
+	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
+	"github.com/dolthub/doltgresql/postgres/parser/timetz"
 	"github.com/dolthub/doltgresql/postgres/parser/uuid"
 	"github.com/dolthub/doltgresql/server/compare"
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -443,7 +445,7 @@ var time_ge = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Time.Compare(ctx, val1.(time.Time), val2.(time.Time))
+		res, err := pgtypes.Time.Compare(ctx, val1.(timeofday.TimeOfDay), val2.(timeofday.TimeOfDay))
 		return res >= 0, err
 	},
 }
@@ -527,7 +529,7 @@ var timetz_ge = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.TimeTZ.Compare(ctx, val1.(time.Time), val2.(time.Time))
+		res, err := pgtypes.TimeTZ.Compare(ctx, val1.(timetz.TimeTZ), val2.(timetz.TimeTZ))
 		return res >= 0, err
 	},
 }

--- a/server/functions/binary/less.go
+++ b/server/functions/binary/less.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/dolthub/doltgresql/core/id"
 	"github.com/dolthub/doltgresql/postgres/parser/duration"
+	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
+	"github.com/dolthub/doltgresql/postgres/parser/timetz"
 	"github.com/dolthub/doltgresql/postgres/parser/uuid"
 	"github.com/dolthub/doltgresql/server/compare"
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -443,7 +445,7 @@ var time_lt = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Time.Compare(ctx, val1.(time.Time), val2.(time.Time))
+		res, err := pgtypes.Time.Compare(ctx, val1.(timeofday.TimeOfDay), val2.(timeofday.TimeOfDay))
 		return res == -1, err
 	},
 }
@@ -527,7 +529,7 @@ var timetz_lt = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.TimeTZ.Compare(ctx, val1.(time.Time), val2.(time.Time))
+		res, err := pgtypes.TimeTZ.Compare(ctx, val1.(timetz.TimeTZ), val2.(timetz.TimeTZ))
 		return res == -1, err
 	},
 }

--- a/server/functions/binary/less_equal.go
+++ b/server/functions/binary/less_equal.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/dolthub/doltgresql/core/id"
 	"github.com/dolthub/doltgresql/postgres/parser/duration"
+	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
+	"github.com/dolthub/doltgresql/postgres/parser/timetz"
 	"github.com/dolthub/doltgresql/postgres/parser/uuid"
 	"github.com/dolthub/doltgresql/server/compare"
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -443,7 +445,7 @@ var time_le = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Time.Compare(ctx, val1.(time.Time), val2.(time.Time))
+		res, err := pgtypes.Time.Compare(ctx, val1.(timeofday.TimeOfDay), val2.(timeofday.TimeOfDay))
 		return res <= 0, err
 	},
 }
@@ -527,7 +529,7 @@ var timetz_le = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.TimeTZ.Compare(ctx, val1.(time.Time), val2.(time.Time))
+		res, err := pgtypes.TimeTZ.Compare(ctx, val1.(timetz.TimeTZ), val2.(timetz.TimeTZ))
 		return res <= 0, err
 	},
 }

--- a/server/functions/binary/minus.go
+++ b/server/functions/binary/minus.go
@@ -23,6 +23,8 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/dolthub/doltgresql/postgres/parser/duration"
+	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
+	"github.com/dolthub/doltgresql/postgres/parser/timetz"
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
@@ -368,12 +370,11 @@ var time_mi_time = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		time1 := val1.(time.Time)
-		time2 := val2.(time.Time)
+		time1 := val1.(timeofday.TimeOfDay)
+		time2 := val2.(timeofday.TimeOfDay)
 
 		// Calculate the difference and return as interval
-		diff := time1.Sub(time2)
-		return duration.MakeDuration(diff.Nanoseconds(), 0, 0), nil
+		return timeofday.TimeOfDay(int64(time1) - int64(time2)).Round(time.Microsecond), nil
 	},
 }
 
@@ -384,11 +385,9 @@ var time_mi_interval = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Time, pgtypes.Interval},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		timeVal := val1.(time.Time)
+		timeVal := val1.(timeofday.TimeOfDay)
 		interval := val2.(duration.Duration)
-
-		// Subtract the interval from the time
-		return timeVal.Add(-time.Duration(interval.Nanos())), nil
+		return timeVal.Sub(interval), nil
 	},
 }
 
@@ -400,10 +399,9 @@ var timetz_mi_interval = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		interval := val1.(duration.Duration)
-		timetzVal := val2.(time.Time)
-
-		// Subtract the interval from the timetz (note: parameters are reversed)
-		return timetzVal.Add(-time.Duration(interval.Nanos())), nil
+		timetzVal := val2.(timetz.TimeTZ)
+		timetzVal.TimeOfDay = timetzVal.TimeOfDay.Sub(interval)
+		return timetzVal, nil
 	},
 }
 

--- a/server/functions/binary/not_equal.go
+++ b/server/functions/binary/not_equal.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/dolthub/doltgresql/core/id"
 	"github.com/dolthub/doltgresql/postgres/parser/duration"
+	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
+	"github.com/dolthub/doltgresql/postgres/parser/timetz"
 	"github.com/dolthub/doltgresql/postgres/parser/uuid"
 	"github.com/dolthub/doltgresql/server/compare"
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -444,7 +446,7 @@ var time_ne = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Time.Compare(ctx, val1.(time.Time), val2.(time.Time))
+		res, err := pgtypes.Time.Compare(ctx, val1.(timeofday.TimeOfDay), val2.(timeofday.TimeOfDay))
 		return res != 0, err
 	},
 }
@@ -528,7 +530,7 @@ var timetz_ne = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.TimeTZ.Compare(ctx, val1.(time.Time), val2.(time.Time))
+		res, err := pgtypes.TimeTZ.Compare(ctx, val1.(timetz.TimeTZ), val2.(timetz.TimeTZ))
 		return res != 0, err
 	},
 }

--- a/server/functions/binary/plus.go
+++ b/server/functions/binary/plus.go
@@ -23,6 +23,8 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/dolthub/doltgresql/postgres/parser/duration"
+	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
+	"github.com/dolthub/doltgresql/postgres/parser/timetz"
 	"github.com/dolthub/doltgresql/server/functions"
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
@@ -299,7 +301,9 @@ var interval_pl = framework.Function2{
 
 // interval_pl_time_callable is the callable logic for the interval_pl_time function.
 func interval_pl_time_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-	return val2.(time.Time).Add(time.Duration(val1.(duration.Duration).Nanos())), nil
+	interval := val1.(duration.Duration)
+	timeVal := val2.(timeofday.TimeOfDay)
+	return timeVal.Add(interval), nil
 }
 
 // interval_pl_time represents the PostgreSQL function of the same name, taking the same parameters.
@@ -327,8 +331,10 @@ var interval_pl_date = framework.Function2{
 
 // interval_pl_timetz_callable is the callable logic for the interval_pl_timetz function.
 func interval_pl_timetz_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-	ttz := val2.(time.Time)
-	return ttz.Add(time.Duration(val1.(duration.Duration).Nanos())), nil
+	interval := val1.(duration.Duration)
+	timeVal := val2.(timetz.TimeTZ)
+	timeVal.TimeOfDay = timeVal.TimeOfDay.Add(interval)
+	return timeVal, nil
 }
 
 // interval_pl_timetz represents the PostgreSQL function of the same name, taking the same parameters.
@@ -436,7 +442,7 @@ var datetime_pl = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		date := val1.(time.Time)
-		timeVal := val2.(time.Time)
+		timeVal := val2.(timeofday.TimeOfDay).ToTime()
 
 		// Combine date from first parameter with time from second parameter
 		// Extract hour, minute, second, nanosecond from time
@@ -458,7 +464,7 @@ var datetimetz_pl = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		date := val1.(time.Time)
-		timetzVal := val2.(time.Time)
+		timetzVal := val2.(timetz.TimeTZ).ToTime()
 
 		// Combine date from first parameter with time+timezone from second parameter
 		// Extract hour, minute, second, nanosecond, and timezone from timetz
@@ -480,7 +486,7 @@ var timedate_pl = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Time, pgtypes.Date},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		timeVal := val1.(time.Time)
+		timeVal := val1.(timeofday.TimeOfDay).ToTime()
 		date := val2.(time.Time)
 
 		// Combine time from first parameter with date from second parameter
@@ -502,7 +508,7 @@ var timetzdate_pl = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.Date},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		timetzVal := val1.(time.Time)
+		timetzVal := val1.(timetz.TimeTZ).ToTime()
 		date := val2.(time.Time)
 
 		// Combine timetz from first parameter with date from second parameter
@@ -555,12 +561,9 @@ var time_pl_interval = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Time, pgtypes.Interval},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		timeVal := val1.(time.Time)
+		timeVal := val1.(timeofday.TimeOfDay)
 		interval := val2.(duration.Duration)
-
-		// Add the interval to the time
-		// Convert interval to duration and add to time
-		return timeVal.Add(time.Duration(interval.Nanos())), nil
+		return timeVal.Add(interval), nil
 	},
 }
 
@@ -571,12 +574,10 @@ var timetz_pl_interval = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.Interval},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		timetzVal := val1.(time.Time)
+		timetzVal := val1.(timetz.TimeTZ)
 		interval := val2.(duration.Duration)
-
-		// Add the interval to the timetz
-		// Convert interval to duration and add to timetz
-		return timetzVal.Add(time.Duration(interval.Nanos())), nil
+		timetzVal.TimeOfDay = timetzVal.TimeOfDay.Add(interval)
+		return timetzVal, nil
 	},
 }
 
@@ -585,9 +586,7 @@ var timetz_pl_interval = framework.Function2{
 func intervalPlusNonInterval(d duration.Duration, t time.Time) (time.Time, error) {
 	seconds, ok := d.AsInt64()
 	if !ok {
-		if !ok {
-			return time.Time{}, errors.Errorf("interval overflow")
-		}
+		return time.Time{}, errors.Errorf("interval overflow")
 	}
 	nanos := float64(seconds) * functions.NanosPerSec
 	if nanos > float64(math.MaxInt64) || nanos < float64(math.MinInt64) {

--- a/server/functions/date_part.go
+++ b/server/functions/date_part.go
@@ -22,6 +22,8 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/dolthub/doltgresql/postgres/parser/duration"
+	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
+	"github.com/dolthub/doltgresql/postgres/parser/timetz"
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
@@ -70,7 +72,7 @@ var date_part_text_time = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
 		field := val1.(string)
-		timeVal := val2.(time.Time)
+		timeVal := val2.(timeofday.TimeOfDay).ToTime()
 		switch strings.ToLower(field) {
 		case "century", "centuries", "day", "days", "decade", "decades", "dow", "doy",
 			"isodow", "isoyear", "julian", "millennium", "millenniums", "month", "months",
@@ -95,7 +97,7 @@ var date_part_text_timetz = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
 		field := val1.(string)
-		timetzVal := val2.(time.Time)
+		timetzVal := val2.(timetz.TimeTZ).ToTime()
 		_, currentOffset := timetzVal.Zone()
 		switch strings.ToLower(field) {
 		case "century", "centuries", "day", "days", "decade", "decades", "dow", "doy",

--- a/server/functions/extract.go
+++ b/server/functions/extract.go
@@ -25,6 +25,8 @@ import (
 	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/doltgresql/postgres/parser/duration"
+	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
+	"github.com/dolthub/doltgresql/postgres/parser/timetz"
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
@@ -72,7 +74,7 @@ var extract_text_time = framework.Function2{
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
 		field := val1.(string)
-		timeVal := val2.(time.Time)
+		timeVal := val2.(timeofday.TimeOfDay).ToTime()
 		switch strings.ToLower(field) {
 		case "century", "centuries", "day", "days", "decade", "decades", "dow", "doy",
 			"isodow", "isoyear", "julian", "millennium", "millenniums", "month", "months",
@@ -93,7 +95,7 @@ var extract_text_timetz = framework.Function2{
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
 		field := val1.(string)
-		timetzVal := val2.(time.Time)
+		timetzVal := val2.(timetz.TimeTZ).ToTime()
 		_, currentOffset := timetzVal.Zone()
 		switch strings.ToLower(field) {
 		case "century", "centuries", "day", "days", "decade", "decades", "dow", "doy",

--- a/server/functions/sql_constant.go
+++ b/server/functions/sql_constant.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/dolthub/go-mysql-server/sql"
 
+	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
+	"github.com/dolthub/doltgresql/postgres/parser/timetz"
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
@@ -56,7 +58,8 @@ var current_time = framework.Function0{
 	Return: pgtypes.TimeTZ,
 	Strict: true,
 	Callable: func(ctx *sql.Context) (any, error) {
-		return ctx.QueryTime(), nil
+		t := ctx.QueryTime()
+		return timetz.MakeTimeTZFromLocation(timeofday.New(t.Hour(), t.Minute(), t.Second(), t.Nanosecond()/1000), t.Location()), nil
 	},
 }
 
@@ -69,7 +72,8 @@ var current_time_int32 = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		// TODO: support precision
-		return ctx.QueryTime(), nil
+		t := ctx.QueryTime()
+		return timetz.MakeTimeTZFromLocation(timeofday.New(t.Hour(), t.Minute(), t.Second(), t.Nanosecond()/1000), t.Location()), nil
 	},
 }
 

--- a/server/functions/time.go
+++ b/server/functions/time.go
@@ -15,8 +15,6 @@
 package functions
 
 import (
-	"time"
-
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/jackc/pgtype"
 
@@ -57,7 +55,7 @@ var time_in = framework.Function3{
 		if err != nil {
 			return nil, err
 		}
-		return timeofday.TimeOfDay(*t).ToTime(), nil
+		return timeofday.TimeOfDay(*t), nil
 	},
 }
 
@@ -68,7 +66,7 @@ var time_out = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Time},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		return val.(time.Time).Format("15:04:05.999999999"), nil
+		return val.(timeofday.TimeOfDay).String(), nil
 	},
 }
 
@@ -88,7 +86,7 @@ var time_recv = framework.Function3{
 		if err != nil {
 			return nil, err
 		}
-		return time.UnixMicro(out.Microseconds).UTC(), nil
+		return timeofday.New(0, 0, 0, int(out.Microseconds)), nil
 	},
 }
 
@@ -100,7 +98,7 @@ var time_send = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		writer := utils.NewWireWriter()
-		writer.WriteInt64(val.(time.Time).UnixMicro())
+		writer.WriteInt64(int64(val.(timeofday.TimeOfDay)))
 		return writer.BufferData(), nil
 	},
 }
@@ -138,8 +136,8 @@ var time_cmp = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Time, pgtypes.Time},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		ab := val1.(time.Time)
-		bb := val2.(time.Time)
+		ab := val1.(timeofday.TimeOfDay)
+		bb := val2.(timeofday.TimeOfDay)
 		return int32(ab.Compare(bb)), nil
 	},
 }

--- a/server/functions/timetz.go
+++ b/server/functions/timetz.go
@@ -15,12 +15,12 @@
 package functions
 
 import (
-	"strconv"
 	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/postgres/parser/sem/tree"
+	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
 	"github.com/dolthub/doltgresql/postgres/parser/timetz"
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
@@ -58,7 +58,7 @@ var timetz_in = framework.Function3{
 		if err != nil {
 			return nil, err
 		}
-		return t.ToTime(), nil
+		return t, nil
 	},
 }
 
@@ -69,8 +69,7 @@ var timetz_out = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.TimeTZ},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		// TODO: this always displays the time with an offset relevant to the server location
-		return timetz.MakeTimeTZFromTime(val.(time.Time)).String(), nil
+		return val.(timetz.TimeTZ).String(), nil
 	},
 }
 
@@ -87,9 +86,9 @@ var timetz_recv = framework.Function3{
 			return nil, nil
 		}
 		reader := utils.NewWireReader(data)
-		micro := reader.ReadInt64()
-		timezoneMicro := int64(reader.ReadInt32()) * 1000000
-		return time.UnixMicro(micro + timezoneMicro), nil
+		tod := reader.ReadInt64()
+		offset := reader.ReadInt32()
+		return timetz.MakeTimeTZ(timeofday.TimeOfDay(tod), offset), nil
 	},
 }
 
@@ -100,26 +99,10 @@ var timetz_send = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.TimeTZ},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		// We have to isolate the UTC time from the timezone, so we subtract the timezone delta from the original time
-		tim := val.(time.Time)
-		timezone, _ := strconv.Atoi(tim.Format("-070000"))
-		isNegative := false
-		if timezone < 0 {
-			isNegative = true
-			timezone = -timezone
-		}
-		seconds := timezone % 100
-		minutes := (timezone / 100) % 100
-		hours := (timezone / 10000) % 100
-		totalSeconds := int32(seconds + (60 * minutes) + (3600 * hours))
-		if !isNegative {
-			totalSeconds = -totalSeconds // The sign is inverted when writing the integer
-		}
-		timeOffset := time.Duration(-totalSeconds) * time.Second // Adding a negative is the same as subtracting
-		tim = tim.UTC().Add(timeOffset)
+		tim := val.(timetz.TimeTZ)
 		writer := utils.NewWireWriter()
-		writer.WriteInt64(tim.UnixMicro())
-		writer.WriteInt32(totalSeconds)
+		writer.WriteInt64(int64(tim.TimeOfDay))
+		writer.WriteInt32(tim.OffsetSecs)
 		return writer.BufferData(), nil
 	},
 }
@@ -157,8 +140,8 @@ var timetz_cmp = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.TimeTZ, pgtypes.TimeTZ},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		ab := val1.(time.Time)
-		bb := val2.(time.Time)
+		ab := val1.(timetz.TimeTZ)
+		bb := val2.(timetz.TimeTZ)
 		return int32(ab.Compare(bb)), nil
 	},
 }

--- a/server/functions/timezone.go
+++ b/server/functions/timezone.go
@@ -79,14 +79,14 @@ var timezone_text_timetz = framework.Function2{
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
 		tz := val1.(string)
-		timeVal := val2.(time.Time)
+		timeVal := val2.(timetz.TimeTZ).ToTime()
 		_, newOffset, _, err := convertTzToOffsetSecs(timeVal, tz)
 		if err != nil {
 			return nil, err
 		}
 		_, currentOffset := timeVal.Zone()
 		t := timeVal.Add(time.Duration((-int64(currentOffset) + int64(newOffset)) * NanosPerSec))
-		return timetz.MakeTimeTZ(timeofday.FromTime(t), -newOffset).ToTime(), nil
+		return timetz.MakeTimeTZ(timeofday.FromTime(t), -newOffset), nil
 	},
 }
 
@@ -99,11 +99,11 @@ var timezone_interval_timetz = framework.Function2{
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
 		dur := val1.(duration.Duration)
-		timeVal := val2.(time.Time)
+		timeVal := val2.(timetz.TimeTZ).ToTime()
 		newOffset := int32(dur.Nanos() / NanosPerSec)
 		_, currentOffset := timeVal.Zone()
 		t := timeVal.Add(time.Duration((-int64(currentOffset) + int64(newOffset)) * NanosPerSec))
-		return timetz.MakeTimeTZ(timeofday.FromTime(t), -newOffset).ToTime(), nil
+		return timetz.MakeTimeTZ(timeofday.FromTime(t), -newOffset), nil
 	},
 }
 

--- a/server/types/time.go
+++ b/server/types/time.go
@@ -15,10 +15,11 @@
 package types
 
 import (
-	"time"
-
 	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
+	"github.com/dolthub/doltgresql/utils"
 
 	"github.com/dolthub/doltgresql/core/id"
 )
@@ -92,7 +93,10 @@ func GetTimePrecisionFromTypMod(typmod int32) int32 {
 // serializeTypeTime handles serialization from the standard representation to our serialized representation that is
 // written in Dolt.
 func serializeTypeTime(ctx *sql.Context, t *DoltgresType, val any) ([]byte, error) {
-	return val.(time.Time).MarshalBinary()
+	v := val.(timeofday.TimeOfDay)
+	writer := utils.NewWriter(8)
+	writer.Int64(int64(v))
+	return writer.Data(), nil
 }
 
 // deserializeTypeTime handles deserialization from the Dolt serialized format to our standard representation used by
@@ -101,9 +105,6 @@ func deserializeTypeTime(ctx *sql.Context, _ *DoltgresType, data []byte) (any, e
 	if len(data) == 0 {
 		return nil, nil
 	}
-	t := time.Time{}
-	if err := t.UnmarshalBinary(data); err != nil {
-		return nil, err
-	}
-	return t, nil
+	reader := utils.NewReader(data)
+	return timeofday.TimeOfDay(reader.Int64()), nil
 }

--- a/server/types/timetz.go
+++ b/server/types/timetz.go
@@ -15,9 +15,11 @@
 package types
 
 import (
-	"time"
-
 	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
+	"github.com/dolthub/doltgresql/postgres/parser/timetz"
+	"github.com/dolthub/doltgresql/utils"
 
 	"github.com/dolthub/doltgresql/core/id"
 )
@@ -73,7 +75,11 @@ func NewTimeTZType(precision int32) (*DoltgresType, error) {
 // serializeTypeTimeTZ handles serialization from the standard representation to our serialized representation that is
 // written in Dolt.
 func serializeTypeTimeTZ(ctx *sql.Context, t *DoltgresType, val any) ([]byte, error) {
-	return val.(time.Time).MarshalBinary()
+	v := val.(timetz.TimeTZ)
+	writer := utils.NewWriter(12)
+	writer.Int64(int64(v.TimeOfDay))
+	writer.Int32(v.OffsetSecs)
+	return writer.Data(), nil
 }
 
 // deserializeTypeTimeTZ handles deserialization from the Dolt serialized format to our standard representation used by
@@ -82,9 +88,8 @@ func deserializeTypeTimeTZ(ctx *sql.Context, _ *DoltgresType, data []byte) (any,
 	if len(data) == 0 {
 		return nil, nil
 	}
-	t := time.Time{}
-	if err := t.UnmarshalBinary(data); err != nil {
-		return nil, err
-	}
-	return t, nil
+	reader := utils.NewReader(data)
+	tod := reader.Int64()
+	offset := reader.Int32()
+	return timetz.MakeTimeTZ(timeofday.TimeOfDay(tod), offset), nil
 }

--- a/server/types/type.go
+++ b/server/types/type.go
@@ -33,6 +33,8 @@ import (
 
 	"github.com/dolthub/doltgresql/core/id"
 	"github.com/dolthub/doltgresql/postgres/parser/duration"
+	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
+	"github.com/dolthub/doltgresql/postgres/parser/timetz"
 	"github.com/dolthub/doltgresql/postgres/parser/uuid"
 	"github.com/dolthub/doltgresql/utils"
 )
@@ -317,6 +319,12 @@ func (t *DoltgresType) Compare(ctx context.Context, v1 interface{}, v2 interface
 	case decimal.Decimal:
 		bb := v2.(decimal.Decimal)
 		return ab.Cmp(bb), nil
+	case timeofday.TimeOfDay:
+		bb := v2.(timeofday.TimeOfDay)
+		return ab.Compare(bb), nil
+	case timetz.TimeTZ:
+		bb := v2.(timetz.TimeTZ)
+		return ab.Compare(bb), nil
 	case uuid.UUID:
 		bb := v2.(uuid.UUID)
 		return bytes.Compare(ab.GetBytesMut(), bb.GetBytesMut()), nil
@@ -403,7 +411,7 @@ func (t *DoltgresType) Convert(ctx context.Context, v interface{}) (interface{},
 		if ok {
 			return v, sql.InRange, nil
 		}
-	case "date", "time", "timestamp", "timestamptz", "timetz":
+	case "date", "timestamp", "timestamptz":
 		if _, ok := v.(time.Time); ok {
 			return v, sql.InRange, nil
 		}
@@ -437,6 +445,14 @@ func (t *DoltgresType) Convert(ctx context.Context, v interface{}) (interface{},
 		}
 	case "oid", "regclass", "regproc", "regtype":
 		if _, ok := v.(id.Id); ok {
+			return v, sql.InRange, nil
+		}
+	case "time":
+		if _, ok := v.(timeofday.TimeOfDay); ok {
+			return v, sql.InRange, nil
+		}
+	case "timetz":
+		if _, ok := v.(timetz.TimeTZ); ok {
 			return v, sql.InRange, nil
 		}
 	case "xid":

--- a/testing/go/framework.go
+++ b/testing/go/framework.go
@@ -678,7 +678,7 @@ func NormalizeValToString(dt *types.DoltgresType, v any) any {
 			panic(err)
 		}
 		return val
-	case types.Interval.ID, types.Time.ID, types.Uuid.ID:
+	case types.Interval.ID, types.Uuid.ID:
 		// These values need to be normalized into the appropriate types
 		// before being converted to string type using the Doltgres
 		// IoOutput method.
@@ -720,6 +720,8 @@ func NormalizeValToString(dt *types.DoltgresType, v any) any {
 			decStr := decimal.NewFromBigInt(val.Int, val.Exp).StringFixed(val.Exp * -1)
 			return Numeric(decStr)
 		}
+	case pgtype.Time:
+		return timeofday.TimeOfDay(val.Microseconds).String()
 	case []any:
 		if dt.IsArrayType() {
 			return NormalizeArrayType(dt, val)
@@ -790,7 +792,7 @@ func NormalizeVal(dt *types.DoltgresType, v any) any {
 		}
 	case pgtype.Time:
 		// This value type is used for TIME type.
-		return timeofday.FromInt(val.Microseconds).ToTime()
+		return timeofday.FromInt(val.Microseconds)
 	case pgtype.Interval:
 		// This value type is used for INTERVAL type.
 		return duration.MakeDuration(val.Microseconds*functions.NanosPerMicro, int64(val.Days), int64(val.Months))

--- a/testing/go/wire_test.go
+++ b/testing/go/wire_test.go
@@ -4214,7 +4214,6 @@ func TestWireTypesSending(t *testing.T) {
 		},
 		{
 			Name: "TIMETZ returning text format",
-			Skip: true, // TODO: it doesn't consider DST when deserializing timezone offset. Look into: https://cs.opensource.google/go/go/+/master:src/time/time.go;l=1564
 			SetUpScript: []string{
 				"CREATE TABLE test (v1 TIMETZ, v2 TIMETZ);",
 				"INSERT INTO test VALUES ('0:0 PST', '04:05:06.789 MST'), ('09:27 PM CST', '12:12 EST');",
@@ -4298,10 +4297,9 @@ func TestWireTypesSending(t *testing.T) {
 		},
 		{
 			Name: "TIMETZ returning binary format",
-			Skip: true,
 			SetUpScript: []string{
 				"CREATE TABLE test (v1 TIMETZ, v2 TIMETZ);",
-				"INSERT INTO test VALUES ('0:0', '04:05:06.789'), ('09:27 PM', '12:12');",
+				"INSERT INTO test VALUES ('0:0 PST', '04:05:06.789 PDT'), ('09:27 PM CST', '12:12 EST');",
 			},
 			Assertions: []WireScriptTestAssertion{
 				{
@@ -4364,13 +4362,13 @@ func TestWireTypesSending(t *testing.T) {
 						&pgproto3.DataRow{
 							Values: [][]byte{
 								{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 112, 128},
-								{0, 0, 0, 3, 108, 151, 202, 136, 0, 0, 112, 128},
+								{0, 0, 0, 3, 108, 151, 202, 136, 0, 0, 98, 112},
 							},
 						},
 						&pgproto3.DataRow{
 							Values: [][]byte{
-								{0, 0, 0, 17, 250, 171, 177, 0, 0, 0, 112, 128},
-								{0, 0, 0, 10, 57, 214, 4, 0, 0, 0, 112, 128},
+								{0, 0, 0, 17, 250, 171, 177, 0, 0, 0, 84, 96},
+								{0, 0, 0, 10, 57, 214, 4, 0, 0, 0, 70, 80},
 							},
 						},
 						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 2")},
@@ -6979,7 +6977,6 @@ func TestWireTypesReceiving(t *testing.T) {
 		},
 		{
 			Name: `TIMETZ receiving binary format`,
-			Skip: true, // TODO: need to consider daylight savings
 			SetUpScript: []string{
 				"CREATE TABLE test (v1 TIMETZ, v2 TIMETZ);",
 			},


### PR DESCRIPTION
`time.Time` serialization and deserialization can cause information to be irreversibly lost due to daylight savings time changes. The location isn't directly serialized due to it being tied to the runtime system information (different operating systems may have different time zone information), and is therefore reconstructed on deserialization.

This is fine for `timestamptz`, as we internally process everything as UTC and use the client's timezone when returning values to the client. For `timetz`, however, the timezone information is embedded in the value itself and is independent of the client, and this was causing information loss during serialization. This PR changes serialization to use the `timetz.TimeTZ` type, which is already used at most steps (by casting `time.Time` to `timetz.TimeTZ` and vice-versa), and therefore the change propagates to all functions that take a `timetz` value.

In line with this, the `time` type was updated to use `timeofday.TimeOfDay`, which is also already used internally in most functions. Although serialization is fine, this was changed to be more inline with `timetz` (as `timetz.TimeTZ` directly uses `timeofday.TimeOfDay`) and also due to `time.Time` carrying implicit information that can cause direct value comparisons to be incorrect. For example, `'01:00:00'::time` should sort before `'02:00:00'::time`, however adding 24 hours to the first value will still result in the correct hour mark for display, but internally the `time.Time` value would be on the next day, and would cause the comparison to actually show `'02:00:00'::time` appearing first (assuming they started on the same day to begin with).

All of these issues are fixed by using the correct types that are already in Doltgres, and already used by the internal functions. I'm not sure why we decided to use `time.Time` instead of those anyway (as `interval` uses the internal type rather than casting to `time.Duration`), but this fixes it. This does mean that the serialization is incompatible with existing databases, however since serialization was incorrect in the first place, it's a necessary change.