### PR TITLE
`pg_catalog` fixes

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -17,6 +17,7 @@ package core
 import (
 	"maps"
 	"slices"
+	"sort"
 
 	"github.com/cockroachdb/errors"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
@@ -554,4 +555,93 @@ func (cv *contextValues) clear(objID objinterface.RootObjectID) {
 	default:
 		panic("unhandled context clear object ID")
 	}
+}
+
+func IterateDatabaseTables(ctx *sql.Context, callback func(schemaName string, table sql.Table) (stop bool, err error)) error {
+	sess := dsess.DSessFromSess(ctx.Session)
+	currentDatabase, err := sess.Provider().Database(ctx, ctx.GetCurrentDatabase())
+	if err != nil {
+		return err
+	}
+
+	schemaDb, ok := currentDatabase.(sql.SchemaDatabase)
+	if !ok {
+		return nil
+	}
+
+	schemas, err := schemaDb.AllSchemas(ctx)
+	if err != nil {
+		return err
+	}
+
+	sort.Slice(schemas, func(i, j int) bool {
+		return schemas[i].SchemaName() < schemas[j].SchemaName()
+	})
+	for _, schema := range schemas {
+		tableNames, err := schema.GetTableNames(ctx)
+		if err != nil {
+			return err
+		}
+
+		sort.Strings(tableNames)
+		for _, tableName := range tableNames {
+			table, ok, err := schema.GetTableInsensitive(ctx, tableName)
+			if err != nil {
+				return err
+			} else if !ok {
+				continue
+			}
+
+			stop, err := callback(schema.SchemaName(), table)
+			if err != nil || stop {
+				return err
+			}
+		}
+	}
+
+	// If the system variable dolt_show_system_tables is set, then IterateCurrentDatabase
+	// will already contain all existing system tables. Else, we need to add them manually
+	showSystemTablesVar, err := ctx.GetSessionVariable(ctx, dsess.ShowSystemTables)
+	if err != nil {
+		return err
+	}
+	alreadySeenSystemTables := showSystemTablesVar.(int8) == 1
+
+	if !alreadySeenSystemTables {
+		_, root, err := GetRootFromContext(ctx)
+		if err != nil {
+			return err
+		}
+
+		systemTables, err := resolve.GetGeneratedSystemTables(ctx, root)
+		if err != nil {
+			return err
+		}
+
+		// Sort system tables for deterministic iteration (OIDs depend on this)
+		sort.Slice(systemTables, func(i, j int) bool {
+			if systemTables[i].Schema == systemTables[j].Schema {
+				return systemTables[i].Name < systemTables[j].Name
+			}
+			return systemTables[i].Schema < systemTables[j].Schema
+		})
+
+		for _, tblName := range systemTables {
+			table, err := GetSqlTableFromContext(ctx, "", tblName)
+			if err != nil {
+				// Skip tables that can't be loaded
+				continue
+			}
+			if table == nil {
+				continue
+			}
+
+			stop, err := callback(tblName.Schema, table)
+			if err != nil || stop {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/core/init.go
+++ b/core/init.go
@@ -37,6 +37,7 @@ func Init() {
 	id.RegisterListener(sequenceIDListener{}, id.Section_Table)
 	typecollection.GetSqlTableFromContext = GetSqlTableFromContext
 	typecollection.GetSchemaName = GetSchemaName
+	typecollection.IterateDatabaseTables = IterateDatabaseTables
 	pgtypes.GetTypesCollectionFromContext = func(ctx *sql.Context) (pgtypes.TypeCollection, error) {
 		return GetTypesCollectionFromContext(ctx)
 	}

--- a/core/typecollection/typecollection.go
+++ b/core/typecollection/typecollection.go
@@ -353,12 +353,17 @@ func (pgs *TypeCollection) IterateTypes(ctx context.Context, f func(typ *pgtypes
 		return nil
 	}
 
+	//Now get composite table types
 	err = IterateDatabaseTables(sqlCtx, func(schemaName string, table sql.Table) (stop bool, err error) {
+		if schemaName == "pg_catalog" {
+			return false, nil
+		}
+
 		typ, err := pgs.tableToType(sqlCtx, table, schemaName)
 		if err != nil {
 			return false, err
 		}
-		//Add associated array type  for this table
+		//Add associated array type for this table
 		if typ.IsDefined {
 			arrayType := pgtypes.CreateArrayTypeFromBaseType(typ)
 			stop, err = f(arrayType)
@@ -366,7 +371,6 @@ func (pgs *TypeCollection) IterateTypes(ctx context.Context, f func(typ *pgtypes
 				return stop, err
 			}
 		}
-
 		return f(typ)
 	})
 

--- a/core/typecollection/typecollection.go
+++ b/core/typecollection/typecollection.go
@@ -463,10 +463,14 @@ func (*TypeCollection) tableToType(ctx *sql.Context, tbl sql.Table, schema strin
 	attrs := make([]pgtypes.CompositeAttribute, len(tblSch))
 	for i, col := range tblSch {
 		collation := "" // TODO: what should we use for the collation?
-		colType, ok := col.Type.(*pgtypes.DoltgresType)
-		if !ok {
-			// TODO: perhaps we should use a better error message stating that it uses a non-Doltgres type?
-			return nil, pgtypes.ErrTypeDoesNotExist.New(tblName)
+		var colType *pgtypes.DoltgresType
+		var err error
+		if dt, ok := col.Type.(*pgtypes.DoltgresType); ok {
+			colType = dt
+		} else {
+			if colType, err = pgtypes.FromGmsTypeToDoltgresType(col.Type); err != nil {
+				return nil, fmt.Errorf("unable to convert column type for %s.%s: %w", tblName, col.Name, err)
+			}
 		}
 		attrs[i] = pgtypes.NewCompositeAttribute(ctx, relID, col.Name, colType.ID, int16(i+1), collation)
 	}

--- a/core/typecollection/typecollection.go
+++ b/core/typecollection/typecollection.go
@@ -344,6 +344,32 @@ func (pgs *TypeCollection) IterateTypes(ctx context.Context, f func(typ *pgtypes
 			return nil
 		}
 	})
+	if err != nil {
+		return err
+	}
+
+	sqlCtx, ok := ctx.(*sql.Context)
+	if !ok {
+		return nil
+	}
+
+	err = IterateDatabaseTables(sqlCtx, func(schemaName string, table sql.Table) (stop bool, err error) {
+		typ, err := pgs.tableToType(sqlCtx, table, schemaName)
+		if err != nil {
+			return false, err
+		}
+		//Add associated array type  for this table
+		if typ.IsDefined {
+			arrayType := pgtypes.CreateArrayTypeFromBaseType(typ)
+			stop, err = f(arrayType)
+			if stop || err != nil {
+				return stop, err
+			}
+		}
+
+		return f(typ)
+	})
+
 	return err
 }
 
@@ -482,3 +508,6 @@ var GetSqlTableFromContext func(ctx *sql.Context, databaseName string, tableName
 
 // GetSchemaName is a forward declaration to get around import cycles
 var GetSchemaName func(ctx *sql.Context, db sql.Database, schemaName string) (string, error)
+
+// IterateDatabaseTables is a forward declaration to get around import cycles
+var IterateDatabaseTables func(ctx *sql.Context, callback func(schemaName string, table sql.Table) (stop bool, err error)) error

--- a/core/typecollection/typecollection.go
+++ b/core/typecollection/typecollection.go
@@ -355,10 +355,6 @@ func (pgs *TypeCollection) IterateTypes(ctx context.Context, f func(typ *pgtypes
 
 	//Now get composite table types
 	err = IterateDatabaseTables(sqlCtx, func(schemaName string, table sql.Table) (stop bool, err error) {
-		if schemaName == "pg_catalog" {
-			return false, nil
-		}
-
 		typ, err := pgs.tableToType(sqlCtx, table, schemaName)
 		if err != nil {
 			return false, err

--- a/server/tables/pgcatalog/pg_class.go
+++ b/server/tables/pgcatalog/pg_class.go
@@ -16,11 +16,11 @@ package pgcatalog
 
 import (
 	"fmt"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
 	"io"
 	"math"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/resolve"
 	"github.com/dolthub/go-mysql-server/sql"
 

--- a/server/tables/pgcatalog/pg_class.go
+++ b/server/tables/pgcatalog/pg_class.go
@@ -16,6 +16,7 @@ package pgcatalog
 
 import (
 	"fmt"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"io"
 	"math"
 
@@ -154,7 +155,13 @@ func cachePgClasses(ctx *sql.Context, pgCatalogCache *pgCatalogCache) error {
 		return err
 	}
 
-	if includeSystemTables {
+	showSystemTablesVar, err := ctx.GetSessionVariable(ctx, dsess.ShowSystemTables)
+	if err != nil {
+		return err
+	}
+	alreadySeenSystemTables := showSystemTablesVar.(int8) == 1
+
+	if includeSystemTables && !alreadySeenSystemTables {
 		_, root, err := core.GetRootFromContext(ctx)
 		if err != nil {
 			return err

--- a/server/tables/pgcatalog/pg_class.go
+++ b/server/tables/pgcatalog/pg_class.go
@@ -17,6 +17,7 @@ package pgcatalog
 import (
 	"fmt"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/index"
 	"io"
 	"math"
 
@@ -155,6 +156,8 @@ func cachePgClasses(ctx *sql.Context, pgCatalogCache *pgCatalogCache) error {
 		return err
 	}
 
+	// If the system variable dolt_show_system_tables is set, then IterateCurrentDatabase
+	// will already contain all existing system tables. Else, we need to add them manually
 	showSystemTablesVar, err := ctx.GetSessionVariable(ctx, dsess.ShowSystemTables)
 	if err != nil {
 		return err
@@ -199,6 +202,12 @@ func formatIndexName(idx sql.Index) string {
 	if idx.ID() == "PRIMARY" {
 		return fmt.Sprintf("%s_pkey", idx.Table())
 	}
+
+	switch idx.(type) {
+	case *index.BranchNameIndex, *index.CommitIndex:
+		return fmt.Sprintf("%s_%s_key", idx.Table(), idx.ID())
+	}
+
 	return idx.ID()
 	// TODO: Unnamed indexes should have below format
 	// return fmt.Sprintf("%s_%s_key", idx.Table(), idx.ID())

--- a/server/tables/pgcatalog/pg_class.go
+++ b/server/tables/pgcatalog/pg_class.go
@@ -453,12 +453,33 @@ func pgClassToRow(class *pgClass) sql.Row {
 		relam = id.NewAccessMethod("heap").AsId()
 	}
 
+	// Compute reltype - the OID of the composite type for this table/view's row type
+	var reltype id.Id
+
+	if class.kind == "r" || class.kind == "v" {
+		// Tables and views have composite types with the same name in the same schema
+		var schemaName, objectName string
+		if class.kind == "r" {
+			tblId := id.Table(class.oid)
+			schemaName = tblId.SchemaName()
+			objectName = tblId.TableName()
+		} else { // kind == "v"
+			viewId := id.View(class.oid)
+			schemaName = viewId.SchemaName()
+			objectName = viewId.ViewName()
+		}
+		typeId := id.NewType(schemaName, objectName)
+		reltype = typeId.AsId()
+	} else {
+		reltype = id.Null
+	}
+
 	// TODO: Fill in the rest of the pg_class columns
 	return sql.Row{
 		class.oid,        // oid
 		class.name,       // relname
 		class.schemaOid,  // relnamespace
-		id.Null,          // reltype
+		reltype,          // reltype
 		id.Null,          // reloftype
 		id.Null,          // relowner
 		relam,            // relam

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -1771,7 +1771,7 @@ func TestSchemaVisibilityInquiryFunctions(t *testing.T) {
 			},
 			Assertions: []ScriptTestAssertion{
 				{
-					Query: `SELECT t.oid, t.typname, n.nspname FROM pg_catalog.pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace WHERE n.nspname='myschema' OR n.nspname='testschema' ORDER BY t.typname;`,
+					Query: `SELECT t.oid, t.typname, n.nspname FROM pg_catalog.pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace WHERE (n.nspname='myschema' OR n.nspname='testschema') AND t.typname not like '%dolt%' ORDER BY t.typname;`,
 					Expected: []sql.Row{
 						{4183151504, "_mydomain", "myschema"},
 						{2179370508, "_myenum", "myschema"},

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -608,6 +608,44 @@ JOIN pg_am AS am ON ix.relam = am.oid WHERE t.relname = 'foo' AND n.nspname = 'p
 				},
 			},
 		},
+		{
+			Name: "pg_class independent of dolt_show_system_tables",
+			SetUpScript: []string{
+				`SET dolt_show_system_tables=1;`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `SELECT relname FROM pg_class where relname like 'dolt_%' order by relname`,
+					Expected: []sql.Row{
+						{"dolt_backups"},
+						{"dolt_branch_activity"},
+						{"dolt_branches"},
+						{"dolt_branches_dolt_branches_name_idx_key"},
+						{"dolt_column_diff"},
+						{"dolt_commit_ancestors"},
+						{"dolt_commit_ancestors_commit_hash_key"},
+						{"dolt_commits"},
+						{"dolt_commits_commit_hash_key"},
+						{"dolt_conflicts"},
+						{"dolt_constraint_violations"},
+						{"dolt_diff"},
+						{"dolt_diff_commit_hash_key"},
+						{"dolt_help"},
+						{"dolt_log"},
+						{"dolt_log_commit_hash_key"},
+						{"dolt_merge_status"},
+						{"dolt_remote_branches"},
+						{"dolt_remote_branches_dolt_branches_name_idx_key"},
+						{"dolt_remotes"},
+						{"dolt_schema_conflicts"},
+						{"dolt_stashes"},
+						{"dolt_status"},
+						{"dolt_status_ignored"},
+						{"dolt_tags"},
+					},
+				},
+			},
+		},
 	})
 }
 

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -493,7 +493,7 @@ func TestPgClass(t *testing.T) {
 				{
 					Query: `SELECT * FROM "pg_catalog"."pg_class" WHERE relname='testing' order by 1;`,
 					Expected: []sql.Row{
-						{3120782595, "testing", 2638679668, 0, 0, 0, 2, 0, 0, 0, float32(0), 0, 0, "t", "f", "p", "r", 0, 0, "f", "f", "f", "f", "f", "t", "d", "f", 0, 0, 0, nil, nil, nil},
+						{3120782595, "testing", 2638679668, 2288626564, 0, 0, 2, 0, 0, 0, float32(0), 0, 0, "t", "f", "p", "r", 0, 0, "f", "f", "f", "f", "f", "t", "d", "f", 0, 0, 0, nil, nil, nil},
 					},
 				},
 				// Index
@@ -507,7 +507,7 @@ func TestPgClass(t *testing.T) {
 				{
 					Query: `SELECT * FROM "pg_catalog"."pg_class" WHERE relname='testview';`,
 					Expected: []sql.Row{
-						{887295443, "testview", 2638679668, 0, 0, 0, 0, 0, 0, 0, float32(0), 0, 0, "f", "f", "p", "v", 0, 0, "f", "f", "f", "f", "f", "t", "d", "f", 0, 0, 0, nil, nil, nil},
+						{887295443, "testview", 2638679668, 491597638, 0, 0, 0, 0, 0, 0, float32(0), 0, 0, "f", "f", "p", "v", 0, 0, "f", "f", "f", "f", "f", "t", "d", "f", 0, 0, 0, nil, nil, nil},
 					},
 				},
 				{ // Different cases and quoted, so it fails
@@ -573,7 +573,7 @@ func TestPgClass(t *testing.T) {
 				{
 					Query: `SELECT * FROM "pg_catalog"."pg_class" WHERE oid='testschema.testing'::regclass;`,
 					Expected: []sql.Row{
-						{3120782595, "testing", 2638679668, 0, 0, 0, 2, 0, 0, 0, float32(0), 0, 0, "t", "f", "p", "r", 0, 0, "f", "f", "f", "f", "f", "t", "d", "f", 0, 0, 0, nil, nil, nil},
+						{3120782595, "testing", 2638679668, 2288626564, 0, 0, 2, 0, 0, 0, float32(0), 0, 0, "t", "f", "p", "r", 0, 0, "f", "f", "f", "f", "f", "t", "d", "f", 0, 0, 0, nil, nil, nil},
 					},
 				},
 				{
@@ -585,7 +585,7 @@ func TestPgClass(t *testing.T) {
 				{
 					Query: `SELECT * FROM "pg_catalog"."pg_class" WHERE oid='testschema.testview'::regclass;`,
 					Expected: []sql.Row{
-						{887295443, "testview", 2638679668, 0, 0, 0, 0, 0, 0, 0, float32(0), 0, 0, "f", "f", "p", "v", 0, 0, "f", "f", "f", "f", "f", "t", "d", "f", 0, 0, 0, nil, nil, nil},
+						{887295443, "testview", 2638679668, 491597638, 0, 0, 0, 0, 0, 0, float32(0), 0, 0, "f", "f", "p", "v", 0, 0, "f", "f", "f", "f", "f", "t", "d", "f", 0, 0, 0, nil, nil, nil},
 					},
 				},
 			},

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -4797,6 +4797,77 @@ func TestPgType(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "composite table types",
+			SetUpScript: []string{
+				`CREATE TABLE users (id int, name text)`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT * FROM pg_type where typname like 'users'",
+					Expected: []sql.Row{
+						{135364127, `users`, 2200, 0, -1, "f", "c", "C", "f", "t", ",", 3272826793, "-", 0, 3142499152, "record_in", "record_out", "record_recv", "record_send", "-", "-", "-", "d", "x", "f", 0, -1, 0, 0, "", "", "{}"},
+					},
+				},
+			},
+		},
+		{
+			Name:        "pg_type ignores dolt_show_system_tables",
+			SetUpScript: []string{},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `SELECT typname FROM pg_type where typname like 'dolt_%' order by typname`,
+					Expected: []sql.Row{
+						{"dolt_backups"},
+						{"dolt_branch_activity"},
+						{"dolt_branches"},
+						{"dolt_column_diff"},
+						{"dolt_commit_ancestors"},
+						{"dolt_commits"},
+						{"dolt_conflicts"},
+						{"dolt_constraint_violations"},
+						{"dolt_diff"},
+						{"dolt_help"},
+						{"dolt_log"},
+						{"dolt_merge_status"},
+						{"dolt_remote_branches"},
+						{"dolt_remotes"},
+						{"dolt_schema_conflicts"},
+						{"dolt_stashes"},
+						{"dolt_status"},
+						{"dolt_status_ignored"},
+						{"dolt_tags"},
+					},
+				},
+				{
+					Query: `SET dolt_show_system_tables=1`,
+				},
+				{
+					Query: `SELECT typname FROM pg_type where typname like 'dolt_%' order by typname;`,
+					Expected: []sql.Row{
+						{"dolt_backups"},
+						{"dolt_branch_activity"},
+						{"dolt_branches"},
+						{"dolt_column_diff"},
+						{"dolt_commit_ancestors"},
+						{"dolt_commits"},
+						{"dolt_conflicts"},
+						{"dolt_constraint_violations"},
+						{"dolt_diff"},
+						{"dolt_help"},
+						{"dolt_log"},
+						{"dolt_merge_status"},
+						{"dolt_remote_branches"},
+						{"dolt_remotes"},
+						{"dolt_schema_conflicts"},
+						{"dolt_stashes"},
+						{"dolt_status"},
+						{"dolt_status_ignored"},
+						{"dolt_tags"},
+					},
+				},
+			},
+		},
 	})
 }
 


### PR DESCRIPTION
Couple of changes for pg_catalog:

1. Adds table composite types and their associated array types to `pg_type`
2. Fixes `pg_class` bugs related `dolt_show_system_tables`
3. Implements `reltype` column in `pg_class`