### PR TITLE
Fixed ANY using bindings

### DIFF
--- a/server/expression/any.go
+++ b/server/expression/any.go
@@ -237,9 +237,19 @@ func (a *AnyExpr) WithChildren(children ...sql.Expression) (sql.Expression, erro
 		return nil, sql.ErrInvalidChildrenNumber.New(a, len(children), 2)
 	}
 
+	leftExpr := children[0]
+	rightExpr := children[1]
+	// Unmodified BindVars use deferred type resolution, so we replace the deference with the left's type in array form
+	if bv, ok := rightExpr.(*expression.BindVar); ok {
+		if _, ok = bv.Typ.(*pgtypes.DoltgresType); !ok {
+			if leftType, ok := leftExpr.Type().(*pgtypes.DoltgresType); ok {
+				bv.Typ = leftType.ToArrayType()
+			}
+		}
+	}
 	anyExpr := &AnyExpr{
-		leftExpr:    children[0],
-		rightExpr:   children[1],
+		leftExpr:    leftExpr,
+		rightExpr:   rightExpr,
 		subOperator: a.subOperator,
 		name:        a.name,
 	}

--- a/testing/go/binding_test.go
+++ b/testing/go/binding_test.go
@@ -49,6 +49,42 @@ func TestBindingWithOidZero(t *testing.T) {
 	require.NoError(t, result.Err)
 }
 
+func TestIssue2386(t *testing.T) {
+	// https://github.com/dolthub/doltgresql/issues/2386
+	ctx, connection, controller := CreateServer(t, "postgres")
+	defer controller.Stop()
+	conn := connection.Default
+	_, err := connection.Exec(ctx, "CREATE TABLE users (id INT PRIMARY KEY, name TEXT NOT NULL);")
+	require.NoError(t, err)
+	_, err = connection.Exec(ctx, "INSERT INTO users VALUES (1, 'alice'), (2, 'bob'), (3, 'carol'), (4, 'dave');")
+	require.NoError(t, err)
+	targetIDs := []int32{1, 3}
+	rows, err := conn.Query(ctx,
+		`SELECT id, name FROM users WHERE id = ANY($1)`,
+		targetIDs,
+	)
+	require.NoError(t, err)
+	defer rows.Close()
+	i := 0
+	for rows.Next() {
+		var id int32
+		var name string
+		err = rows.Scan(&id, &name)
+		require.NoError(t, err)
+		switch i {
+		case 0:
+			require.Equal(t, int32(1), id)
+			require.Equal(t, "alice", name)
+		case 1:
+			require.Equal(t, int32(3), id)
+			require.Equal(t, "carol", name)
+		default:
+			t.FailNow()
+		}
+		i++
+	}
+}
+
 func TestBindingWithTextArray(t *testing.T) {
 	ctx, connection, controller := CreateServer(t, "postgres")
 	defer controller.Stop()


### PR DESCRIPTION
This fixes:
* https://github.com/dolthub/doltgresql/issues/2386

In GMS/MySQL, we often can't determine the type of a bound parameter during the initial parse as the return type is subject to the input (binding a `float32` vs `int32` may result in an actual return type difference). This is not true for Postgres as type resolution is very well defined. This creates a mismatch where we defer the type resolution, but the client expects to be told what type the bindings should be.

We should have a more general solution that covers bindings at the GMS layer for how MySQL and Postgres handle type resolution differently, but the scope of that project seemed too large for now, so this only implements a local fix specifically for the issue linked above.