### PR TITLE
Fixed issues 2547 and 2557

### DIFF
--- a/server/functions/concat.go
+++ b/server/functions/concat.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+import (
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// initConcat registers the functions to the catalog.
+func initConcat() {
+	framework.RegisterFunction(concat_any)
+}
+
+// concat_any represents the PostgreSQL function of the same name, taking the same parameters.
+var concat_any = framework.Function1N{
+	Name:       "concat",
+	Return:     pgtypes.Text,
+	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Any},
+	Strict:     false,
+	Callable: func(ctx *sql.Context, t []*pgtypes.DoltgresType, val1 any, vals []any) (any, error) {
+		sb := strings.Builder{}
+		if val1 != nil {
+			output, err := t[0].IoOutput(ctx, val1)
+			if err != nil {
+				return nil, err
+			}
+			sb.WriteString(output)
+		}
+		for i, val := range vals {
+			if val == nil {
+				continue
+			}
+			valType := t[i+1]
+			if valType.ID == pgtypes.Bool.ID {
+				// Within this context, `bool` returns 't' rather than 'true'
+				if val.(bool) {
+					sb.WriteRune('t')
+				} else {
+					sb.WriteRune('f')
+				}
+			} else {
+				output, err := valType.IoOutput(ctx, val)
+				if err != nil {
+					return nil, err
+				}
+				sb.WriteString(output)
+			}
+		}
+		return sb.String(), nil
+	},
+}

--- a/server/functions/framework/c_function.go
+++ b/server/functions/framework/c_function.go
@@ -69,6 +69,12 @@ func (cFunc CFunction) NonDeterministic() bool {
 	return cFunc.IsNonDeterministic
 }
 
+// IsCVariadic implements the FunctionInterface interface.
+func (cFunc CFunction) IsCVariadic() bool {
+	// TODO: implement c-language variadic
+	return false
+}
+
 // VariadicIndex implements the interface FunctionInterface.
 func (cFunc CFunction) VariadicIndex() int {
 	// TODO: implement variadic

--- a/server/functions/framework/catalog.go
+++ b/server/functions/framework/catalog.go
@@ -48,7 +48,13 @@ func RegisterFunction(f FunctionInterface) {
 	case Function1:
 		name := strings.ToLower(f.Name)
 		Catalog[name] = append(Catalog[name], f)
+	case Function1N:
+		name := strings.ToLower(f.Name)
+		Catalog[name] = append(Catalog[name], f)
 	case Function2:
+		name := strings.ToLower(f.Name)
+		Catalog[name] = append(Catalog[name], f)
+	case Function2N:
 		name := strings.ToLower(f.Name)
 		Catalog[name] = append(Catalog[name], f)
 	case Function3:

--- a/server/functions/framework/compiled_function.go
+++ b/server/functions/framework/compiled_function.go
@@ -104,13 +104,14 @@ func newCompiledFunctionInternal(
 
 	// Then we'll handle the polymorphic types
 	// https://www.postgresql.org/docs/15/extend-type-system.html#EXTEND-TYPES-POLYMORPHIC
-	functionParameterTypes := fn.GetParameters()
-	c.callResolved = make([]*pgtypes.DoltgresType, len(functionParameterTypes)+1)
+	c.callResolved = make([]*pgtypes.DoltgresType, len(overload.params.paramTypes)+1)
 	hasPolymorphicParam := false
-	for i, param := range functionParameterTypes {
+	for i, param := range overload.params.paramTypes {
 		if param.IsPolymorphicType() {
 			// resolve will ensure that the parameter types are valid, so we can just assign them here
 			hasPolymorphicParam = true
+			c.callResolved[i] = originalTypes[i]
+		} else if param.ID == pgtypes.Any.ID {
 			c.callResolved[i] = originalTypes[i]
 		} else if i < len(args) {
 			if d, ok := args[i].Type().(*pgtypes.DoltgresType); ok {
@@ -124,7 +125,7 @@ func newCompiledFunctionInternal(
 	c.callResolved[len(c.callResolved)-1] = returnType
 	if returnType.IsPolymorphicType() {
 		if hasPolymorphicParam {
-			c.callResolved[len(c.callResolved)-1] = c.resolvePolymorphicReturnType(functionParameterTypes, originalTypes, returnType)
+			c.callResolved[len(c.callResolved)-1] = c.resolvePolymorphicReturnType(overload.params.paramTypes, originalTypes, returnType)
 		} else if c.Name == "array_in" || c.Name == "array_recv" || c.Name == "enum_in" || c.Name == "enum_recv" || c.Name == "anyenum_in" || c.Name == "anyenum_recv" {
 			// The return type should resolve to the type of OID value passed in as second argument.
 			// TODO: Possible that the oid type has a special property with polymorphic return types,
@@ -266,18 +267,20 @@ func (c *CompiledFunction) Eval(ctx *sql.Context, row sql.Row) (interface{}, err
 	var err error
 	isStrict := c.overload.Function().IsStrict()
 	args := make([]any, len(c.Arguments))
+	exprTypes := make([]*pgtypes.DoltgresType, len(args))
 	for i, arg := range c.Arguments {
 		args[i], err = arg.Eval(ctx, row)
 		if err != nil {
 			return nil, err
 		}
-		// TODO: once we remove GMS types from all of our expressions, we can remove this step which ensures the correct type
-		if _, ok := arg.Type().(*pgtypes.DoltgresType); !ok {
+		var ok bool
+		if exprTypes[i], ok = arg.Type().(*pgtypes.DoltgresType); !ok {
 			dt, err := pgtypes.FromGmsTypeToDoltgresType(arg.Type())
 			if err != nil {
 				return nil, err
 			}
 			args[i], _, _ = dt.Convert(ctx, args[i])
+			exprTypes[i] = dt
 		}
 		if args[i] == nil && isStrict {
 			return nil, nil
@@ -285,7 +288,7 @@ func (c *CompiledFunction) Eval(ctx *sql.Context, row sql.Row) (interface{}, err
 	}
 
 	if len(c.overload.casts) > 0 {
-		targetParamTypes := c.overload.Function().GetParameters()
+		targetParamTypes := c.overload.params.paramTypes
 		for i, arg := range args {
 			// For variadic params, we need to identify the corresponding target type
 			var targetType *pgtypes.DoltgresType
@@ -320,8 +323,12 @@ func (c *CompiledFunction) Eval(ctx *sql.Context, row sql.Row) (interface{}, err
 		return f.Callable(ctx)
 	case Function1:
 		return f.Callable(ctx, ([2]*pgtypes.DoltgresType)(c.callResolved), args[0])
+	case Function1N:
+		return f.Callable(ctx, c.callResolved, args[0], args[1:])
 	case Function2:
 		return f.Callable(ctx, ([3]*pgtypes.DoltgresType)(c.callResolved), args[0], args[1])
+	case Function2N:
+		return f.Callable(ctx, c.callResolved, args[0], args[1], args[2:])
 	case Function3:
 		return f.Callable(ctx, ([4]*pgtypes.DoltgresType)(c.callResolved), args[0], args[1], args[2])
 	case Function4:

--- a/server/functions/framework/functions.go
+++ b/server/functions/framework/functions.go
@@ -36,6 +36,9 @@ type FunctionInterface interface {
 	GetExpectedParameterCount() int
 	// NonDeterministic returns whether the function is non-deterministic.
 	NonDeterministic() bool
+	// IsCVariadic returns whether this function uses a variadic form restricted to C-language functions.
+	// https://www.postgresql.org/docs/15/xfunc-c.html#id-1.8.3.13.13
+	IsCVariadic() bool
 	// IsStrict returns whether the function is STRICT, which means if any parameter is NULL, then it returns NULL.
 	// Otherwise, if it's not, the NULL input must be handled by user.
 	IsStrict() bool
@@ -48,7 +51,7 @@ type FunctionInterface interface {
 	enforceInterfaceInheritance(error)
 }
 
-// AggregateFunction is an interface for PostgreSQL aggregate functions
+// AggregateFunctionInterface is an interface for PostgreSQL aggregate functions
 type AggregateFunctionInterface interface {
 	FunctionInterface
 	// TODO: this maybe needs to take the place of the Callable function
@@ -78,6 +81,20 @@ type Function1 struct {
 	Callable           func(ctx *sql.Context, paramsAndReturn [2]*pgtypes.DoltgresType, val1 any) (any, error)
 }
 
+// Function1N is a function that takes at least one parameter. This is different from a SQL variadic function, as the
+// additional parameters may have different types (that do not contribute to type deduction like with `anyelement`), and
+// is only usable by C-language functions (notably built-in ones such as `concat`). The field `paramsAndReturn` works
+// similarly to standard functions, with the last type being the return type.
+type Function1N struct {
+	Name               string
+	Return             *pgtypes.DoltgresType
+	Parameters         [1]*pgtypes.DoltgresType
+	IsNonDeterministic bool
+	Strict             bool
+	SRF                bool
+	Callable           func(ctx *sql.Context, paramsAndReturn []*pgtypes.DoltgresType, val1 any, vals []any) (any, error)
+}
+
 // Function2 is a function that takes two parameters. The parameter and return types are passed into the Callable
 // function when the parameters (and possibly return type) have at least one polymorphic type. The return type is the
 // last type in the array.
@@ -90,6 +107,20 @@ type Function2 struct {
 	Strict             bool
 	SRF                bool
 	Callable           func(ctx *sql.Context, paramsAndReturn [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error)
+}
+
+// Function2N is a function that takes at least two parameters. This is different from a SQL variadic function, as the
+// additional parameters may have different types (that do not contribute to type deduction like with `anyelement`), and
+// is only usable by C-language functions (notably built-in ones such as `concat_ws`). The field `paramsAndReturn` works
+// similarly to standard functions, with the last type being the return type.
+type Function2N struct {
+	Name               string
+	Return             *pgtypes.DoltgresType
+	Parameters         [2]*pgtypes.DoltgresType
+	IsNonDeterministic bool
+	Strict             bool
+	SRF                bool
+	Callable           func(ctx *sql.Context, paramsAndReturn []*pgtypes.DoltgresType, val1 any, val2 any, vals []any) (any, error)
 }
 
 // Function3 is a function that takes three parameters. The parameter and return types are passed into the Callable
@@ -164,7 +195,9 @@ type Function7 struct {
 
 var _ FunctionInterface = Function0{}
 var _ FunctionInterface = Function1{}
+var _ FunctionInterface = Function1N{}
 var _ FunctionInterface = Function2{}
+var _ FunctionInterface = Function2N{}
 var _ FunctionInterface = Function3{}
 var _ FunctionInterface = Function4{}
 var _ FunctionInterface = Function5{}
@@ -189,6 +222,9 @@ func (f Function0) GetExpectedParameterCount() int { return 0 }
 
 // NonDeterministic implements the FunctionInterface interface.
 func (f Function0) NonDeterministic() bool { return f.IsNonDeterministic }
+
+// IsCVariadic implements the FunctionInterface interface.
+func (f Function0) IsCVariadic() bool { return false }
 
 // IsStrict implements the FunctionInterface interface.
 func (f Function0) IsStrict() bool { return f.Strict }
@@ -228,6 +264,9 @@ func (f Function1) GetExpectedParameterCount() int { return 1 }
 // NonDeterministic implements the FunctionInterface interface.
 func (f Function1) NonDeterministic() bool { return f.IsNonDeterministic }
 
+// IsCVariadic implements the FunctionInterface interface.
+func (f Function1) IsCVariadic() bool { return false }
+
 // IsStrict implements the FunctionInterface interface.
 func (f Function1) IsStrict() bool { return f.Strict }
 
@@ -241,6 +280,43 @@ func (f Function1) InternalID() id.Id {
 
 // enforceInterfaceInheritance implements the FunctionInterface interface.
 func (f Function1) enforceInterfaceInheritance(error) {}
+
+// GetName implements the FunctionInterface interface.
+func (f Function1N) GetName() string { return f.Name }
+
+// GetReturn implements the FunctionInterface interface.
+func (f Function1N) GetReturn() *pgtypes.DoltgresType { return getTypeIfRowType(f.IsSRF(), f.Return) }
+
+// GetParameters implements the FunctionInterface interface.
+func (f Function1N) GetParameters() []*pgtypes.DoltgresType { return f.Parameters[:] }
+
+// VariadicIndex implements the FunctionInterface interface.
+func (f Function1N) VariadicIndex() int {
+	return -1
+}
+
+// GetExpectedParameterCount implements the FunctionInterface interface.
+func (f Function1N) GetExpectedParameterCount() int { return 1 }
+
+// NonDeterministic implements the FunctionInterface interface.
+func (f Function1N) NonDeterministic() bool { return f.IsNonDeterministic }
+
+// IsCVariadic implements the FunctionInterface interface.
+func (f Function1N) IsCVariadic() bool { return true }
+
+// IsStrict implements the FunctionInterface interface.
+func (f Function1N) IsStrict() bool { return f.Strict }
+
+// IsSRF implements the FunctionInterface interface.
+func (f Function1N) IsSRF() bool { return f.SRF }
+
+// InternalID implements the FunctionInterface interface.
+func (f Function1N) InternalID() id.Id {
+	return id.NewFunction("pg_catalog", f.Name, f.Parameters[0].ID).AsId()
+}
+
+// enforceInterfaceInheritance implements the FunctionInterface interface.
+func (f Function1N) enforceInterfaceInheritance(error) {}
 
 // GetName implements the FunctionInterface interface.
 func (f Function2) GetName() string { return f.Name }
@@ -266,6 +342,9 @@ func (f Function2) GetExpectedParameterCount() int { return 2 }
 // NonDeterministic implements the FunctionInterface interface.
 func (f Function2) NonDeterministic() bool { return f.IsNonDeterministic }
 
+// IsCVariadic implements the FunctionInterface interface.
+func (f Function2) IsCVariadic() bool { return false }
+
 // IsStrict implements the FunctionInterface interface.
 func (f Function2) IsStrict() bool { return f.Strict }
 
@@ -279,6 +358,43 @@ func (f Function2) InternalID() id.Id {
 
 // enforceInterfaceInheritance implements the FunctionInterface interface.
 func (f Function2) enforceInterfaceInheritance(error) {}
+
+// GetName implements the FunctionInterface interface.
+func (f Function2N) GetName() string { return f.Name }
+
+// GetReturn implements the FunctionInterface interface.
+func (f Function2N) GetReturn() *pgtypes.DoltgresType { return getTypeIfRowType(f.IsSRF(), f.Return) }
+
+// GetParameters implements the FunctionInterface interface.
+func (f Function2N) GetParameters() []*pgtypes.DoltgresType { return f.Parameters[:] }
+
+// VariadicIndex implements the FunctionInterface interface.
+func (f Function2N) VariadicIndex() int {
+	return -1
+}
+
+// GetExpectedParameterCount implements the FunctionInterface interface.
+func (f Function2N) GetExpectedParameterCount() int { return 2 }
+
+// NonDeterministic implements the FunctionInterface interface.
+func (f Function2N) NonDeterministic() bool { return f.IsNonDeterministic }
+
+// IsCVariadic implements the FunctionInterface interface.
+func (f Function2N) IsCVariadic() bool { return true }
+
+// IsStrict implements the FunctionInterface interface.
+func (f Function2N) IsStrict() bool { return f.Strict }
+
+// IsSRF implements the FunctionInterface interface.
+func (f Function2N) IsSRF() bool { return f.SRF }
+
+// InternalID implements the FunctionInterface interface.
+func (f Function2N) InternalID() id.Id {
+	return id.NewFunction("pg_catalog", f.Name, f.Parameters[0].ID, f.Parameters[1].ID).AsId()
+}
+
+// enforceInterfaceInheritance implements the FunctionInterface interface.
+func (f Function2N) enforceInterfaceInheritance(error) {}
 
 // GetName implements the FunctionInterface interface.
 func (f Function3) GetName() string { return f.Name }
@@ -303,6 +419,9 @@ func (f Function3) GetExpectedParameterCount() int { return 3 }
 
 // NonDeterministic implements the FunctionInterface interface.
 func (f Function3) NonDeterministic() bool { return f.IsNonDeterministic }
+
+// IsCVariadic implements the FunctionInterface interface.
+func (f Function3) IsCVariadic() bool { return false }
 
 // IsStrict implements the FunctionInterface interface.
 func (f Function3) IsStrict() bool { return f.Strict }
@@ -342,6 +461,9 @@ func (f Function4) GetExpectedParameterCount() int { return 4 }
 // NonDeterministic implements the FunctionInterface interface.
 func (f Function4) NonDeterministic() bool { return f.IsNonDeterministic }
 
+// IsCVariadic implements the FunctionInterface interface.
+func (f Function4) IsCVariadic() bool { return false }
+
 // IsStrict implements the FunctionInterface interface.
 func (f Function4) IsStrict() bool { return f.Strict }
 
@@ -379,6 +501,9 @@ func (f Function5) GetExpectedParameterCount() int { return 5 }
 
 // NonDeterministic implements the FunctionInterface interface.
 func (f Function5) NonDeterministic() bool { return f.IsNonDeterministic }
+
+// IsCVariadic implements the FunctionInterface interface.
+func (f Function5) IsCVariadic() bool { return false }
 
 // IsStrict implements the FunctionInterface interface.
 func (f Function5) IsStrict() bool { return f.Strict }
@@ -418,6 +543,9 @@ func (f Function6) GetExpectedParameterCount() int { return 6 }
 // NonDeterministic implements the FunctionInterface interface.
 func (f Function6) NonDeterministic() bool { return f.IsNonDeterministic }
 
+// IsCVariadic implements the FunctionInterface interface.
+func (f Function6) IsCVariadic() bool { return false }
+
 // IsStrict implements the FunctionInterface interface.
 func (f Function6) IsStrict() bool { return f.Strict }
 
@@ -455,6 +583,9 @@ func (f Function7) GetExpectedParameterCount() int { return 7 }
 
 // NonDeterministic implements the FunctionInterface interface.
 func (f Function7) NonDeterministic() bool { return f.IsNonDeterministic }
+
+// IsCVariadic implements the FunctionInterface interface.
+func (f Function7) IsCVariadic() bool { return false }
 
 // IsStrict implements the FunctionInterface interface.
 func (f Function7) IsStrict() bool { return f.Strict }

--- a/server/functions/framework/interpreted_function.go
+++ b/server/functions/framework/interpreted_function.go
@@ -99,6 +99,11 @@ func (iFunc InterpretedFunction) NonDeterministic() bool {
 	return iFunc.IsNonDeterministic
 }
 
+// IsCVariadic implements the FunctionInterface interface.
+func (iFunc InterpretedFunction) IsCVariadic() bool {
+	return false
+}
+
 // VariadicIndex implements the interface FunctionInterface.
 func (iFunc InterpretedFunction) VariadicIndex() int {
 	// TODO: implement variadic

--- a/server/functions/framework/overloads.go
+++ b/server/functions/framework/overloads.go
@@ -76,7 +76,24 @@ func (o *Overloads) overloadsForParams(numParams int) []Overload {
 	for _, overload := range o.AllOverloads {
 		params := overload.GetParameters()
 		variadicIndex := overload.VariadicIndex()
-		if variadicIndex >= 0 && len(params) <= numParams {
+		if overload.IsCVariadic() {
+			if len(params) <= numParams {
+				paramTypes := make([]*pgtypes.DoltgresType, numParams)
+				argTypes := make([]*pgtypes.DoltgresType, numParams)
+				copy(paramTypes, params)
+				copy(argTypes, params)
+				for i := len(params); i < numParams; i++ {
+					paramTypes[i] = pgtypes.Any
+					argTypes[i] = pgtypes.Any
+				}
+				results = append(results, Overload{
+					function:   overload,
+					paramTypes: paramTypes,
+					argTypes:   argTypes,
+					variadic:   -1,
+				})
+			}
+		} else if variadicIndex >= 0 && len(params) <= numParams {
 			// Variadic functions may only match when the function is declared with parameters that are fewer or equal
 			// to our target length. If our target length is less, then we cannot expand, so we do not treat it as
 			// variadic.

--- a/server/functions/framework/sql_function.go
+++ b/server/functions/framework/sql_function.go
@@ -78,6 +78,11 @@ func (sqlFunc SQLFunction) NonDeterministic() bool {
 	return sqlFunc.IsNonDeterministic
 }
 
+// IsCVariadic implements the FunctionInterface interface.
+func (sqlFunc SQLFunction) IsCVariadic() bool {
+	return false
+}
+
 // VariadicIndex implements the interface FunctionInterface.
 func (sqlFunc SQLFunction) VariadicIndex() int {
 	// TODO: implement variadic

--- a/server/functions/init.go
+++ b/server/functions/init.go
@@ -96,6 +96,7 @@ func Init() {
 	initCharLength()
 	initChr()
 	initColDescription()
+	initConcat()
 	initCos()
 	initCosd()
 	initCosh()

--- a/server/types/json_document.go
+++ b/server/types/json_document.go
@@ -15,7 +15,7 @@
 package types
 
 import (
-	"bytes"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -25,6 +25,10 @@ import (
 
 	"github.com/dolthub/doltgresql/utils"
 )
+
+// jsonDocumentStringUnicodeRegex is used on a JsonDocument's string to find all Unicode escape sequences that have an
+// additional backslash.
+var jsonDocumentStringUnicodeRegex = regexp.MustCompile(`\\\\u([0-9A-Fa-f]{4})`)
 
 // JsonValueType represents a JSON value type. These values are serialized, and therefore should never be modified.
 type JsonValueType byte
@@ -340,11 +344,6 @@ func JsonValueFormatter(sb *strings.Builder, value JsonValue) {
 
 // UnmarshalToJsonDocument converts a JSON document byte slice into the actual JSON document.
 func UnmarshalToJsonDocument(val []byte) (JsonDocument, error) {
-	// The JSON unmarshaller incorrectly replaces the two ASCII characters for a newline (92 & 110) with a single ASCII
-	// newline character (10). We also handle \t and \r.
-	val = bytes.ReplaceAll(val, []byte{'\\', 'n'}, []byte{'\\', '\\', 'n'})
-	val = bytes.ReplaceAll(val, []byte{'\\', 'r'}, []byte{'\\', '\\', 'r'})
-	val = bytes.ReplaceAll(val, []byte{'\\', 't'}, []byte{'\\', '\\', 't'})
 	var decoded interface{}
 	if err := json.Unmarshal(val, &decoded); err != nil {
 		return JsonDocument{}, err
@@ -396,6 +395,15 @@ func ConvertToJsonDocument(val interface{}) (JsonValue, error) {
 		}
 		return values, nil
 	case string:
+		// JSON parsing will convert some escaped whitespace characters to their actual characters, which is incorrect.
+		// We must retain their escaped form to be considered valid JSON.
+		val = strings.ReplaceAll(val, "\\", `\\`)
+		val = strings.ReplaceAll(val, "\n", `\n`)
+		val = strings.ReplaceAll(val, "\t", `\t`)
+		val = strings.ReplaceAll(val, "\r", `\r`)
+		// We specifically don't want Unicode escape sequences to be replaced, so we revert those.
+		// This is safe as we double backslashes before this step, so this will return it to its original input.
+		val = jsonDocumentStringUnicodeRegex.ReplaceAllString(val, `\u$1`)
 		return JsonValueString(val), nil
 	case float64:
 		// TODO: handle this as a proper numeric as float64 is not precise enough

--- a/server/types/type.go
+++ b/server/types/type.go
@@ -660,6 +660,9 @@ func (t *DoltgresType) IsResolvedType() bool {
 // IsValidForPolymorphicType returns whether the given type is valid for the calling polymorphic type.
 func (t *DoltgresType) IsValidForPolymorphicType(target *DoltgresType) bool {
 	switch t.ID.TypeName() {
+	case "any":
+		// "any" is not a polymorphic type like the others are, but it's useful to treat it as such for this check
+		return true
 	case "anyelement":
 		return true
 	case "anyarray":

--- a/testing/go/expressions_test.go
+++ b/testing/go/expressions_test.go
@@ -92,11 +92,11 @@ func TestIn(t *testing.T) {
 				},
 				{
 					Query:    `SELECT concat('a', NULL) in ('a', 'b', 'ab');`,
-					Expected: []sql.Row{{nil}},
+					Expected: []sql.Row{{"t"}},
 				},
 				{
 					Query:    `SELECT concat('a', NULL) in ('a', NULL);`,
-					Expected: []sql.Row{{nil}},
+					Expected: []sql.Row{{"t"}},
 				},
 			},
 		},

--- a/testing/go/framework.go
+++ b/testing/go/framework.go
@@ -464,7 +464,7 @@ func CreateServerLocalWithPort(t *testing.T, database string, port int) (context
 // newTestDatabaseConnection returns a Connection to the test |database| at |host|:|port|. If the |database| provided
 // does not exist, it will be automatically created.
 func newTestDatabaseConnection(t *testing.T, ctx context.Context, database, host string, port int) *Connection {
-	const connectionUrlFmt = "postgres://postgres:password@%s:%d/%s"
+	const connectionUrlFmt = "postgres://postgres:password@%s:%d/%s?DateStyle=ISO%%2C%%20MDY"
 	func() {
 		var conn *pgx.Conn
 		var err error

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -3428,6 +3428,35 @@ func TestStringFunction(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "concat",
+			Assertions: []ScriptTestAssertion{
+				{ // https://github.com/dolthub/doltgresql/issues/2547
+					Query:    `SELECT LENGTH(CONCAT('', NULL, ''));`,
+					Expected: []sql.Row{{0}},
+				},
+				{
+					Query:    `SELECT CONCAT('a', NULL, 'b');`,
+					Expected: []sql.Row{{"ab"}},
+				},
+				{
+					Query:    `SELECT CONCAT(1, 2, true);`,
+					Expected: []sql.Row{{"12t"}},
+				},
+				{
+					Query:    `SELECT CONCAT(1::int2, 2::int4, true::bool, false::text);`,
+					Expected: []sql.Row{{"12tfalse"}},
+				},
+				{
+					Query:    `SELECT CONCAT('b');`,
+					Expected: []sql.Row{{"b"}},
+				},
+				{
+					Query:    `SELECT CONCAT(NULL);`,
+					Expected: []sql.Row{{""}},
+				},
+			},
+		},
 	})
 }
 

--- a/testing/go/issues_test.go
+++ b/testing/go/issues_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/jackc/pgx/v5/pgproto3"
 
 	"github.com/dolthub/doltgresql/core/id"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
@@ -432,6 +433,192 @@ limit 1`,
 				{
 					Query:    `SELECT (SELECT v1 FROM test WHERE pk = 2) - (SELECT v1 FROM test WHERE pk = 1);`,
 					Expected: []sql.Row{{"-02:00:00"}},
+				},
+			},
+		},
+	})
+}
+
+func TestIssuesWire(t *testing.T) {
+	RunWireScripts(t, []WireScriptTest{
+		{
+			Name: "Issue #2546",
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Query{String: "SELECT 'foo';"},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{
+									Name:                 []byte("?column?"),
+									TableOID:             0,
+									TableAttributeNumber: 0,
+									DataTypeOID:          25,
+									DataTypeSize:         -1,
+									TypeModifier:         -1,
+									Format:               0,
+								},
+							},
+						},
+						&pgproto3.DataRow{Values: [][]byte{[]byte("foo")}},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "Issue #2557",
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name1",
+							Query: `SELECT '{"v":"a\\nb"}'::jsonb;`,
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							PreparedStatement: "stmt_name1",
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(`{"v": "a\\nb"}`),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name2",
+							Query: `SELECT $${"v":"a\\nb"}$$::jsonb;`,
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							PreparedStatement: "stmt_name2",
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(`{"v": "a\\nb"}`),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name3",
+							Query: `SELECT $${"v":"a\\\nb"}$$::jsonb;`,
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							PreparedStatement: "stmt_name3",
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(`{"v": "a\\\nb"}`),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{
+							Name:  "stmt_name4",
+							Query: `select json '{ "a":  "dollar \\u0024 character" }' ->> 'a' as not_an_escape;`,
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Bind{
+							PreparedStatement: "stmt_name4",
+							ResultFormatCodes: []int16{0},
+						},
+						&pgproto3.Execute{},
+						&pgproto3.Close{
+							ObjectType: 'P',
+						},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.BindComplete{},
+						&pgproto3.DataRow{
+							Values: [][]byte{
+								[]byte(`dollar \u0024 character`),
+							},
+						},
+						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.CloseComplete{},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
 				},
 			},
 		},

--- a/testing/go/wire_test.go
+++ b/testing/go/wire_test.go
@@ -5186,34 +5186,6 @@ func TestWireTypesSending(t *testing.T) {
 				},
 			},
 		},
-		{ // https://github.com/dolthub/doltgresql/issues/2546
-			Name: "Issue #2546",
-			Assertions: []WireScriptTestAssertion{
-				{
-					Send: []pgproto3.FrontendMessage{
-						&pgproto3.Query{String: "SELECT 'foo';"},
-					},
-					Receive: []pgproto3.BackendMessage{
-						&pgproto3.RowDescription{
-							Fields: []pgproto3.FieldDescription{
-								{
-									Name:                 []byte("?column?"),
-									TableOID:             0,
-									TableAttributeNumber: 0,
-									DataTypeOID:          25,
-									DataTypeSize:         -1,
-									TypeModifier:         -1,
-									Format:               0,
-								},
-							},
-						},
-						&pgproto3.DataRow{Values: [][]byte{[]byte("foo")}},
-						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
-						&pgproto3.ReadyForQuery{TxStatus: 'I'},
-					},
-				},
-			},
-		},
 	})
 }
 


### PR DESCRIPTION
This fixes:
* https://github.com/dolthub/doltgresql/issues/2547
* https://github.com/dolthub/doltgresql/issues/2557

This introduces a new function type which mirrors the C-language variadic function implementation. These functions differ from standard PostgreSQL variadic functions, as normally variadic functions require that all variadic parameters have the same type. This limitation is not true for C-language functions. This was required to implement a valid `concat` function, as we were previously relying on GMS' built-in version, which is not correct for Postgres. I also corrected some tests that enforced the incorrect behavior.

This also fixes a bug in JSON parsing. It was already known that Go's JSON library converts escaped characters into their original forms, however we were attempting to preemptively handle the incorrect conversion. This has been changed, as we can cleanup the output since the unescaped forms are invalid JSON anyway, which fixes the behavior and makes our output more accurate.