### PR TITLE
Support using same parameter multiple times

### DIFF
--- a/server/connection_data.go
+++ b/server/connection_data.go
@@ -30,6 +30,7 @@ import (
 	"github.com/dolthub/doltgresql/core/dataloader"
 	"github.com/dolthub/doltgresql/core/id"
 	pgexprs "github.com/dolthub/doltgresql/server/expression"
+	"github.com/dolthub/doltgresql/server/functions/framework"
 	"github.com/dolthub/doltgresql/server/node"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
@@ -147,9 +148,8 @@ func extractBindVarTypes(queryPlan sql.Node) ([]uint32, error) {
 					return false
 				}
 			}
-			if _, ok := types[e.Name]; ok {
-				// sanity check
-				err = errors.Errorf("double placeholder given for %s", e.Name)
+			if existingOid, ok := types[e.Name]; ok {
+				err = checkCompatibleTypes(existingOid, typOid, e.Name)
 			}
 			types[e.Name] = typOid
 		case *pgexprs.ExplicitCast:
@@ -164,9 +164,8 @@ func extractBindVarTypes(queryPlan sql.Node) ([]uint32, error) {
 						return false
 					}
 				}
-				if _, ok = types[bindVar.Name]; ok {
-					// sanity check
-					err = errors.Errorf("double placeholder given for %s", bindVar.Name)
+				if existingOid, ok := types[bindVar.Name]; ok {
+					err = checkCompatibleTypes(existingOid, typOid, bindVar.Name)
 				}
 				types[bindVar.Name] = typOid
 				return false
@@ -180,9 +179,8 @@ func extractBindVarTypes(queryPlan sql.Node) ([]uint32, error) {
 					err = errors.Errorf("could not determine OID for placeholder %s: %e", bindVar.Name, err)
 					return false
 				}
-				if _, ok = types[bindVar.Name]; ok {
-					// sanity check
-					err = errors.Errorf("double placeholder given for %s", bindVar.Name)
+				if existingOid, ok := types[bindVar.Name]; ok {
+					err = checkCompatibleTypes(existingOid, typOid, bindVar.Name)
 				}
 				types[bindVar.Name] = typOid
 				return false
@@ -224,4 +222,15 @@ func VitessTypeToObjectID(typ sql.Type) (uint32, error) {
 		return 0, err
 	}
 	return id.Cache().ToOID(doltgresType.ID.AsId()), nil
+}
+
+// checkCompatibleTypes checks if multiple types for which a parameter are used are compatible.
+func checkCompatibleTypes(existingOid, newOid uint32, newName string) error {
+	var err error
+	existing := pgtypes.GetTypeByID(id.Type(id.Cache().ToInternal(existingOid)))
+	newType := pgtypes.GetTypeByID(id.Type(id.Cache().ToInternal(newOid)))
+	if _, _, err = framework.FindCommonType([]*pgtypes.DoltgresType{existing, newType}); err != nil {
+		err = errors.Errorf("double placeholder given for %s", newName)
+	}
+	return err
 }

--- a/server/connection_data.go
+++ b/server/connection_data.go
@@ -230,7 +230,7 @@ func checkCompatibleTypes(existingOid, newOid uint32, newName string) error {
 	existing := pgtypes.GetTypeByID(id.Type(id.Cache().ToInternal(existingOid)))
 	newType := pgtypes.GetTypeByID(id.Type(id.Cache().ToInternal(newOid)))
 	if _, _, err = framework.FindCommonType([]*pgtypes.DoltgresType{existing, newType}); err != nil {
-		err = errors.Errorf("double placeholder given for %s", newName)
+		err = errors.Errorf("parameter %s is used for incompatible types: %s and %s", newName, existing.String(), newType.String())
 	}
 	return err
 }

--- a/testing/go/prepared_statement_test.go
+++ b/testing/go/prepared_statement_test.go
@@ -1343,12 +1343,7 @@ var preparedStatementTests = []ScriptTest{
 			{
 				Query:       "SELECT * FROM text_test where fullname = $1 and id = $1",
 				BindVars:    []any{1},
-				ExpectedErr: "double placeholder given for v1",
-			},
-			{
-				Query:       "SELECT * FROM text_test where fullname = $1 and id = $1",
-				BindVars:    []any{"foo"},
-				ExpectedErr: "double placeholder given for v1",
+				ExpectedErr: "parameter v1 is used for incompatible types: text and integer",
 			},
 		},
 	},

--- a/testing/go/prepared_statement_test.go
+++ b/testing/go/prepared_statement_test.go
@@ -1294,6 +1294,64 @@ var preparedStatementTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "Bind parameter to compatible different types",
+		SetUpScript: []string{
+			"CREATE TABLE text_test (id text, code varchar(10))",
+			"CREATE TABLE num_test(small int2, large int8, other float4)",
+			"INSERT INTO text_test values ('foo', 'bar'), ('bar', 'foo')",
+			"INSERT INTO num_test values (0,0,0), (1, 2, 1.5)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT * FROM text_test where id = any($1) and code = any($1)",
+				BindVars: []any{[]string{"foo", "bar"}},
+				Expected: []sql.Row{
+					{"foo", "bar"},
+					{"bar", "foo"},
+				},
+			},
+			{
+				Query:    "SELECT * from num_test where small = $1 and large = $1 and other = $1",
+				BindVars: []any{0},
+				Expected: []sql.Row{
+					{0, 0, float64(0)},
+				},
+			},
+			{
+				Query:    "SELECT * from num_test where small = $1::INTEGER and large = $1::INTEGER and other = $1::INTEGER",
+				BindVars: []any{0},
+				Expected: []sql.Row{
+					{0, 0, float64(0)},
+				},
+			},
+			{
+				Query:    "SELECT * FROM num_test where small = $1 or other = $1",
+				BindVars: []any{1.5},
+				Expected: []sql.Row{
+					{1, 2, 1.5},
+				},
+			},
+		},
+	},
+	{
+		Name: "Cannot bind parameter to column with incompatible type",
+		SetUpScript: []string{
+			"CREATE TABLE text_test (fullname text, id int)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "SELECT * FROM text_test where fullname = $1 and id = $1",
+				BindVars:    []any{1},
+				ExpectedErr: "double placeholder given for v1",
+			},
+			{
+				Query:       "SELECT * FROM text_test where fullname = $1 and id = $1",
+				BindVars:    []any{"foo"},
+				ExpectedErr: "double placeholder given for v1",
+			},
+		},
+	},
 }
 
 var pgCatalogTests = []ScriptTest{


### PR DESCRIPTION
Right now we always don't allow a query to use the same parameter in multiple locations. 

Technically that should always be allowed and then we'll fail later down the line if you're trying to bind a parameter and compare it to something with an incompatible type.

But the error messages we have if I just completely remove the check are a little ugly, so I added some code to our function that handles the types of parameters by breaking if you try to use a parameter as multiple incompatible types within the same query.

So for instance the query: select * from table where column_int = $1 and column_float4 = $1 should be fine because integer/int4 is compatible with float4.
But the query: select * from table where column_text = $1 and column_int = $1 will error because text and integer/int4 are not compatible.
