### PR TITLE
pg_type index implementation

### DIFF
--- a/server/tables/pgcatalog/pg_catalog_cache.go
+++ b/server/tables/pgcatalog/pg_catalog_cache.go
@@ -24,7 +24,6 @@ import (
 	"github.com/dolthub/doltgresql/core/id"
 	"github.com/dolthub/doltgresql/core/sequences"
 	"github.com/dolthub/doltgresql/server/functions"
-	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
 // pgNamespace represents a row in the pg_namespace table.
@@ -47,6 +46,9 @@ type pgCatalogCache struct {
 
 	// pg_classes
 	pgClasses *pgClassCache
+
+	// pg_type
+	pgTypes *pgTypeCache
 
 	// pg_constraints
 	pgConstraints *pgConstraintCache
@@ -71,10 +73,6 @@ type pgCatalogCache struct {
 	// pg_views
 	views       []sql.ViewDefinition
 	viewSchemas []string
-
-	// pg_types
-	types        []*pgtypes.DoltgresType
-	schemasToOid map[string]id.Namespace
 
 	// pg_tables
 	tables       []sql.Table
@@ -102,6 +100,25 @@ func (p pgClassCache) getIndex(name string) *inMemIndexStorage[*pgClass] {
 }
 
 var _ BTreeStorageAccess[*pgClass] = &pgClassCache{}
+
+type pgTypeCache struct {
+	types   []*pgType
+	nameIdx *inMemIndexStorage[*pgType]
+	oidIdx  *inMemIndexStorage[*pgType]
+}
+
+func (p pgTypeCache) getIndex(name string) *inMemIndexStorage[*pgType] {
+	switch name {
+	case PgOidIndexName:
+		return p.oidIdx
+	case PgTypnameIndexName:
+		return p.nameIdx
+	default:
+		panic("unknown pg_class index: " + name)
+	}
+}
+
+var _ BTreeStorageAccess[*pgType] = &pgTypeCache{}
 
 // pgIndexCache holds cached data for the pg_index table, including two btree indexes for fast lookups by index OID
 type pgIndexCache struct {

--- a/server/tables/pgcatalog/pg_catalog_cache.go
+++ b/server/tables/pgcatalog/pg_catalog_cache.go
@@ -101,20 +101,23 @@ func (p pgClassCache) getIndex(name string) *inMemIndexStorage[*pgClass] {
 
 var _ BTreeStorageAccess[*pgClass] = &pgClassCache{}
 
+// pgTypeCache holds cached data for the pg_type table, including two btree indexes for fast lookups by OID and
+// by typname
 type pgTypeCache struct {
 	types   []*pgType
 	nameIdx *inMemIndexStorage[*pgType]
 	oidIdx  *inMemIndexStorage[*pgType]
 }
 
+// getIndex implements BTreeStorageAccess.
 func (p pgTypeCache) getIndex(name string) *inMemIndexStorage[*pgType] {
 	switch name {
-	case PgOidIndexName:
+	case PgTypeOidIndex:
 		return p.oidIdx
-	case PgTypnameIndexName:
+	case PgTypnameIndex:
 		return p.nameIdx
 	default:
-		panic("unknown pg_class index: " + name)
+		panic("unknown pg_type index: " + name)
 	}
 }
 

--- a/server/tables/pgcatalog/pg_catalog_cache.go
+++ b/server/tables/pgcatalog/pg_catalog_cache.go
@@ -112,9 +112,9 @@ type pgTypeCache struct {
 // getIndex implements BTreeStorageAccess.
 func (p pgTypeCache) getIndex(name string) *inMemIndexStorage[*pgType] {
 	switch name {
-	case PgTypeOidIndex:
+	case pgTypeOidIndex:
 		return p.oidIdx
-	case PgTypnameIndex:
+	case pgTypnameIndex:
 		return p.nameIdx
 	default:
 		panic("unknown pg_type index: " + name)

--- a/server/tables/pgcatalog/pg_type.go
+++ b/server/tables/pgcatalog/pg_type.go
@@ -16,23 +16,23 @@ package pgcatalog
 
 import (
 	"fmt"
-	"github.com/dolthub/doltgresql/core"
-	"github.com/dolthub/doltgresql/server/functions"
 	"io"
 	"math"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
+	"github.com/dolthub/doltgresql/core"
 	"github.com/dolthub/doltgresql/core/id"
+	"github.com/dolthub/doltgresql/server/functions"
 	"github.com/dolthub/doltgresql/server/tables"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
 // PgTypeName is a constant to the pg_type name.
 const (
-	PgTypeName         = "pg_type"
-	PgOidIndexName     = "pg_type_oid_index"
-	PgTypnameIndexName = "pg_type_typname_nsp_index"
+	PgTypeName     = "pg_type"
+	PgTypeOidIndex = "pg_type_oid_index"
+	PgTypnameIndex = "pg_type_typname_nsp_index"
 )
 
 // InitPgType handles registration of the pg_type handler.
@@ -144,7 +144,7 @@ func (p PgTypeHandler) getIndexScanRange(rng sql.Range, index sql.Index) (*pgTyp
 	var hasLowerBound, hasUpperBound bool
 
 	switch index.(pgCatalogInMemIndex).name {
-	case PgOidIndexName:
+	case PgTypeOidIndex:
 		msrng := rng.(sql.MySQLRange)
 		oidRng := msrng[0]
 		if oidRng.HasLowerBound() {
@@ -169,7 +169,7 @@ func (p PgTypeHandler) getIndexScanRange(rng sql.Range, index sql.Index) (*pgTyp
 			}
 		}
 
-	case PgTypnameIndexName:
+	case PgTypnameIndex:
 		msrng := rng.(sql.MySQLRange)
 		typNameRange := msrng[0]
 		schemaOidRange := msrng[1]
@@ -247,14 +247,14 @@ func (p PgTypeHandler) PkSchema() sql.PrimaryKeySchema {
 func (p PgTypeHandler) Indexes() ([]sql.Index, error) {
 	return []sql.Index{
 		pgCatalogInMemIndex{
-			name:        PgOidIndexName,
+			name:        PgTypeOidIndex,
 			tblName:     "pg_type",
 			dbName:      "pg_catalog",
 			uniq:        true,
 			columnExprs: []sql.ColumnExpressionType{{Expression: "pg_type.oid", Type: pgtypes.Oid}},
 		},
 		pgCatalogInMemIndex{
-			name:    PgTypnameIndexName,
+			name:    PgTypnameIndex,
 			tblName: "pg_type",
 			dbName:  "pg_catalog",
 			uniq:    true,

--- a/server/tables/pgcatalog/pg_type.go
+++ b/server/tables/pgcatalog/pg_type.go
@@ -15,19 +15,25 @@
 package pgcatalog
 
 import (
+	"fmt"
+	"github.com/dolthub/doltgresql/core"
+	"github.com/dolthub/doltgresql/server/functions"
 	"io"
+	"math"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
-	"github.com/dolthub/doltgresql/core"
 	"github.com/dolthub/doltgresql/core/id"
-	"github.com/dolthub/doltgresql/server/functions"
 	"github.com/dolthub/doltgresql/server/tables"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
 // PgTypeName is a constant to the pg_type name.
-const PgTypeName = "pg_type"
+const (
+	PgTypeName         = "pg_type"
+	PgOidIndexName     = "pg_type_oid_index"
+	PgTypnameIndexName = "pg_type_typname_nsp_index"
+)
 
 // InitPgType handles registration of the pg_type handler.
 func InitPgType() {
@@ -38,6 +44,7 @@ func InitPgType() {
 type PgTypeHandler struct{}
 
 var _ tables.Handler = PgTypeHandler{}
+var _ tables.IndexedTableHandler = PgTypeHandler{}
 
 // Name implements the interface tables.Handler.
 func (p PgTypeHandler) Name() string {
@@ -52,48 +59,180 @@ func (p PgTypeHandler) RowIter(ctx *sql.Context, partition sql.Partition) (sql.R
 		return nil, err
 	}
 
+	if pgCatalogCache.pgTypes == nil {
+		err = cachePgTypes(ctx, pgCatalogCache)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if typeIdxPart, ok := partition.(inMemIndexPartition); ok {
+		return &inMemIndexScanIter[*pgType]{
+			lookup:         typeIdxPart.lookup,
+			rangeConverter: p,
+			btreeAccess:    pgCatalogCache.pgTypes,
+			rowConverter:   pgTypeToRow,
+		}, nil
+	}
+
+	return &pgTypeTableScanIter{
+		typeCache: pgCatalogCache.pgTypes,
+		idx:       0,
+	}, nil
+}
+
+func cachePgTypes(ctx *sql.Context, pgCatalogCache *pgCatalogCache) error {
+	var types []*pgType
+	nameIdx := NewUniqueInMemIndexStorage[*pgType](lessTypeName)
+	oidIdx := NewUniqueInMemIndexStorage[*pgType](lessTypeOid)
+
 	schemasToOid := make(map[string]id.Namespace)
-	if pgCatalogCache.types == nil {
-		err := functions.IterateCurrentDatabase(ctx, functions.Callbacks{
-			Schema: func(ctx *sql.Context, schema functions.ItemSchema) (cont bool, err error) {
-				schemasToOid[schema.Item.SchemaName()] = schema.OID
-				return true, nil
-			},
-		})
-		if err != nil {
-			return nil, err
+	err := functions.IterateCurrentDatabase(ctx, functions.Callbacks{
+		Schema: func(ctx *sql.Context, schema functions.ItemSchema) (cont bool, err error) {
+			schemasToOid[schema.Item.SchemaName()] = schema.OID
+			return true, nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	allTypes := pgtypes.GetAllBuitInTypes()
+	typeColl, err := core.GetTypesCollectionFromContext(ctx)
+	if err != nil {
+		return err
+	}
+	userTypes, schemas, cnt, err := typeColl.GetAllTypes(ctx)
+	if err != nil {
+		return err
+	}
+	if cnt > 0 {
+		for _, schema := range schemas {
+			if schema != PgCatalogName {
+				allTypes = append(allTypes, userTypes[schema]...)
+			}
 		}
+	}
 
-		allTypes := pgtypes.GetAllBuitInTypes()
-
-		// TODO: why are we serializing pg_catalog types in the user type collection
-		typeColl, err := core.GetTypesCollectionFromContext(ctx)
-		if err != nil {
-			return nil, err
+	for _, typ := range allTypes {
+		schemaOid := schemasToOid[typ.ID.SchemaName()]
+		t := &pgType{
+			oid:             typ.ID.AsId(),
+			oidNative:       id.Cache().ToOID(typ.ID.AsId()),
+			name:            typ.Name(),
+			schemaOid:       schemaOid.AsId(),
+			schemaOidNative: id.Cache().ToOID(schemaOid.AsId()),
+			typ:             typ,
 		}
+		oidIdx.Add(t)
+		nameIdx.Add(t)
+		types = append(types, t)
+	}
 
-		userTypes, schemas, cnt, err := typeColl.GetAllTypes(ctx)
-		if err != nil {
-			return nil, err
-		}
+	pgCatalogCache.pgTypes = &pgTypeCache{
+		types:   types,
+		nameIdx: nameIdx,
+		oidIdx:  oidIdx,
+	}
 
-		if cnt > 0 {
-			for _, schema := range schemas {
-				if schema != PgCatalogName {
-					allTypes = append(allTypes, userTypes[schema]...)
+	return nil
+}
+
+// getIndexScanRange implements the interface RangeConverter.
+func (p PgTypeHandler) getIndexScanRange(rng sql.Range, index sql.Index) (*pgType, bool, *pgType, bool) {
+	var gte, lt *pgType
+	var hasLowerBound, hasUpperBound bool
+
+	switch index.(pgCatalogInMemIndex).name {
+	case PgOidIndexName:
+		msrng := rng.(sql.MySQLRange)
+		oidRng := msrng[0]
+		if oidRng.HasLowerBound() {
+			lb := sql.GetMySQLRangeCutKey(oidRng.LowerBound)
+			if lb != nil {
+				lowerRangeCutKey := lb.(id.Id)
+				gte = &pgType{
+					oidNative: idToOid(lowerRangeCutKey),
 				}
+				hasLowerBound = true
 			}
 		}
 
-		pgCatalogCache.types = allTypes
-		pgCatalogCache.schemasToOid = schemasToOid
+		if oidRng.HasUpperBound() {
+			ub := sql.GetMySQLRangeCutKey(oidRng.UpperBound)
+			if ub != nil {
+				upperRangeCutKey := ub.(id.Id)
+				lt = &pgType{
+					oidNative: idToOid(upperRangeCutKey) + 1,
+				}
+				hasUpperBound = true
+			}
+		}
+
+	case PgTypnameIndexName:
+		msrng := rng.(sql.MySQLRange)
+		typNameRange := msrng[0]
+		schemaOidRange := msrng[1]
+		var typnameLower, typnameUpper string
+		schemaOidLower := uint32(0)
+		schemaOidUpper := uint32(math.MaxUint32)
+		schemaOidUpperSet := false
+
+		if typNameRange.HasLowerBound() {
+			lb := sql.GetMySQLRangeCutKey(typNameRange.LowerBound)
+			if lb != nil {
+				typnameLower = lb.(string)
+				hasLowerBound = true
+			}
+		}
+		if typNameRange.HasUpperBound() {
+			ub := sql.GetMySQLRangeCutKey(typNameRange.UpperBound)
+			if ub != nil {
+				typnameUpper = ub.(string)
+				hasUpperBound = true
+			}
+		}
+
+		if schemaOidRange.HasLowerBound() {
+			lb := sql.GetMySQLRangeCutKey(schemaOidRange.LowerBound)
+			if lb != nil {
+				lowerRangeCutKey := lb.(id.Id)
+				schemaOidLower = idToOid(lowerRangeCutKey)
+			}
+		}
+		if schemaOidRange.HasUpperBound() {
+			ub := sql.GetMySQLRangeCutKey(schemaOidRange.UpperBound)
+			if ub != nil {
+				upperRangeCutKey := ub.(id.Id)
+				schemaOidUpper = idToOid(upperRangeCutKey)
+				schemaOidUpperSet = true
+			}
+		}
+
+		if typNameRange.HasLowerBound() || schemaOidRange.HasLowerBound() {
+			gte = &pgType{
+				name:            typnameLower,
+				schemaOidNative: schemaOidLower,
+			}
+		}
+
+		if typNameRange.HasUpperBound() || schemaOidRange.HasUpperBound() {
+			// our less-than upper bound depends on whether we have a prefix match or both fields were set
+			if !schemaOidUpperSet {
+				typnameUpper = fmt.Sprintf("%s%o", typnameUpper, rune(0))
+			} else {
+				schemaOidUpper = schemaOidUpper + 1
+			}
+			lt = &pgType{
+				name:            typnameUpper,
+				schemaOidNative: schemaOidUpper,
+			}
+		}
+	default:
+		panic("unknown index name: " + index.(pgCatalogInMemIndex).name)
 	}
 
-	return &pgTypeRowIter{
-		types:   pgCatalogCache.types,
-		schemas: pgCatalogCache.schemasToOid,
-		idx:     0,
-	}, nil
+	return gte, hasLowerBound, lt, hasUpperBound
 }
 
 // Schema implements the interface tables.Handler.
@@ -102,6 +241,39 @@ func (p PgTypeHandler) PkSchema() sql.PrimaryKeySchema {
 		Schema:     pgTypeSchema,
 		PkOrdinals: nil,
 	}
+}
+
+// Indexes implements tables.IndexedTableHandler.
+func (p PgTypeHandler) Indexes() ([]sql.Index, error) {
+	return []sql.Index{
+		pgCatalogInMemIndex{
+			name:        PgOidIndexName,
+			tblName:     "pg_type",
+			dbName:      "pg_catalog",
+			uniq:        true,
+			columnExprs: []sql.ColumnExpressionType{{Expression: "pg_type.oid", Type: pgtypes.Oid}},
+		},
+		pgCatalogInMemIndex{
+			name:    PgTypnameIndexName,
+			tblName: "pg_type",
+			dbName:  "pg_catalog",
+			uniq:    true,
+			columnExprs: []sql.ColumnExpressionType{
+				{Expression: "pg_type.typname", Type: pgtypes.Name},
+				{Expression: "pg_type.typnamespace", Type: pgtypes.Oid},
+			},
+		},
+	}, nil
+}
+
+// LookupPartitions implements tables.IndexedTableHandler.
+func (p PgTypeHandler) LookupPartitions(_ *sql.Context, lookup sql.IndexLookup) (sql.PartitionIter, error) {
+	return &inMemIndexPartIter{
+		part: inMemIndexPartition{
+			idxName: lookup.Index.(pgCatalogInMemIndex).name,
+			lookup:  lookup,
+		},
+	}, nil
 }
 
 // pgTypeSchema is the schema for pg_type.
@@ -140,62 +312,89 @@ var pgTypeSchema = sql.Schema{
 	{Name: "typacl", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: PgTypeName},   // TODO: type aclitem[]
 }
 
-// pgTypeRowIter is the sql.RowIter for the pg_type table.
-type pgTypeRowIter struct {
-	types   []*pgtypes.DoltgresType
-	idx     int
-	schemas map[string]id.Namespace
+// pgType represents a row in the pg_type table.
+// We store oids in their native format as well so that we can do range scans on them.
+type pgType struct {
+	oid             id.Id
+	oidNative       uint32
+	name            string
+	schemaOid       id.Id
+	schemaOidNative uint32
+	typ             *pgtypes.DoltgresType
 }
 
-var _ sql.RowIter = (*pgTypeRowIter)(nil)
+// lessTypeOid is a sort function for pgType based on oid.
+func lessTypeOid(a, b *pgType) bool {
+	return a.oidNative < b.oidNative
+}
+
+// lessTypeName is a sort function for pgType based on name, then schemaOid.
+func lessTypeName(a, b *pgType) bool {
+	if a.name == b.name {
+		return a.schemaOidNative < b.schemaOidNative
+	}
+	return a.name < b.name
+}
+
+// pgTypeTableScanIter is the sql.RowIter for the pg_type table.
+type pgTypeTableScanIter struct {
+	typeCache *pgTypeCache
+	idx       int
+}
+
+var _ sql.RowIter = (*pgTypeTableScanIter)(nil)
 
 // Next implements the interface sql.RowIter.
-func (iter *pgTypeRowIter) Next(ctx *sql.Context) (sql.Row, error) {
-	if iter.idx >= len(iter.types) {
+func (iter *pgTypeTableScanIter) Next(_ *sql.Context) (sql.Row, error) {
+	if iter.idx >= len(iter.typeCache.types) {
 		return nil, io.EOF
 	}
 	iter.idx++
-	typ := iter.types[iter.idx-1]
-	// TODO: typ.Acl is stored as []string
-	typAcl := []any(nil)
+	nextType := iter.typeCache.types[iter.idx-1]
 
-	return sql.Row{
-		typ.ID.AsId(),                            // oid
-		typ.Name(),                               // typname
-		iter.schemas[typ.ID.SchemaName()].AsId(), // typnamespace
-		id.Null,                                  // typowner
-		typ.TypLength,                            // typlen
-		typ.PassedByVal,                          // typbyval
-		string(typ.TypType),                      // typtype
-		string(typ.TypCategory),                  // typcategory
-		typ.IsPreferred,                          // typispreferred
-		typ.IsDefined,                            // typisdefined
-		typ.Delimiter,                            // typdelim
-		typ.RelID,                                // typrelid
-		typ.SubscriptFuncName(),                  // typsubscript
-		typ.Elem.AsId(),                          // typelem
-		typ.Array.AsId(),                         // typarray
-		typ.InputFuncName(),                      // typinput
-		typ.OutputFuncName(),                     // typoutput
-		typ.ReceiveFuncName(),                    // typreceive
-		typ.SendFuncName(),                       // typsend
-		typ.ModInFuncName(),                      // typmodin
-		typ.ModOutFuncName(),                     // typmodout
-		typ.AnalyzeFuncName(),                    // typanalyze
-		string(typ.Align),                        // typalign
-		string(typ.Storage),                      // typstorage
-		typ.NotNull,                              // typnotnull
-		typ.BaseTypeID.AsId(),                    // typbasetype
-		typ.TypMod,                               // typtypmod
-		typ.NDims,                                // typndims
-		typ.TypCollation.AsId(),                  // typcollation
-		typ.DefaulBin,                            // typdefaultbin
-		typ.Default,                              // typdefault
-		typAcl,                                   // typacl
-	}, nil
+	return pgTypeToRow(nextType), nil
 }
 
 // Close implements the interface sql.RowIter.
-func (iter *pgTypeRowIter) Close(ctx *sql.Context) error {
+func (iter *pgTypeTableScanIter) Close(_ *sql.Context) error {
 	return nil
+}
+
+func pgTypeToRow(nextType *pgType) sql.Row {
+	typAcl := []any(nil)
+
+	return sql.Row{
+		nextType.oid,
+		nextType.name,
+		nextType.schemaOid,
+		id.Null,
+		nextType.typ.TypLength,           // typlen
+		nextType.typ.PassedByVal,         // typbyval
+		string(nextType.typ.TypType),     // typtype
+		string(nextType.typ.TypCategory), // typcategory
+		nextType.typ.IsPreferred,         // typispreferred
+		nextType.typ.IsDefined,           // typisdefined
+		nextType.typ.Delimiter,           // typdelim
+		nextType.typ.RelID,               // typrelid
+		nextType.typ.SubscriptFuncName(), // typsubscript
+		nextType.typ.Elem.AsId(),         // typelem
+		nextType.typ.Array.AsId(),        // typarray
+		nextType.typ.InputFuncName(),     // typinput
+		nextType.typ.OutputFuncName(),    // typoutput
+		nextType.typ.ReceiveFuncName(),   // typreceive
+		nextType.typ.SendFuncName(),      // typsend
+		nextType.typ.ModInFuncName(),     // typmodin
+		nextType.typ.ModOutFuncName(),    // typmodout
+		nextType.typ.AnalyzeFuncName(),   // typanalyze
+		string(nextType.typ.Align),       // typalign
+		string(nextType.typ.Storage),     // typstorage
+		nextType.typ.NotNull,             // typnotnull
+		nextType.typ.BaseTypeID.AsId(),   // typbasetype
+		nextType.typ.TypMod,              // typtypmod
+		nextType.typ.NDims,               // typndims
+		nextType.typ.TypCollation.AsId(), // typcollation
+		nextType.typ.DefaulBin,           // typdefaultbin
+		nextType.typ.Default,             // typdefault
+		typAcl,                           // typacl
+	}
 }

--- a/server/tables/pgcatalog/pg_type.go
+++ b/server/tables/pgcatalog/pg_type.go
@@ -28,16 +28,16 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-// PgTypeName is a constant to the pg_type name.
+// pgTypeName is a constant to the pg_type name.
 const (
-	PgTypeName     = "pg_type"
-	PgTypeOidIndex = "pg_type_oid_index"
-	PgTypnameIndex = "pg_type_typname_nsp_index"
+	pgTypeName     = "pg_type"
+	pgTypeOidIndex = "pg_type_oid_index"
+	pgTypnameIndex = "pg_type_typname_nsp_index"
 )
 
 // InitPgType handles registration of the pg_type handler.
 func InitPgType() {
-	tables.AddHandler(PgCatalogName, PgTypeName, PgTypeHandler{})
+	tables.AddHandler(PgCatalogName, pgTypeName, PgTypeHandler{})
 }
 
 // PgTypeHandler is the handler for the pg_type table.
@@ -48,7 +48,7 @@ var _ tables.IndexedTableHandler = PgTypeHandler{}
 
 // Name implements the interface tables.Handler.
 func (p PgTypeHandler) Name() string {
-	return PgTypeName
+	return pgTypeName
 }
 
 // RowIter implements the interface tables.Handler.
@@ -144,7 +144,7 @@ func (p PgTypeHandler) getIndexScanRange(rng sql.Range, index sql.Index) (*pgTyp
 	var hasLowerBound, hasUpperBound bool
 
 	switch index.(pgCatalogInMemIndex).name {
-	case PgTypeOidIndex:
+	case pgTypeOidIndex:
 		msrng := rng.(sql.MySQLRange)
 		oidRng := msrng[0]
 		if oidRng.HasLowerBound() {
@@ -169,7 +169,7 @@ func (p PgTypeHandler) getIndexScanRange(rng sql.Range, index sql.Index) (*pgTyp
 			}
 		}
 
-	case PgTypnameIndex:
+	case pgTypnameIndex:
 		msrng := rng.(sql.MySQLRange)
 		typNameRange := msrng[0]
 		schemaOidRange := msrng[1]
@@ -247,14 +247,14 @@ func (p PgTypeHandler) PkSchema() sql.PrimaryKeySchema {
 func (p PgTypeHandler) Indexes() ([]sql.Index, error) {
 	return []sql.Index{
 		pgCatalogInMemIndex{
-			name:        PgTypeOidIndex,
+			name:        pgTypeOidIndex,
 			tblName:     "pg_type",
 			dbName:      "pg_catalog",
 			uniq:        true,
 			columnExprs: []sql.ColumnExpressionType{{Expression: "pg_type.oid", Type: pgtypes.Oid}},
 		},
 		pgCatalogInMemIndex{
-			name:    PgTypnameIndex,
+			name:    pgTypnameIndex,
 			tblName: "pg_type",
 			dbName:  "pg_catalog",
 			uniq:    true,
@@ -278,38 +278,38 @@ func (p PgTypeHandler) LookupPartitions(_ *sql.Context, lookup sql.IndexLookup) 
 
 // pgTypeSchema is the schema for pg_type.
 var pgTypeSchema = sql.Schema{
-	{Name: "oid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typname", Type: pgtypes.Name, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typnamespace", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typowner", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typlen", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typbyval", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typtype", Type: pgtypes.InternalChar, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typcategory", Type: pgtypes.InternalChar, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typispreferred", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typisdefined", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typdelim", Type: pgtypes.InternalChar, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typrelid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typsubscript", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgTypeName}, // TODO: type regproc
-	{Name: "typelem", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typarray", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typinput", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgTypeName},   // TODO: type regproc
-	{Name: "typoutput", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgTypeName},  // TODO: type regproc
-	{Name: "typreceive", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgTypeName}, // TODO: type regproc
-	{Name: "typsend", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgTypeName},    // TODO: type regproc
-	{Name: "typmodin", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgTypeName},   // TODO: type regproc
-	{Name: "typmodout", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgTypeName},  // TODO: type regproc
-	{Name: "typanalyze", Type: pgtypes.Text, Default: nil, Nullable: false, Source: PgTypeName}, // TODO: type regproc
-	{Name: "typalign", Type: pgtypes.InternalChar, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typstorage", Type: pgtypes.InternalChar, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typnotnull", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typbasetype", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typtypmod", Type: pgtypes.Int32, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typndims", Type: pgtypes.Int32, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typcollation", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: PgTypeName},
-	{Name: "typdefaultbin", Type: pgtypes.Text, Default: nil, Nullable: true, Source: PgTypeName}, // TODO: type pg_node_tree, collation C
-	{Name: "typdefault", Type: pgtypes.Text, Default: nil, Nullable: true, Source: PgTypeName},    // TODO: collation C
-	{Name: "typacl", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: PgTypeName},   // TODO: type aclitem[]
+	{Name: "oid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typname", Type: pgtypes.Name, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typnamespace", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typowner", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typlen", Type: pgtypes.Int16, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typbyval", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typtype", Type: pgtypes.InternalChar, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typcategory", Type: pgtypes.InternalChar, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typispreferred", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typisdefined", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typdelim", Type: pgtypes.InternalChar, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typrelid", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typsubscript", Type: pgtypes.Text, Default: nil, Nullable: false, Source: pgTypeName}, // TODO: type regproc
+	{Name: "typelem", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typarray", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typinput", Type: pgtypes.Text, Default: nil, Nullable: false, Source: pgTypeName},   // TODO: type regproc
+	{Name: "typoutput", Type: pgtypes.Text, Default: nil, Nullable: false, Source: pgTypeName},  // TODO: type regproc
+	{Name: "typreceive", Type: pgtypes.Text, Default: nil, Nullable: false, Source: pgTypeName}, // TODO: type regproc
+	{Name: "typsend", Type: pgtypes.Text, Default: nil, Nullable: false, Source: pgTypeName},    // TODO: type regproc
+	{Name: "typmodin", Type: pgtypes.Text, Default: nil, Nullable: false, Source: pgTypeName},   // TODO: type regproc
+	{Name: "typmodout", Type: pgtypes.Text, Default: nil, Nullable: false, Source: pgTypeName},  // TODO: type regproc
+	{Name: "typanalyze", Type: pgtypes.Text, Default: nil, Nullable: false, Source: pgTypeName}, // TODO: type regproc
+	{Name: "typalign", Type: pgtypes.InternalChar, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typstorage", Type: pgtypes.InternalChar, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typnotnull", Type: pgtypes.Bool, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typbasetype", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typtypmod", Type: pgtypes.Int32, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typndims", Type: pgtypes.Int32, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typcollation", Type: pgtypes.Oid, Default: nil, Nullable: false, Source: pgTypeName},
+	{Name: "typdefaultbin", Type: pgtypes.Text, Default: nil, Nullable: true, Source: pgTypeName}, // TODO: type pg_node_tree, collation C
+	{Name: "typdefault", Type: pgtypes.Text, Default: nil, Nullable: true, Source: pgTypeName},    // TODO: collation C
+	{Name: "typacl", Type: pgtypes.TextArray, Default: nil, Nullable: true, Source: pgTypeName},   // TODO: type aclitem[]
 }
 
 // pgType represents a row in the pg_type table.

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -5345,6 +5345,139 @@ WHERE i.indrelid IN (1496157033, 1496157034) ORDER BY 1`,
 	})
 }
 
+func TestPgTypeIndexes(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "pg_type_oid_index",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT typname FROM pg_catalog.pg_type WHERE oid = 23 ORDER BY 1;`,
+					Expected: []sql.Row{{"int4"}},
+				},
+				{
+					Query:    `SELECT typname FROM pg_catalog.pg_type WHERE oid = '23' ORDER BY 1;`,
+					Expected: []sql.Row{{"int4"}},
+				},
+				{
+					Query:    `SELECT typname FROM pg_catalog.pg_type WHERE oid > 22 AND oid < 25 ORDER BY typname;`,
+					Expected: []sql.Row{{"int4"}, {"regproc"}},
+				},
+				{
+					Query:    `SELECT typname FROM pg_catalog.pg_type WHERE oid IN (23, 25) ORDER BY typname;`,
+					Expected: []sql.Row{{"int4"}, {"text"}},
+				},
+				{
+					// Full scan still works without index filter
+					Query:    `SELECT typname FROM pg_catalog.pg_type ORDER BY oid LIMIT 1;`,
+					Expected: []sql.Row{{"bool"}},
+				},
+				{
+					Query: `EXPLAIN SELECT typname FROM pg_catalog.pg_type WHERE oid = 23 ORDER BY 1;`,
+					Expected: []sql.Row{
+						{"Project"},
+						{" ├─ columns: [pg_type.typname]"},
+						{" └─ Sort(pg_type.typname ASC)"},
+						{"     └─ Filter"},
+						{"         ├─ pg_type.oid = 23"},
+						{"         └─ IndexedTableAccess(pg_type)"},
+						{"             ├─ index: [pg_type.oid]"},
+						{"             └─ filters: [{[{Type:[\"pg_catalog\",\"int4\"]}, {Type:[\"pg_catalog\",\"int4\"]}]}]"},
+					},
+				},
+				{
+					Query: `EXPLAIN SELECT typname FROM pg_catalog.pg_type WHERE oid > 22 AND oid < 25 ORDER BY 1;`,
+					Expected: []sql.Row{
+						{"Project"},
+						{" ├─ columns: [pg_type.typname]"},
+						{" └─ Sort(pg_type.typname ASC)"},
+						{"     └─ Filter"},
+						{"         ├─ (pg_type.oid > 22 AND pg_type.oid < 25)"},
+						{"         └─ IndexedTableAccess(pg_type)"},
+						{"             ├─ index: [pg_type.oid]"},
+						{"             └─ filters: [{({Type:[\"pg_catalog\",\"int2vector\"]}, {Type:[\"pg_catalog\",\"text\"]})}]"},
+					},
+				},
+				{
+					Query: `EXPLAIN SELECT typname FROM pg_catalog.pg_type WHERE oid IN (23, 25) ORDER BY typname;`,
+					Expected: []sql.Row{
+						{"Project"},
+						{" ├─ columns: [pg_type.typname]"},
+						{" └─ Sort(pg_type.typname ASC)"},
+						{"     └─ Filter"},
+						{"         ├─ pg_type.oid IN (23, 25)"},
+						{"         └─ IndexedTableAccess(pg_type)"},
+						{"             ├─ index: [pg_type.oid]"},
+						{"             └─ filters: [{[{Type:[\"pg_catalog\",\"int4\"]}, {Type:[\"pg_catalog\",\"int4\"]}]}, {[{Type:[\"pg_catalog\",\"text\"]}, {Type:[\"pg_catalog\",\"text\"]}]}]"},
+					},
+				},
+			},
+		},
+		{
+			Name: "pg_type_typname_nsp_index",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT oid FROM pg_catalog.pg_type WHERE typname = 'int4' AND typnamespace = 11 ORDER BY 1;`,
+					Expected: []sql.Row{{23}},
+				},
+				{
+					Query:    `SELECT typname FROM pg_catalog.pg_type WHERE typname > 'int2' AND typname < 'int8' AND typnamespace = 11 ORDER BY 1;`,
+					Expected: []sql.Row{{"int2vector"}, {"int4"}},
+				},
+				{
+					Query:    `SELECT typname FROM pg_catalog.pg_type WHERE typname >= 'int2' AND typname <= 'int4' AND typnamespace = 11 ORDER BY 1;`,
+					Expected: []sql.Row{{"int2"}, {"int2vector"}, {"int4"}},
+				},
+				{
+					Query:    `SELECT typname FROM pg_catalog.pg_type WHERE typname > 'int2' AND typname <= 'int4' AND typnamespace = 11 ORDER BY 1;`,
+					Expected: []sql.Row{{"int2vector"}, {"int4"}},
+				},
+				{
+					Query:    `SELECT typname FROM pg_catalog.pg_type WHERE typname >= 'int4' AND typname <= 'int4' AND typnamespace = 11 ORDER BY 1;`,
+					Expected: []sql.Row{{"int4"}},
+				},
+				{
+					Query: `EXPLAIN SELECT oid FROM pg_catalog.pg_type WHERE typname = 'int4' AND typnamespace = 11 ORDER BY 1;`,
+					Expected: []sql.Row{
+						{"Project"},
+						{" ├─ columns: [pg_type.oid]"},
+						{" └─ Sort(pg_type.oid ASC)"},
+						{"     └─ Filter"},
+						{"         ├─ (pg_type.typname = 'int4' AND pg_type.typnamespace = 11)"},
+						{"         └─ IndexedTableAccess(pg_type)"},
+						{"             ├─ index: [pg_type.typname,pg_type.typnamespace]"},
+						{"             └─ filters: [{[int4, int4], [{Namespace:[\"pg_catalog\"]}, {Namespace:[\"pg_catalog\"]}]}]"},
+					},
+				},
+				{
+					Query: `EXPLAIN SELECT typname FROM pg_catalog.pg_type WHERE typname > 'int2' AND typname < 'int8' AND typnamespace = 11 ORDER BY 1;`,
+					Expected: []sql.Row{
+						{"Project"},
+						{" ├─ columns: [pg_type.typname]"},
+						{" └─ Filter"},
+						{"     ├─ ((pg_type.typname > 'int2' AND pg_type.typname < 'int8') AND pg_type.typnamespace = 11)"},
+						{"     └─ IndexedTableAccess(pg_type)"},
+						{"         ├─ index: [pg_type.typname,pg_type.typnamespace]"},
+						{"         └─ filters: [{(int2, int8), [{Namespace:[\"pg_catalog\"]}, {Namespace:[\"pg_catalog\"]}]}]"},
+					},
+				},
+			},
+		},
+		{
+			Name: "join on pg_type using index",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `SELECT t.typname, n.nspname
+  FROM pg_catalog.pg_type t
+  JOIN pg_catalog.pg_namespace n ON t.typnamespace = n.oid
+  WHERE t.typname = 'int4'
+  ORDER BY 1;`,
+					Expected: []sql.Row{{"int4", "pg_catalog"}},
+				},
+			},
+		},
+	})
+}
+
 func TestSqlAlchemyQueries(t *testing.T) {
 	sharedSetupScript := []string{
 		`create table t1 (a int primary key, b int not null)`,

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -5473,6 +5473,29 @@ func TestPgTypeIndexes(t *testing.T) {
   ORDER BY 1;`,
 					Expected: []sql.Row{{"int4", "pg_catalog"}},
 				},
+				{
+					Query: `EXPLAIN SELECT t.typname, n.nspname
+								FROM pg_catalog.pg_type t
+								JOIN pg_catalog.pg_namespace n ON t.typnamespace = n.oid
+					   			WHERE t.typname = 'int4'
+								ORDER BY 1;`,
+					Expected: []sql.Row{
+						{"Project"},
+						{" ├─ columns: [t.typname, n.nspname]"},
+						{" └─ Sort(t.typname ASC)"},
+						{"     └─ LookupJoin"},
+						{"         ├─ Filter"},
+						{"         │   ├─ t.typname = 'int4'"},
+						{"         │   └─ TableAlias(t)"},
+						{"         │       └─ IndexedTableAccess(pg_type)"},
+						{"         │           ├─ index: [pg_type.typname,pg_type.typnamespace]"},
+						{"         │           └─ filters: [{[int4, int4], [NULL, ∞)}]"},
+						{"         └─ TableAlias(n)"},
+						{"             └─ IndexedTableAccess(pg_namespace)"},
+						{"                 ├─ index: [pg_namespace.oid]"},
+						{"                 └─ keys: t.typnamespace"},
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
Adds the two internal indices that should exist on `pg_type`. Very similar to the existing implementation of `pg_class`.