### PR TITLE
Add support for UTF8 chars in identifiers

### DIFF
--- a/core/identifiers.go
+++ b/core/identifiers.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+// IsValidPostgresIdentifier returns true according to Postgres quoted identifier rules.
+// Quoted identifiers can contain any character except the null character (code zero),
+// including supplementary Unicode (emoji, code points above U+FFFF) unlike MySQL.
+// https://www.postgresql.org/docs/current/sql-syntax-lexical.html
+func IsValidPostgresIdentifier(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	for _, c := range name {
+		if c == 0x0000 {
+			return false
+		}
+	}
+	return true
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/cockroachdb/apd/v2 v2.0.3-0.20200518165714-d020e156310a
 	github.com/cockroachdb/errors v1.7.5
-	github.com/dolthub/dolt/go v0.40.5-0.20260414181222-29a5ed0fef4f
+	github.com/dolthub/dolt/go v0.40.5-0.20260414201247-c1c78c1dc032
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260412215059-d7fc9477f4b7

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP4
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
 github.com/dolthub/dolt/go v0.40.5-0.20260414181222-29a5ed0fef4f h1:j/hURnYQxMIypeNFBp5SCXMl9B9j6BdEaE2gMFnvVZA=
 github.com/dolthub/dolt/go v0.40.5-0.20260414181222-29a5ed0fef4f/go.mod h1:herP1qJMjcHmk0i4211oIP8WEfKWIk9aXEYJ9/ha59M=
+github.com/dolthub/dolt/go v0.40.5-0.20260414201247-c1c78c1dc032 h1:R7ADQRHJd7AcJXuQEgBoTDOyaQ1CwzRIkMFiMYj59sg=
+github.com/dolthub/dolt/go v0.40.5-0.20260414201247-c1c78c1dc032/go.mod h1:herP1qJMjcHmk0i4211oIP8WEfKWIk9aXEYJ9/ha59M=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 h1:JShhbqMw26nKx3pqqu/cFxOpzBkN+4elVhzuUfgDw2k=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=

--- a/server/tables/init.go
+++ b/server/tables/init.go
@@ -15,8 +15,11 @@
 package tables
 
 import (
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
 	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/core"
 )
 
 // Init handles initialization of all Postgres-specific and Doltgres-specific tables.
@@ -27,4 +30,5 @@ func Init() {
 		}
 		return db, nil
 	}
+	doltdb.IsValidIdentifier = core.IsValidPostgresIdentifier
 }

--- a/testing/go/create_table_test.go
+++ b/testing/go/create_table_test.go
@@ -24,6 +24,28 @@ import (
 func TestCreateTable(t *testing.T) {
 	RunScripts(t, []ScriptTest{
 		{
+			// https://github.com/dolthub/doltgresql/issues/2580
+			Name: "create table with UTF8 identifiers",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `CREATE TABLE foo😏(data🍆 TEXT);`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `CREATE INDEX idx🍤 ON foo😏(data🍆);`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `Insert into foo😏 (data🍆) VALUES ('foo');`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT data🍆 FROM foo😏;`,
+					Expected: []sql.Row{{"foo"}},
+				},
+			},
+		},
+		{
 			Name: "create table with primary key",
 			Assertions: []ScriptTestAssertion{
 				{


### PR DESCRIPTION
Enables use of UTF8 chars in identifiers, matching PostgreSQL behavior. 

Related to https://github.com/dolthub/doltgresql/issues/2580