### PR TITLE
Column names expression fix

### DIFF
--- a/server/ast/select.go
+++ b/server/ast/select.go
@@ -15,6 +15,7 @@
 package ast
 
 import (
+	"github.com/dolthub/doltgresql/postgres/parser/sessiondata"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -134,28 +135,13 @@ func nodeSelectExpr(ctx *Context, node tree.SelectExpr) (vitess.SelectExpr, erro
 			return nil, err
 		}
 
-		if ce, ok := expr.(*tree.CastExpr); ok && node.As == "" {
-			hasConst := false
-			_, _ = tree.SimpleVisit(expr, func(visitingExpr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
-				switch visitingExpr.(type) {
-				case tree.Constant:
-					hasConst = true
-					return false, visitingExpr, nil
+		if node.As == "" {
+			//TODO: Currently calling GetRenderColName on funcExpr panics.
+			if _, ok := expr.(*tree.FuncExpr); !ok {
+				colName, err := tree.GetRenderColName(sessiondata.EmptySearchPath, node)
+				if err == nil {
+					node.As = tree.UnrestrictedName(colName)
 				}
-				return true, visitingExpr, nil
-			})
-			if hasConst {
-				_, dt, err := nodeResolvableTypeReference(ctx, ce.Type, false)
-				if err != nil {
-					return nil, err
-				}
-				// constant value is not part of column name
-				// e.g. `1::INT2` should create column name as `int2`.
-				node.As = tree.UnrestrictedName(dt.Name())
-			} else {
-				// cast type is not part of column name
-				// e.g. `id::INT2` should create column name as `id`.
-				node.As = tree.UnrestrictedName(tree.AsString(ce.Expr))
 			}
 		}
 

--- a/server/doltgres_handler.go
+++ b/server/doltgres_handler.go
@@ -523,7 +523,9 @@ func schemaToFieldDescriptions(ctx *sql.Context, s sql.Schema, formatCodes []int
 				// such as `SELECT 'foo';`
 				doltgresType = pgtypes.Text
 				dataTypeSize = int16(doltgresType.MaxTextResponseByteLength(ctx))
-				colName = "?column?"
+				if c.Name == "" {
+					colName = "?column?"
+				}
 				tableAttributeNumber = 0
 			}
 			if doltgresType.TypType == pgtypes.TypeType_Domain {

--- a/testing/go/expressions_test.go
+++ b/testing/go/expressions_test.go
@@ -487,3 +487,27 @@ func TestSubscript(t *testing.T) {
 		},
 	})
 }
+
+func TestCaseStatement(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "case statement column name",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:            `SELECT CASE WHEN 1=1 THEN 'foo' ELSE 'bar' END AS colname;`,
+					Expected:         []sql.Row{{"foo"}},
+					ExpectedColNames: []string{"colname"},
+				},
+				{
+					Query:            `SELECT CASE WHEN 1=1 THEN 'foo' ELSE 'bar' END`,
+					ExpectedColNames: []string{"case"},
+				},
+				{
+					Query:            `SELECT CASE WHEN 1=1 THEN 1::int2 else 2 end`,
+					Expected:         []sql.Row{{1}},
+					ExpectedColNames: []string{"case"},
+				},
+			},
+		},
+	})
+}

--- a/testing/go/select_test.go
+++ b/testing/go/select_test.go
@@ -196,5 +196,18 @@ func TestSelect(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "SELECT raw values column name",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:            "select 1",
+					ExpectedColNames: []string{"?column?"},
+				},
+				{
+					Query:            "select 'hello'",
+					ExpectedColNames: []string{"?column?"},
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
Currently a bug where queries like `select case....` or `select case.... as name` will both have column names of `?column?`. 