### PR TITLE
security: update lodash to >=4.18.0 in Node tests

### DIFF
--- a/testing/postgres-client-tests/node/package-lock.json
+++ b/testing/postgres-client-tests/node/package-lock.json
@@ -168,9 +168,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -556,9 +556,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "ms": {
       "version": "2.1.2",


### PR DESCRIPTION
## Summary
- Updates `lodash` from 4.17.21 to 4.18.0 in `testing/postgres-client-tests/node/`
- Fixes Dependabot alert #46 (medium: prototype pollution via `_.unset`/`_.omit`)
- Fixes Dependabot alert #47 (high: code injection via `_.template` imports)
- Transitive dependency of `knex`, updated via `npm audit fix`

## Test plan
- [ ] CI passes
- [ ] Node client integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)