### PR TITLE
Bug fix: don't round JSON numeric values when outside of float64 range

### DIFF
--- a/server/types/json_document.go
+++ b/server/types/json_document.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"bytes"
 	"regexp"
 	"sort"
 	"strings"
@@ -345,7 +346,11 @@ func JsonValueFormatter(sb *strings.Builder, value JsonValue) {
 // UnmarshalToJsonDocument converts a JSON document byte slice into the actual JSON document.
 func UnmarshalToJsonDocument(val []byte) (JsonDocument, error) {
 	var decoded interface{}
-	if err := json.Unmarshal(val, &decoded); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(val))
+	// UseNumber causes JSON numbers to be decoded as json.Number (string-backed) instead of
+	// float64, which ensures we preserve values and precision.
+	decoder.UseNumber()
+	if err := decoder.Decode(&decoded); err != nil {
 		return JsonDocument{}, err
 	}
 	jsonValue, err := ConvertToJsonDocument(decoded)
@@ -405,8 +410,18 @@ func ConvertToJsonDocument(val interface{}) (JsonValue, error) {
 		// This is safe as we double backslashes before this step, so this will return it to its original input.
 		val = jsonDocumentStringUnicodeRegex.ReplaceAllString(val, `\u$1`)
 		return JsonValueString(val), nil
+	case json.Number:
+		d, err := decimal.NewFromString(string(val))
+		if err != nil {
+			return nil, err
+		}
+		// Strip trailing fractional zeros: "25.0"→{250,-1} and "25"→{25,0} differ in MarshalBinary, breaking GROUP BY hash equality.
+		d, err = decimal.NewFromString(d.String())
+		if err != nil {
+			return nil, err
+		}
+		return JsonValueNumber(d), nil
 	case float64:
-		// TODO: handle this as a proper numeric as float64 is not precise enough
 		return JsonValueNumber(decimal.NewFromFloat(val)), nil
 	case bool:
 		return JsonValueBoolean(val), nil

--- a/testing/go/types_test.go
+++ b/testing/go/types_test.go
@@ -1543,6 +1543,42 @@ var typesTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "JSONB GROUP BY with equivalent numbers",
+		SetUpScript: []string{
+			`CREATE TABLE t (id SERIAL PRIMARY KEY, doc JSONB);`,
+			`INSERT INTO t (doc) VALUES ('{"age":25}'), ('{"age":25}'), ('{"age":25.0}'), ('{"age":30}');`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `SELECT doc, COUNT(*) FROM t GROUP BY doc ORDER BY doc;`,
+				Expected: []sql.Row{
+					{`{"age": 25}`, int64(3)},
+					{`{"age": 30}`, int64(1)},
+				},
+			},
+		},
+	},
+	{
+		Name: "JSONB int64 boundary values",
+		SetUpScript: []string{
+			`CREATE TABLE t (id SERIAL PRIMARY KEY, doc JSONB);`,
+			`INSERT INTO t (doc) VALUES ('-9223372036854775808'::jsonb), ('9223372036854775807'::jsonb);`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `SELECT doc FROM t ORDER BY id;`,
+				ExpectedRaw: [][][]byte{
+					{[]byte("-9223372036854775808")},
+					{[]byte("9223372036854775807")},
+				},
+			},
+			{
+				Query:    `SELECT doc::text::bigint FROM t ORDER BY id;`,
+				Expected: []sql.Row{{int64(-9223372036854775808)}, {int64(9223372036854775807)}},
+			},
+		},
+	},
+	{
 		Name: "Line type",
 		Skip: true,
 		SetUpScript: []string{


### PR DESCRIPTION
Fixes: https://github.com/dolthub/doltgresql/issues/2686