### PR TITLE
fix: correct deserialization order of sequence/routine/membership in …

### DIFF
--- a/server/auth/serialization.go
+++ b/server/auth/serialization.go
@@ -89,12 +89,12 @@ func (db *Database) deserializeV0(reader *utils.Reader) error {
 	db.schemaPrivileges.deserialize(0, reader)
 	// Read the table privileges
 	db.tablePrivileges.deserialize(0, reader)
-	// Read the role chain
-	db.roleMembership.deserialize(0, reader)
-	// Read the routine privileges
-	db.routinePrivileges.deserialize(0, reader)
 	// Read the sequence privileges
 	db.sequencePrivileges.deserialize(0, reader)
+	// Read the routine privileges
+	db.routinePrivileges.deserialize(0, reader)
+	// Read the role membership
+	db.roleMembership.deserialize(0, reader)
 	return nil
 }
 
@@ -116,11 +116,11 @@ func (db *Database) deserializeV1(reader *utils.Reader) error {
 	db.schemaPrivileges.deserialize(1, reader)
 	// Read the table privileges
 	db.tablePrivileges.deserialize(1, reader)
-	// Read the role chain
-	db.roleMembership.deserialize(1, reader)
-	// Read the routine privileges
-	db.routinePrivileges.deserialize(1, reader)
 	// Read the sequence privileges
 	db.sequencePrivileges.deserialize(1, reader)
+	// Read the routine privileges
+	db.routinePrivileges.deserialize(1, reader)
+	// Read the role membership
+	db.roleMembership.deserialize(1, reader)
 	return nil
 }


### PR DESCRIPTION
…auth

The serialize() function wrote fields in this order:
  tablePrivileges → sequencePrivileges → routinePrivileges → roleMembership

But deserializeV1() read them in a different order:
  tablePrivileges → roleMembership → routinePrivileges → sequencePrivileges

This mismatch went unnoticed because all three sections (sequencePrivileges, routinePrivileges, roleMembership) have the same zero-value byte representation (count=0) when no privileges exist. Once GRANT ALL PRIVILEGES ON ALL ROUTINES or GRANT ALL PRIVILEGES ON ALL FUNCTIONS is executed, routinePrivileges becomes non-empty, the reader offset shifts, and doltgres panics with an index out of range error on the next startup when attempting to read the persisted auth file.

Fix deserializeV1() to match the order used by serialize().

Fixes #2693