### PR TITLE
Fix scripts/build.sh to work on RedHat-based distros

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,8 +12,8 @@ script_dir=$(dirname "$0")
 cd $script_dir/..
 
 go_version=`go version | cut -d" " -f 3 | sed -e 's|go||' | sed -e 's|\.[0-9]$||'`
-os=`go version | cut -d" " -f 4 | sed "s|/.*||"`
-arch=`go version | cut -d" " -f 4 | sed "s|.*/||"`
+os=`go version | sed "s| (.*)||" | cut -d" " -f 4 | sed "s|/.*||"`
+arch=`go version | sed "s| (.*)||" | cut -d" " -f 4 | sed "s|.*/||"`
 
 echo "os is $os"
 echo "arch is $arch"


### PR DESCRIPTION
On CentOS and other RH-based distros the output of "go version" contains the "(Red Hat 1.26.2-2.el10)" string, which confuses the parser.