### PR TITLE
bug fix: load non-built-in types when looking for an array type's element type

### DIFF
--- a/core/casts/collection.go
+++ b/core/casts/collection.go
@@ -75,7 +75,7 @@ func NewCollection(ctx context.Context, underlyingMap prolly.AddressMap, ns tree
 
 // GetExplicitCast returns the explicit type cast function that will cast the source type to the target type. Returns
 // a Cast with an invalid ID if such a cast is not valid.
-func (pgc *Collection) GetExplicitCast(ctx context.Context, sourceType *pgtypes.DoltgresType, targetType *pgtypes.DoltgresType) (Cast, error) {
+func (pgc *Collection) GetExplicitCast(ctx *sql.Context, sourceType *pgtypes.DoltgresType, targetType *pgtypes.DoltgresType) (Cast, error) {
 	castID := id.NewCast(sourceType.ID, targetType.ID)
 	c, err := pgc.getCast(ctx, castID, sourceType, targetType, CastType_Explicit)
 	if err != nil {
@@ -123,7 +123,7 @@ func (pgc *Collection) GetExplicitCast(ctx context.Context, sourceType *pgtypes.
 
 // GetAssignmentCast returns the assignment type cast function that will cast the source type to the target type.
 // Returns a Cast with an invalid ID if such a cast is not valid.
-func (pgc *Collection) GetAssignmentCast(ctx context.Context, sourceType *pgtypes.DoltgresType, targetType *pgtypes.DoltgresType) (Cast, error) {
+func (pgc *Collection) GetAssignmentCast(ctx *sql.Context, sourceType *pgtypes.DoltgresType, targetType *pgtypes.DoltgresType) (Cast, error) {
 	castID := id.NewCast(sourceType.ID, targetType.ID)
 	c, err := pgc.getCast(ctx, castID, sourceType, targetType, CastType_Assignment)
 	if err != nil {
@@ -166,7 +166,7 @@ func (pgc *Collection) GetAssignmentCast(ctx context.Context, sourceType *pgtype
 
 // GetImplicitCast returns the implicit type cast function that will cast the source type to the target type. Returns a
 // Cast with an invalid ID if such a cast is not valid.
-func (pgc *Collection) GetImplicitCast(ctx context.Context, sourceType *pgtypes.DoltgresType, targetType *pgtypes.DoltgresType) (Cast, error) {
+func (pgc *Collection) GetImplicitCast(ctx *sql.Context, sourceType *pgtypes.DoltgresType, targetType *pgtypes.DoltgresType) (Cast, error) {
 	castID := id.NewCast(sourceType.ID, targetType.ID)
 	c, err := pgc.getCast(ctx, castID, sourceType, targetType, CastType_Implicit)
 	if err != nil {
@@ -211,22 +211,26 @@ func (pgc *Collection) getCast(ctx context.Context, castID id.Cast, sourceType *
 		// If there isn't a direct mapping, then we need to check if the types are array variants.
 		// As long as the base types are convertable, the array variants are also convertable.
 		if sourceType != nil && targetType != nil && sourceType.IsArrayType() && targetType.IsArrayType() {
-			fromBaseType := sourceType.ArrayBaseType()
-			toBaseType := targetType.ArrayBaseType()
+			sqlCtx, ok := ctx.(*sql.Context)
+			if !ok {
+				return Cast{}, fmt.Errorf("non *sql.Context provided to Collection.getCast()")
+			}
+			fromBaseType := sourceType.ArrayBaseTypeCtx(sqlCtx)
+			toBaseType := targetType.ArrayBaseTypeCtx(sqlCtx)
 			var baseCast Cast
 			switch castType {
 			case CastType_Explicit:
-				baseCast, err = pgc.GetExplicitCast(ctx, fromBaseType, toBaseType)
+				baseCast, err = pgc.GetExplicitCast(sqlCtx, fromBaseType, toBaseType)
 				if err != nil {
 					return Cast{}, err
 				}
 			case CastType_Assignment:
-				baseCast, err = pgc.GetAssignmentCast(ctx, fromBaseType, toBaseType)
+				baseCast, err = pgc.GetAssignmentCast(sqlCtx, fromBaseType, toBaseType)
 				if err != nil {
 					return Cast{}, err
 				}
 			case CastType_Implicit:
-				baseCast, err = pgc.GetImplicitCast(ctx, fromBaseType, toBaseType)
+				baseCast, err = pgc.GetImplicitCast(sqlCtx, fromBaseType, toBaseType)
 				if err != nil {
 					return Cast{}, err
 				}
@@ -244,8 +248,8 @@ func (pgc *Collection) getCast(ctx context.Context, castID id.Cast, sourceType *
 						// Some errors are optional depending on the context, so we'll still process all values even
 						// after an error is received.
 						var nErr error
-						sourceBaseType := sourceType.ArrayBaseType()
-						targetBaseType := targetType.ArrayBaseType()
+						sourceBaseType := sourceType.ArrayBaseTypeCtx(ctx)
+						targetBaseType := targetType.ArrayBaseTypeCtx(ctx)
 						newVals[i], nErr = baseCast.Eval(ctx, oldVal, sourceBaseType, targetBaseType)
 						if nErr != nil && err == nil {
 							err = nErr

--- a/core/typecollection/typecollection.go
+++ b/core/typecollection/typecollection.go
@@ -182,7 +182,28 @@ func (pgs *TypeCollection) GetType(ctx context.Context, name id.Type) (*pgtypes.
 		if !ok {
 			return nil, nil
 		}
-		tbl, schema, err := pgs.getTable(sqlCtx, name.SchemaName(), name.TypeName())
+		typeName := name.TypeName()
+
+		// A name starting with "_" may be the implicit array type for a table's composite row type.
+		// PostgreSQL implicitly creates an array type for every user-defined type (including the
+		// composite type that is implicitly created for each table). Look up the element type by
+		// stripping the leading "_", and if a matching table exists, build the array type on the fly.
+		if strings.HasPrefix(typeName, "_") {
+			elemTbl, schema, err := pgs.getTable(sqlCtx, name.SchemaName(), typeName[1:])
+			if err != nil {
+				return nil, err
+			}
+			if elemTbl != nil {
+				compositeType, err := pgs.tableToType(sqlCtx, elemTbl, schema)
+				if err != nil {
+					return nil, err
+				}
+				return pgtypes.CreateArrayTypeFromBaseType(compositeType), nil
+			}
+			return nil, nil
+		}
+
+		tbl, schema, err := pgs.getTable(sqlCtx, name.SchemaName(), typeName)
 		if err != nil || tbl == nil {
 			return nil, err
 		}

--- a/core/typecollection/typecollection.go
+++ b/core/typecollection/typecollection.go
@@ -109,10 +109,8 @@ func (pgs *TypeCollection) DropType(ctx context.Context, names ...id.Type) (err 
 }
 
 // GetAllTypes returns a map containing all types in the collection, grouped by the schema they're contained in.
-// Each type array is also sorted by the type name. It includes built-in types, but does not include types referring to
-// a table's row type.
+// Each type array is also sorted by the type name. It includes built-in types.
 func (pgs *TypeCollection) GetAllTypes(ctx context.Context) (typeMap map[string][]*pgtypes.DoltgresType, schemaNames []string, totalCount int, err error) {
-	// TODO: this should probably get tables as well since tables create composite types matching their rows
 	schemaNamesMap := make(map[string]struct{})
 	typeMap = make(map[string][]*pgtypes.DoltgresType)
 	err = pgs.IterateTypes(ctx, func(t *pgtypes.DoltgresType) (stop bool, err error) {
@@ -177,30 +175,23 @@ func (pgs *TypeCollection) GetType(ctx context.Context, name id.Type) (*pgtypes.
 			return createAnonymousCompositeType(ctx, name)
 		}
 
-		// If it's not a built-in type or created type, then check if it's a composite table row type
+		// Table composite types are computed on the fly from the live table schema rather than
+		// stored as root objects (storing them would create a naming collision with the actual
+		// table in Dolt's diff layer, since both map to the same doltdb.TableName).
 		sqlCtx, ok := ctx.(*sql.Context)
 		if !ok {
 			return nil, nil
 		}
 		typeName := name.TypeName()
 
-		// A name starting with "_" may be the implicit array type for a table's composite row type.
-		// PostgreSQL implicitly creates an array type for every user-defined type (including the
-		// composite type that is implicitly created for each table). Look up the element type by
-		// stripping the leading "_", and if a matching table exists, build the array type on the fly.
+		// A name starting with "_" may be the implicit array type for a table's composite row
+		// type. Resolve the element type first (which handles the table lookup), then wrap it.
 		if strings.HasPrefix(typeName, "_") {
-			elemTbl, schema, err := pgs.getTable(sqlCtx, name.SchemaName(), typeName[1:])
-			if err != nil {
+			elemType, err := pgs.GetType(ctx, id.NewType(name.SchemaName(), typeName[1:]))
+			if err != nil || elemType == nil {
 				return nil, err
 			}
-			if elemTbl != nil {
-				compositeType, err := pgs.tableToType(sqlCtx, elemTbl, schema)
-				if err != nil {
-					return nil, err
-				}
-				return pgtypes.CreateArrayTypeFromBaseType(compositeType), nil
-			}
-			return nil, nil
+			return pgtypes.CreateArrayTypeFromBaseType(elemType), nil
 		}
 
 		tbl, schema, err := pgs.getTable(sqlCtx, name.SchemaName(), typeName)
@@ -264,7 +255,7 @@ func (pgs *TypeCollection) HasType(ctx context.Context, name id.Type) bool {
 	if err == nil && ok {
 		return true
 	}
-	// If it's not a built-in type or created type, then check if it's a composite table row type
+	// Table composite types are not stored; check the table as a fallback.
 	sqlCtx, ok := ctx.(*sql.Context)
 	if !ok {
 		return false

--- a/server/ast/resolvable_type_reference.go
+++ b/server/ast/resolvable_type_reference.go
@@ -41,9 +41,12 @@ func nodeResolvableTypeReference(ctx *Context, typ tree.ResolvableTypeReference,
 	switch columnType := typ.(type) {
 	case *tree.ArrayTypeReference:
 		if uon, ok := columnType.ElementType.(*tree.UnresolvedObjectName); ok {
-			return nodeResolvableTypeReference(ctx, uon, mayBeTrigger)
+			tn := uon.ToTableName()
+			columnTypeName = tn.Object() + "[]"
+			doltgresType = pgtypes.NewUnresolvedArrayDoltgresType(tn.Schema(), tn.Object())
+		} else {
+			return nil, nil, errors.Errorf("the given array type is not yet supported")
 		}
-		return nil, nil, errors.Errorf("the given array type is not yet supported")
 	case *tree.OIDTypeReference:
 		return nil, nil, errors.Errorf("referencing types by their OID is not yet supported")
 	case *tree.UnresolvedObjectName:
@@ -69,9 +72,8 @@ func nodeResolvableTypeReference(ctx *Context, typ tree.ResolvableTypeReference,
 					// currently the built-in types will be resolved, so it can retrieve its array type
 					doltgresType = baseResolvedType.ToArrayType()
 				} else {
-					// TODO: handle array type of non-built-in types
-					baseResolvedType.TypCategory = pgtypes.TypeCategory_ArrayTypes
-					doltgresType = baseResolvedType
+					// User-defined element type: build an unresolved array type with the proper structure.
+					doltgresType = pgtypes.NewUnresolvedArrayDoltgresType(baseResolvedType.ID.SchemaName(), baseResolvedType.ID.TypeName())
 				}
 			}
 		} else if columnType.Family() == types.GeometryFamily {

--- a/server/expression/any.go
+++ b/server/expression/any.go
@@ -343,7 +343,7 @@ func anyExpressionWithChildren(ctx *sql.Context, anyExpr *AnyExpr) (sql.Expressi
 	if !ok {
 		return nil, errors.Errorf("expected right child to be a DoltgresType but got `%T`", anyExpr.rightExpr)
 	}
-	rightType := arrType.ArrayBaseType()
+	rightType := arrType.ArrayBaseTypeCtx(ctx)
 	op, err := framework.GetOperatorFromString(anyExpr.subOperator)
 	if err != nil {
 		return nil, err

--- a/server/expression/array.go
+++ b/server/expression/array.go
@@ -23,6 +23,7 @@ import (
 	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/doltgresql/core"
+	"github.com/dolthub/doltgresql/core/id"
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
@@ -183,6 +184,19 @@ func (array *Array) getTargetType(ctx *sql.Context, children ...sql.Expression) 
 	targetType, _, err := framework.FindCommonType(ctx, childrenTypes)
 	if err != nil {
 		return nil, errors.Errorf("ARRAY %s", err.Error())
+	}
+	// If the common type is unresolved (e.g. a user-defined composite type seen before the analyzer runs),
+	// look it up from the type collection so that ToArrayType can find the array type ID.
+	if !targetType.IsResolvedType() {
+		schemaName := targetType.ID.SchemaName()
+		if schemaName == "" {
+			schemaName, _ = core.GetCurrentSchema(ctx)
+		}
+		if typeColl, tcErr := core.GetTypesCollectionFromContext(ctx); tcErr == nil && typeColl != nil {
+			if resolved, rErr := typeColl.GetType(ctx, id.NewType(schemaName, targetType.ID.TypeName())); rErr == nil && resolved != nil {
+				targetType = resolved
+			}
+		}
 	}
 	return targetType.ToArrayType(), nil
 }

--- a/server/expression/array.go
+++ b/server/expression/array.go
@@ -63,7 +63,7 @@ func (array *Array) Children() []sql.Expression {
 
 // Eval implements the sql.Expression interface.
 func (array *Array) Eval(ctx *sql.Context, row sql.Row) (any, error) {
-	resultTyp := array.coercedType.ArrayBaseType()
+	resultTyp := array.coercedType.ArrayBaseTypeCtx(ctx)
 	values := make([]any, len(array.children))
 	castsColl, err := core.GetCastsCollectionFromContext(ctx)
 	if err != nil {

--- a/server/expression/explicit_cast.go
+++ b/server/expression/explicit_cast.go
@@ -120,7 +120,7 @@ func (c *ExplicitCast) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 		// during an error, so it's safe to use.
 		castToType := c.castToType
 		if c.castToType.IsArrayType() {
-			castToType = c.castToType.ArrayBaseType()
+			castToType = c.castToType.ArrayBaseTypeCtx(ctx)
 		}
 		// A nil result will be returned if there's a critical error, which we should never ignore.
 		if castToType.TypCategory != pgtypes.TypeCategory_StringTypes || castResult == nil {

--- a/server/expression/subscript.go
+++ b/server/expression/subscript.go
@@ -57,7 +57,7 @@ func (s Subscript) Type(ctx *sql.Context) sql.Type {
 	if !ok {
 		panic(fmt.Sprintf("unexpected type %T for subscript", s.Child.Type(ctx)))
 	}
-	return dt.ArrayBaseType()
+	return dt.ArrayBaseTypeCtx(ctx)
 }
 
 // IsNullable implements the sql.Expression interface.

--- a/server/functions/array.go
+++ b/server/functions/array.go
@@ -47,7 +47,7 @@ var array_in = framework.Function3{
 		input := val1.(string)
 		baseTypeOid := val2.(id.Id)
 		baseType := pgtypes.IDToBuiltInDoltgresType[id.Type(baseTypeOid)]
-		if baseType == nil && pgtypes.GetTypesCollectionFromContext != nil {
+		if baseType == nil {
 			if typColl, err := pgtypes.GetTypesCollectionFromContext(ctx); err == nil && typColl != nil {
 				if t, err := typColl.GetType(ctx, id.Type(baseTypeOid)); err == nil {
 					baseType = t

--- a/server/functions/array.go
+++ b/server/functions/array.go
@@ -47,6 +47,16 @@ var array_in = framework.Function3{
 		input := val1.(string)
 		baseTypeOid := val2.(id.Id)
 		baseType := pgtypes.IDToBuiltInDoltgresType[id.Type(baseTypeOid)]
+		if baseType == nil && pgtypes.GetTypesCollectionFromContext != nil {
+			if typColl, err := pgtypes.GetTypesCollectionFromContext(ctx); err == nil && typColl != nil {
+				if t, err := typColl.GetType(ctx, id.Type(baseTypeOid)); err == nil {
+					baseType = t
+				}
+			}
+		}
+		if baseType == nil {
+			return nil, errors.Errorf("unknown array element type: %s", string(baseTypeOid))
+		}
 		typmod := val3.(int32)
 		baseType = baseType.WithAttTypMod(typmod)
 		if len(input) < 2 || input[0] != '{' || input[len(input)-1] != '}' {
@@ -151,7 +161,7 @@ var array_out = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, t [2]*pgtypes.DoltgresType, val any) (any, error) {
 		arrType := t[0]
-		baseType := arrType.ArrayBaseType()
+		baseType := arrType.ArrayBaseTypeCtx(ctx)
 		return pgtypes.ArrToString(ctx, val.([]any), baseType, false)
 	},
 }
@@ -302,7 +312,7 @@ var btarraycmp = framework.Function2{
 		bb := val2.([]any)
 		minLength := utils.Min(len(ab), len(bb))
 		for i := 0; i < minLength; i++ {
-			res, err := at.ArrayBaseType().Compare(ctx, ab[i], bb[i])
+			res, err := at.ArrayBaseTypeCtx(ctx).Compare(ctx, ab[i], bb[i])
 			if err != nil {
 				return 0, err
 			}

--- a/server/functions/array_position.go
+++ b/server/functions/array_position.go
@@ -42,7 +42,7 @@ var array_position_anyarray_anyelement = framework.Function2{
 		array := val1.([]any)
 		searchElement := val2
 		arrayType := t[0]
-		baseType := arrayType.ArrayBaseType()
+		baseType := arrayType.ArrayBaseTypeCtx(ctx)
 
 		// Search for the element starting from position 1 (1-indexed)
 		for i, element := range array {
@@ -75,7 +75,7 @@ var array_position_anyarray_anyelement_int32 = framework.Function3{
 		searchElement := val2
 		start := val3.(int32)
 		arrayType := t[0]
-		baseType := arrayType.ArrayBaseType()
+		baseType := arrayType.ArrayBaseTypeCtx(ctx)
 
 		// Convert 1-indexed start position to 0-indexed
 		startIdx := int(start - 1)
@@ -116,7 +116,7 @@ var array_positions_anyarray_anyelement = framework.Function2{
 		array := val1.([]any)
 		searchElement := val2
 		arrayType := t[0]
-		baseType := arrayType.ArrayBaseType()
+		baseType := arrayType.ArrayBaseTypeCtx(ctx)
 		var positions []any
 
 		// Search for all occurrences of the element

--- a/server/functions/array_to_string.go
+++ b/server/functions/array_to_string.go
@@ -66,7 +66,7 @@ var array_to_string_anyarray_text_text = framework.Function3{
 // getStringArrFromAnyArray takes inputs of any array, delimiter and null entry replacement. It uses the IoOutput() of the
 // base type of the AnyArray type to get string representation of array elements.
 func getStringArrFromAnyArray(ctx *sql.Context, arrType *pgtypes.DoltgresType, arr []any, delimiter string, nullEntry any) (string, error) {
-	baseType := arrType.ArrayBaseType()
+	baseType := arrType.ArrayBaseTypeCtx(ctx)
 	strs := make([]string, 0)
 	for _, el := range arr {
 		if el != nil {

--- a/server/functions/framework/compiled_function.go
+++ b/server/functions/framework/compiled_function.go
@@ -218,7 +218,7 @@ func (c *CompiledFunction) Type(ctx *sql.Context) sql.Type {
 		if rt.IsPolymorphicType() && len(c.originalTypes) > 0 {
 			rt = c.originalTypes[0]
 			if rt.IsArrayType() {
-				return rt.ArrayBaseType()
+				return rt.ArrayBaseTypeCtx(ctx)
 			}
 		}
 		return rt
@@ -303,7 +303,7 @@ func (c *CompiledFunction) Eval(ctx *sql.Context, row sql.Row) (interface{}, err
 					// should be impossible, we check this at function compile time
 					return nil, cerrors.Errorf("variadic arguments must be array types, was %T", targetType)
 				}
-				targetType = targetType.ArrayBaseType()
+				targetType = targetType.ArrayBaseTypeCtx(ctx)
 			} else {
 				targetType = targetParamTypes[i]
 			}

--- a/server/functions/framework/compiled_function.go
+++ b/server/functions/framework/compiled_function.go
@@ -306,6 +306,13 @@ func (c *CompiledFunction) Eval(ctx *sql.Context, row sql.Row) (interface{}, err
 				targetType = targetType.ArrayBaseTypeCtx(ctx)
 			} else {
 				targetType = targetParamTypes[i]
+				// When the declared parameter type is anyarray, the implicit cast from an
+				// unknown/text argument (via UseInOut) would target anyarray.IoInput which
+				// cannot be loaded as a QuickFunction. Resolve to the concrete array type
+				// (e.g. _aggtype) so the cast uses the real element-type I/O path instead.
+				if targetType.ID == pgtypes.AnyArray.ID {
+					targetType = c.resolvePolymorphicReturnType(targetParamTypes, exprTypes, targetType)
+				}
 			}
 
 			if c.overload.casts[i].ID.IsValid() {

--- a/server/functions/framework/compiled_function.go
+++ b/server/functions/framework/compiled_function.go
@@ -310,6 +310,8 @@ func (c *CompiledFunction) Eval(ctx *sql.Context, row sql.Row) (interface{}, err
 				// unknown/text argument (via UseInOut) would target anyarray.IoInput which
 				// cannot be loaded as a QuickFunction. Resolve to the concrete array type
 				// (e.g. _aggtype) so the cast uses the real element-type I/O path instead.
+				// TODO: If targetType.ID can be resolved to the concrete type earlier in
+				//       processing, then we don't need this check here anymore.
 				if targetType.ID == pgtypes.AnyArray.ID {
 					targetType = c.resolvePolymorphicReturnType(targetParamTypes, exprTypes, targetType)
 				}

--- a/server/types/array.go
+++ b/server/types/array.go
@@ -80,13 +80,13 @@ var LogicalArrayElementTypes = map[id.Type]*DoltgresType{
 // serializeTypeArray handles serialization from the standard representation to our serialized representation that is
 // written in Dolt.
 func serializeTypeArray(ctx *sql.Context, t *DoltgresType, val any) ([]byte, error) {
-	return serializeArray(ctx, val.([]any), t.ArrayBaseType())
+	return serializeArray(ctx, val.([]any), t.ArrayBaseTypeCtx(ctx))
 }
 
 // deserializeTypeArray handles deserialization from the Dolt serialized format to our standard representation used by
 // expressions and nodes.
 func deserializeTypeArray(ctx *sql.Context, t *DoltgresType, data []byte) (any, error) {
-	return deserializeArray(ctx, data, t.ArrayBaseType())
+	return deserializeArray(ctx, data, t.ArrayBaseTypeCtx(ctx))
 }
 
 // deserializeArray serializes an array of given base type.

--- a/server/types/globals.go
+++ b/server/types/globals.go
@@ -203,6 +203,7 @@ func init() {
 		toInternal("any"):              Any,
 		toInternal("anyarray"):         AnyArray,
 		toInternal("anyelement"):       AnyElement,
+		toInternal("_anyelement"):      AnyArray,
 		toInternal("anyenum"):          AnyEnum,
 		toInternal("anynonarray"):      AnyNonArray,
 		toInternal("anyrange"):         Unknown,

--- a/server/types/globals.go
+++ b/server/types/globals.go
@@ -203,7 +203,6 @@ func init() {
 		toInternal("any"):              Any,
 		toInternal("anyarray"):         AnyArray,
 		toInternal("anyelement"):       AnyElement,
-		toInternal("_anyelement"):      AnyArray,
 		toInternal("anyenum"):          AnyEnum,
 		toInternal("anynonarray"):      AnyNonArray,
 		toInternal("anyrange"):         Unknown,

--- a/server/types/type.go
+++ b/server/types/type.go
@@ -122,6 +122,19 @@ func NewUnresolvedDoltgresTypeFromID(idType id.Type) *DoltgresType {
 	}
 }
 
+// NewUnresolvedArrayDoltgresType returns an unresolved DoltgresType for an array of a user-defined element type.
+// TypCategory and Elem are pre-filled so that IsArrayType() returns true before full resolution from the type
+// collection. The array type ID follows the Postgres convention of "_" + element type name.
+func NewUnresolvedArrayDoltgresType(sch, elemName string) *DoltgresType {
+	return &DoltgresType{
+		ID:           id.NewType(sch, "_"+elemName),
+		IsUnresolved: true,
+		TypCategory:  TypeCategory_ArrayTypes,
+		Elem:         id.NewType(sch, elemName),
+		Array:        id.NullType,
+	}
+}
+
 // AnalyzeFuncName returns the name that would be displayed in pg_type for the `typanalyze` field.
 func (t *DoltgresType) AnalyzeFuncName() string {
 	return globalFunctionRegistry.GetString(t.AnalyzeFunc)
@@ -940,7 +953,11 @@ func (t *DoltgresType) ToArrayType() *DoltgresType {
 	}
 	arr, ok := IDToBuiltInDoltgresType[t.Array]
 	if !ok {
-		panic(fmt.Sprintf("cannot get array type from: %s", t.Name()))
+		if t.Array == id.NullType {
+			panic(fmt.Sprintf("cannot get array type from: %s", t.Name()))
+		}
+		// User-defined type: the array type is not in the built-in map, so build it from this base type.
+		return CreateArrayTypeFromBaseType(t)
 	}
 	newArr := *arr.WithAttTypMod(t.attTypMod)
 	newArr.InternalName = fmt.Sprintf("%s[]", t.String())

--- a/server/types/type.go
+++ b/server/types/type.go
@@ -129,7 +129,17 @@ func (t *DoltgresType) AnalyzeFuncName() string {
 
 // ArrayBaseType returns a base type of given array type.
 // If this type is not an array type, it returns itself.
+// Prefer using ArrayBaseTypeCtx() instead.
 func (t *DoltgresType) ArrayBaseType() *DoltgresType {
+	// TODO: Remove this method and rename ArrayBaseTypeCtx(ctx)
+	//       to ArrayBaseType(ctx) when all callers are migrated.
+	return t.ArrayBaseTypeCtx(nil)
+}
+
+// ArrayBaseTypeCtx returns the base type of an array type, using the context to resolve user-defined element types
+// that aren't in the built-in type map.
+// If this type is not an array type, it returns itself.
+func (t *DoltgresType) ArrayBaseTypeCtx(ctx *sql.Context) *DoltgresType {
 	if !t.IsArrayType() {
 		return t
 	}
@@ -139,10 +149,21 @@ func (t *DoltgresType) ArrayBaseType() *DoltgresType {
 
 	elem, ok = IDToBuiltInDoltgresType[t.Elem]
 	if !ok {
-		// Some array types have no declared element type for pg_catalog compatibilty, but still have a logical type
-		// we return for analysis
+		// Some array types have no declared element type for pg_catalog compatibility, but still have a logical type
+		// we return for analysis.
 		elem, ok = LogicalArrayElementTypes[t.ID]
 		if !ok {
+			if t.IsUnresolved && t.Elem != id.NullType {
+				return NewUnresolvedDoltgresType(t.Elem.SchemaName(), t.Elem.TypeName())
+			}
+			if ctx != nil && t.Elem != id.NullType && GetTypesCollectionFromContext != nil {
+				if typeColl, err := GetTypesCollectionFromContext(ctx); err == nil && typeColl != nil {
+					if elemType, err := typeColl.GetType(ctx, t.Elem); err == nil && elemType != nil {
+						newElem := *elemType.WithAttTypMod(t.attTypMod)
+						return &newElem
+					}
+				}
+			}
 			panic(fmt.Sprintf("cannot get base type from: %s", t.Name()))
 		}
 	}
@@ -351,7 +372,8 @@ func (t *DoltgresType) Compare(ctx context.Context, v1 interface{}, v2 interface
 		bb := v2.([]any)
 		minLength := utils.Min(len(ab), len(bb))
 		for i := 0; i < minLength; i++ {
-			res, err := t.ArrayBaseType().Compare(ctx, ab[i], bb[i])
+			sqlCtx, _ := ctx.(*sql.Context)
+			res, err := t.ArrayBaseTypeCtx(sqlCtx).Compare(ctx, ab[i], bb[i])
 			if err != nil {
 				return 0, err
 			}

--- a/server/types/type.go
+++ b/server/types/type.go
@@ -169,7 +169,7 @@ func (t *DoltgresType) ArrayBaseTypeCtx(ctx *sql.Context) *DoltgresType {
 			if t.IsUnresolved && t.Elem != id.NullType {
 				return NewUnresolvedDoltgresType(t.Elem.SchemaName(), t.Elem.TypeName())
 			}
-			if ctx != nil && t.Elem != id.NullType && GetTypesCollectionFromContext != nil {
+			if ctx != nil && t.Elem != id.NullType {
 				if typeColl, err := GetTypesCollectionFromContext(ctx); err == nil && typeColl != nil {
 					if elemType, err := typeColl.GetType(ctx, t.Elem); err == nil && elemType != nil {
 						newElem := *elemType.WithAttTypMod(t.attTypMod)

--- a/server/types/type.go
+++ b/server/types/type.go
@@ -627,6 +627,8 @@ func (t *DoltgresType) IoInput(ctx *sql.Context, input string) (any, error) {
 		}
 	} else if t.TypType == TypeType_Enum {
 		return globalFunctionRegistry.GetFunction(ctx, t.InputFunc).CallVariadic(ctx, input, t.ID.AsId())
+	} else if t.IsCompositeType() {
+		return ParseCompositeLiteral(ctx, input, t)
 	} else {
 		return globalFunctionRegistry.GetFunction(ctx, t.InputFunc).CallVariadic(ctx, input)
 	}
@@ -954,7 +956,10 @@ func (t *DoltgresType) ToArrayType() *DoltgresType {
 	arr, ok := IDToBuiltInDoltgresType[t.Array]
 	if !ok {
 		if t.Array == id.NullType {
-			panic(fmt.Sprintf("cannot get array type from: %s", t.Name()))
+			// Unresolved or stub type: derive an unresolved array type using the Postgres naming convention.
+			// The caller (e.g. during plan-building before the analyzer resolves types) will re-invoke
+			// ToArrayType on the fully-resolved base type once the analyzer has run.
+			return NewUnresolvedArrayDoltgresType(t.ID.SchemaName(), t.ID.TypeName())
 		}
 		// User-defined type: the array type is not in the built-in map, so build it from this base type.
 		return CreateArrayTypeFromBaseType(t)

--- a/server/types/utils.go
+++ b/server/types/utils.go
@@ -237,6 +237,116 @@ func VectorToString(ctx *sql.Context, arr []any, baseType *DoltgresType) (string
 	return sb.String(), nil
 }
 
+// ParseCompositeLiteral parses a Postgres composite literal string like "(1,2,hello)" into a slice
+// of RecordValues using the field types from |compositeType|.
+func ParseCompositeLiteral(ctx *sql.Context, input string, compositeType *DoltgresType) ([]RecordValue, error) {
+	if len(input) < 2 || input[0] != '(' || input[len(input)-1] != ')' {
+		return nil, cerrors.Errorf(`malformed composite literal: "%s"`, input)
+	}
+	inner := input[1 : len(input)-1]
+
+	attrs := compositeType.CompositeAttrs
+	if len(attrs) == 0 {
+		return []RecordValue{}, nil
+	}
+
+	fieldStrs, err := parseCompositeLiteralFields(inner)
+	if err != nil {
+		return nil, err
+	}
+	if len(fieldStrs) != len(attrs) {
+		return nil, cerrors.Errorf("composite literal has %d fields but type %s has %d",
+			len(fieldStrs), compositeType.ID.TypeName(), len(attrs))
+	}
+
+	values := make([]RecordValue, len(attrs))
+	for i, attr := range attrs {
+		var fieldType *DoltgresType
+		if t, ok := IDToBuiltInDoltgresType[attr.TypeID]; ok {
+			fieldType = t
+		} else if GetTypesCollectionFromContext != nil {
+			if typColl, tcErr := GetTypesCollectionFromContext(ctx); tcErr == nil && typColl != nil {
+				if t, gErr := typColl.GetType(ctx, attr.TypeID); gErr == nil && t != nil {
+					fieldType = t
+				}
+			}
+		}
+		if fieldType == nil {
+			return nil, cerrors.Errorf("cannot resolve field type %s for composite type %s",
+				attr.TypeID.TypeName(), compositeType.ID.TypeName())
+		}
+
+		if fieldStrs[i] == nil {
+			values[i] = RecordValue{Value: nil, Type: fieldType}
+		} else {
+			val, err := fieldType.IoInput(ctx, *fieldStrs[i])
+			if err != nil {
+				return nil, err
+			}
+			values[i] = RecordValue{Value: val, Type: fieldType}
+		}
+	}
+	return values, nil
+}
+
+// parseCompositeLiteralFields splits the inner part of a composite literal (with parens already
+// removed) into per-field string pointers. A nil pointer indicates a SQL NULL value.
+func parseCompositeLiteralFields(input string) ([]*string, error) {
+	if len(input) == 0 {
+		return []*string{}, nil
+	}
+	var fields []*string
+	i := 0
+	for {
+		if i >= len(input) {
+			fields = append(fields, nil)
+			break
+		}
+		if input[i] == '"' {
+			// Double-quoted field value
+			i++ // skip opening quote
+			var sb strings.Builder
+			for i < len(input) && input[i] != '"' {
+				if input[i] == '\\' && i+1 < len(input) {
+					i++
+					sb.WriteByte(input[i])
+				} else {
+					sb.WriteByte(input[i])
+				}
+				i++
+			}
+			if i >= len(input) {
+				return nil, cerrors.Errorf("unterminated quoted string in composite literal")
+			}
+			i++ // skip closing quote
+			s := sb.String()
+			fields = append(fields, &s)
+		} else {
+			// Unquoted field value — read until next comma
+			start := i
+			for i < len(input) && input[i] != ',' {
+				i++
+			}
+			fieldStr := input[start:i]
+			if fieldStr == "" || strings.EqualFold(fieldStr, "NULL") {
+				fields = append(fields, nil)
+			} else {
+				s := fieldStr
+				fields = append(fields, &s)
+			}
+		}
+
+		if i >= len(input) {
+			break
+		}
+		if input[i] != ',' {
+			return nil, cerrors.Errorf("expected ',' in composite literal, got '%c'", input[i])
+		}
+		i++ // skip comma
+	}
+	return fields, nil
+}
+
 // quoteString determines if |s| needs to be quoted, by looking for special characters like ' ' or ',',
 // and if so, quotes the string and returns it. If quoting is not needed, then |s| is returned as is.
 func quoteString(s string) string {

--- a/server/types/utils.go
+++ b/server/types/utils.go
@@ -264,7 +264,7 @@ func ParseCompositeLiteral(ctx *sql.Context, input string, compositeType *Doltgr
 		var fieldType *DoltgresType
 		if t, ok := IDToBuiltInDoltgresType[attr.TypeID]; ok {
 			fieldType = t
-		} else if GetTypesCollectionFromContext != nil {
+		} else {
 			if typColl, tcErr := GetTypesCollectionFromContext(ctx); tcErr == nil && typColl != nil {
 				if t, gErr := typColl.GetType(ctx, attr.TypeID); gErr == nil && t != nil {
 					fieldType = t

--- a/server/types/utils.go
+++ b/server/types/utils.go
@@ -69,9 +69,9 @@ type Cast interface {
 
 // CastsCollection is an interface from the core package, redeclared here to get around import cycles.
 type CastsCollection interface {
-	GetExplicitCast(ctx context.Context, sourceType *DoltgresType, targetType *DoltgresType) (Cast, error)
-	GetAssignmentCast(ctx context.Context, sourceType *DoltgresType, targetType *DoltgresType) (Cast, error)
-	GetImplicitCast(ctx context.Context, sourceType *DoltgresType, targetType *DoltgresType) (Cast, error)
+	GetExplicitCast(ctx *sql.Context, sourceType *DoltgresType, targetType *DoltgresType) (Cast, error)
+	GetAssignmentCast(ctx *sql.Context, sourceType *DoltgresType, targetType *DoltgresType) (Cast, error)
+	GetImplicitCast(ctx *sql.Context, sourceType *DoltgresType, targetType *DoltgresType) (Cast, error)
 }
 
 // GetTypesCollectionFromContext is a function from the core package, redeclared here to get around import cycles.
@@ -145,7 +145,7 @@ func serializedStringCompare(v1 []byte, v2 []byte) int {
 // with an exception to BOOLEAN type. It returns "t" instead of "true".
 func sqlString(ctx *sql.Context, t *DoltgresType, val any) (string, error) {
 	if t.IsArrayType() {
-		baseType := t.ArrayBaseType()
+		baseType := t.ArrayBaseTypeCtx(ctx)
 		return ArrToString(ctx, val.([]any), baseType, true)
 	} else if t.ID == Bool.ID {
 		if val.(bool) {

--- a/testing/go/create_function_sql_test.go
+++ b/testing/go/create_function_sql_test.go
@@ -410,5 +410,17 @@ func TestCreateFunctionsLanguageSQL(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "user-defined composite array parameter and return type",
+			SetUpScript: []string{
+				`CREATE TYPE aggtype AS (a integer, b integer, c text)`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `CREATE FUNCTION aggf_trans(aggtype[],integer,integer,text) RETURNS aggtype[] AS 'select array_append($1,ROW($2,$3,$4)::aggtype)' LANGUAGE sql STRICT IMMUTABLE`,
+					Expected: []sql.Row{},
+				},
+			},
+		},
 	})
 }

--- a/testing/go/create_function_sql_test.go
+++ b/testing/go/create_function_sql_test.go
@@ -420,6 +420,14 @@ func TestCreateFunctionsLanguageSQL(t *testing.T) {
 					Query:    `CREATE FUNCTION aggf_trans(aggtype[],integer,integer,text) RETURNS aggtype[] AS 'select array_append($1,ROW($2,$3,$4)::aggtype)' LANGUAGE sql STRICT IMMUTABLE`,
 					Expected: []sql.Row{},
 				},
+				{
+					Query:    `SELECT aggf_trans(ARRAY[]::aggtype[], 1, 2, 'hello')`,
+					Expected: []sql.Row{{`{"(1,2,hello)"}`}},
+				},
+				{
+					Query:    `SELECT aggf_trans(ARRAY[ROW(1,2,'hello')::aggtype], 3, 4, 'world')`,
+					Expected: []sql.Row{{`{"(1,2,hello)","(3,4,world)"}`}},
+				},
 			},
 		},
 	})

--- a/testing/go/domain_test.go
+++ b/testing/go/domain_test.go
@@ -273,6 +273,27 @@ func TestDomain(t *testing.T) {
 			},
 		},
 		{
+			Name: "domain array type column",
+			SetUpScript: []string{
+				`CREATE DOMAIN vc4 AS varchar(4);`,
+				`CREATE TABLE t (pk int primary key, v vc4[]);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `INSERT INTO t VALUES (1, array['ab', 'cd']::vc4[]);`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `INSERT INTO t VALUES (2, '{ef,gh}');`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT * FROM t ORDER BY pk;`,
+					Expected: []sql.Row{{1, "{ab,cd}"}, {2, "{ef,gh}"}},
+				},
+			},
+		},
+		{
 			Name: "explicit cast to domain type",
 			SetUpScript: []string{
 				`CREATE DOMAIN year_not_null AS integer NOT NULL CONSTRAINT year_check CHECK (((VALUE >= 1901) AND (VALUE <= 2155)));`,

--- a/testing/go/types_test.go
+++ b/testing/go/types_test.go
@@ -3913,6 +3913,27 @@ var enumTypeTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "enum array type column",
+		SetUpScript: []string{
+			`CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');`,
+			`CREATE TABLE t (pk int primary key, v mood[]);`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    `INSERT INTO t VALUES (1, array['sad', 'happy']::mood[]);`,
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    `INSERT INTO t VALUES (2, '{ok,sad}');`,
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    `SELECT * FROM t ORDER BY pk;`,
+				Expected: []sql.Row{{1, "{sad,happy}"}, {2, "{ok,sad}"}},
+			},
+		},
+	},
+	{
 		Skip: true,
 		Name: "create type with existing array type name updates the name of the array type",
 		Assertions: []ScriptTestAssertion{


### PR DESCRIPTION
Various bug fixes for regressions reported in PR https://github.com/dolthub/doltgresql/pull/2642, primarily related to resolving arrays of non-built-in types. The major change is adding `ctx` to the `ArrayBaseType()` method, but not all call sites could be updated, so unfortunately results in a new `ArrayBaseTypeCtx(ctx)` method until we can find a way to always provide a sql context and completely remove the old method form. 