### PR TITLE
properly flush results

### DIFF
--- a/server/connection_handler.go
+++ b/server/connection_handler.go
@@ -1027,7 +1027,6 @@ func (h *ConnectionHandler) spoolRowsCallback(query ConvertedQuery, rows *int32,
 		}
 		sess.ClearNotices()
 
-		// TODO: we should avoid flushing every single row every time
 		if returnsRow(query) {
 			// EXECUTE does not send RowDescription; instead it should be sent from DESCRIBE prior to it
 			if !isExecute && !hasSentRowDescription {
@@ -1036,6 +1035,7 @@ func (h *ConnectionHandler) spoolRowsCallback(query ConvertedQuery, rows *int32,
 					Fields: res.Fields,
 				})
 			}
+			// res.Rows should be length rowsBatch = 128
 			for _, row := range res.Rows {
 				h.backend.Send(&pgproto3.DataRow{
 					Values: row.val,

--- a/server/connection_handler.go
+++ b/server/connection_handler.go
@@ -1027,23 +1027,23 @@ func (h *ConnectionHandler) spoolRowsCallback(query ConvertedQuery, rows *int32,
 		}
 		sess.ClearNotices()
 
+		// TODO: we should avoid flushing every single row every time
 		if returnsRow(query) {
 			// EXECUTE does not send RowDescription; instead it should be sent from DESCRIBE prior to it
 			if !isExecute && !hasSentRowDescription {
 				hasSentRowDescription = true
-				if err := h.send(&pgproto3.RowDescription{
+				h.backend.Send(&pgproto3.RowDescription{
 					Fields: res.Fields,
-				}); err != nil {
-					return err
-				}
+				})
 			}
-
 			for _, row := range res.Rows {
-				if err := h.send(&pgproto3.DataRow{
+				h.backend.Send(&pgproto3.DataRow{
 					Values: row.val,
-				}); err != nil {
-					return err
-				}
+				})
+			}
+			err := h.backend.Flush()
+			if err != nil {
+				return err
 			}
 		}
 


### PR DESCRIPTION
Instead of flushing RowDescription and every RowData right away, have the entire Result buffer in memory first.