### PR TITLE
Add `DoltgresDatabaseProvider`

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -508,7 +508,7 @@ func updateSessionRootForDatabase(ctx *sql.Context, db string, cv *contextValues
 	// branch state dirty, and dolt only allows a single dirty working set per commit. So it's important here to only
 	// update the session root if something actually changed for that db.
 	if err, rootChanged := rootValueChanged(newRoot, root); rootChanged {
-		if err = session.SetWorkingRoot(ctx, ctx.GetCurrentDatabase(), newRoot); err != nil {
+		if err = session.SetWorkingRoot(ctx, db, newRoot); err != nil {
 			// TODO: We need a way to see if the session has a writeable working root
 			// (new interface method on session probably), and avoid setting it if so
 			if errors.Is(err, doltdb.ErrOperationNotSupportedInDetachedHead) {

--- a/core/sequences/collection.go
+++ b/core/sequences/collection.go
@@ -140,12 +140,12 @@ func (pgs *Collection) HasSequence(ctx context.Context, name id.Sequence) bool {
 func (pgs *Collection) CreateSequence(ctx context.Context, seq *Sequence) error {
 	// Ensure that the sequence does not already exist
 	if _, ok := pgs.accessedMap[seq.Id]; ok {
-		return errors.Errorf(`relation "%s" already exists`, seq.Id)
+		return errors.Errorf(`relation "%s" already exists`, seq.Id.SequenceName())
 	}
 	if ok, err := pgs.underlyingMap.Has(ctx, string(seq.Id)); err != nil {
 		return err
 	} else if ok {
-		return errors.Errorf(`relation "%s" already exists`, seq.Id)
+		return errors.Errorf(`relation "%s" already exists`, seq.Id.SequenceName())
 	}
 	// Add it to our cache, which will be emptied when we do anything permanent
 	pgs.accessedMap[seq.Id] = seq

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/cockroachdb/apd/v3 v3.2.3
 	github.com/cockroachdb/errors v1.7.5
-	github.com/dolthub/dolt/go v0.40.5-0.20260529182654-e75d21b12642
+	github.com/dolthub/dolt/go v0.40.5-0.20260529205203-4057ea35d93b
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.20.1-0.20260529165710-0c9baca7aa28
+	github.com/dolthub/go-mysql-server v0.20.1-0.20260529204403-6d1b298fbfe3
 	github.com/dolthub/pg_query_go/v6 v6.0.0-20251215122834-fb20be4254d1
 	github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216
 	github.com/dolthub/vitess v0.0.0-20260528164423-e3f9fa81284c

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/cockroachdb/apd/v3 v3.2.3
 	github.com/cockroachdb/errors v1.7.5
-	github.com/dolthub/dolt/go v0.40.5-0.20260529205203-4057ea35d93b
+	github.com/dolthub/dolt/go v0.40.5-0.20260601194813-789010e1ff49
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.20.1-0.20260529204403-6d1b298fbfe3
+	github.com/dolthub/go-mysql-server v0.20.1-0.20260601185611-f066a7510ce0
 	github.com/dolthub/pg_query_go/v6 v6.0.0-20251215122834-fb20be4254d1
 	github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216
 	github.com/dolthub/vitess v0.0.0-20260528164423-e3f9fa81284c

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP4
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
 github.com/dolthub/dolt/go v0.40.5-0.20260529182654-e75d21b12642 h1:mQOevOK6qtNRTTbteh6OxvusMsjPoMem1+KECjyI/C8=
 github.com/dolthub/dolt/go v0.40.5-0.20260529182654-e75d21b12642/go.mod h1:66b69RoXH4WVEn6akI8dS3CEYuD340u45Vvou8g36G0=
+github.com/dolthub/dolt/go v0.40.5-0.20260529205203-4057ea35d93b h1:iiPE8Uvs0jBoGvt+KFdm71gDquvEeSaX9hvJuUxKlJo=
+github.com/dolthub/dolt/go v0.40.5-0.20260529205203-4057ea35d93b/go.mod h1:oUiVP3Te0Iqxj4auo+DJmGBtUQ0inrwiwnm8M+WAMY4=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 h1:JShhbqMw26nKx3pqqu/cFxOpzBkN+4elVhzuUfgDw2k=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=
@@ -257,6 +259,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20260412212219-49724d547866 h1:U6gSf5I0e6
 github.com/dolthub/go-icu-regex v0.0.0-20260412212219-49724d547866/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260529165710-0c9baca7aa28 h1:7/u3ZCuzvCLF7u8oE3ZhdqhtXHnjXIf7fsdqevHa7ms=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260529165710-0c9baca7aa28/go.mod h1:UTL4UvG/y8PMBcI8I60gf0DH4YPBALW/8UQCcvft95Y=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260529204403-6d1b298fbfe3 h1:YQjGSg7fWpaoNGzsFfvevHYP0aHETm24IZnncsUg4Tc=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260529204403-6d1b298fbfe3/go.mod h1:UTL4UvG/y8PMBcI8I60gf0DH4YPBALW/8UQCcvft95Y=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20260414231531-5f031e3e9037 h1:oIW9HwuWrhxv+4HZxA+QQSKHLqWFyXZ2FmNjUYwkdiM=

--- a/go.sum
+++ b/go.sum
@@ -249,6 +249,8 @@ github.com/dolthub/dolt/go v0.40.5-0.20260529182654-e75d21b12642 h1:mQOevOK6qtNR
 github.com/dolthub/dolt/go v0.40.5-0.20260529182654-e75d21b12642/go.mod h1:66b69RoXH4WVEn6akI8dS3CEYuD340u45Vvou8g36G0=
 github.com/dolthub/dolt/go v0.40.5-0.20260529205203-4057ea35d93b h1:iiPE8Uvs0jBoGvt+KFdm71gDquvEeSaX9hvJuUxKlJo=
 github.com/dolthub/dolt/go v0.40.5-0.20260529205203-4057ea35d93b/go.mod h1:oUiVP3Te0Iqxj4auo+DJmGBtUQ0inrwiwnm8M+WAMY4=
+github.com/dolthub/dolt/go v0.40.5-0.20260601194813-789010e1ff49 h1:8JDMW2FLXtHqipXwkD8S8A6OrrfNoACD1yyv0TNGSsA=
+github.com/dolthub/dolt/go v0.40.5-0.20260601194813-789010e1ff49/go.mod h1:OM1or9afsCpgcuFwG/0uQNwMLE6kuyo8xt/DwqS9PPw=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69 h1:JShhbqMw26nKx3pqqu/cFxOpzBkN+4elVhzuUfgDw2k=
 github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=
@@ -261,6 +263,8 @@ github.com/dolthub/go-mysql-server v0.20.1-0.20260529165710-0c9baca7aa28 h1:7/u3
 github.com/dolthub/go-mysql-server v0.20.1-0.20260529165710-0c9baca7aa28/go.mod h1:UTL4UvG/y8PMBcI8I60gf0DH4YPBALW/8UQCcvft95Y=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260529204403-6d1b298fbfe3 h1:YQjGSg7fWpaoNGzsFfvevHYP0aHETm24IZnncsUg4Tc=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260529204403-6d1b298fbfe3/go.mod h1:UTL4UvG/y8PMBcI8I60gf0DH4YPBALW/8UQCcvft95Y=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260601185611-f066a7510ce0 h1:ne6ZbpCqCCvB4Maw1R5yo8zLaqgfUiQA3FacMynIzSk=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260601185611-f066a7510ce0/go.mod h1:UTL4UvG/y8PMBcI8I60gf0DH4YPBALW/8UQCcvft95Y=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20260414231531-5f031e3e9037 h1:oIW9HwuWrhxv+4HZxA+QQSKHLqWFyXZ2FmNjUYwkdiM=

--- a/server/functions/iterate.go
+++ b/server/functions/iterate.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dolthub/doltgresql/core/id"
 	"github.com/dolthub/doltgresql/core/sequences"
 	"github.com/dolthub/doltgresql/core/typecollection"
+	"github.com/dolthub/doltgresql/server/tables"
 	"github.com/dolthub/doltgresql/server/types"
 )
 
@@ -129,6 +130,8 @@ func IterateDatabase(ctx *sql.Context, database string, callbacks Callbacks) err
 	if err != nil {
 		return err
 	}
+	// TODO: Consider overriding Provider.Database() to always wrap the returned db
+	currentDatabase = tables.WrapSqlDatabase(currentDatabase)
 
 	// Then we'll iterate over everything that is contained within a schema
 	if currentSchemaDatabase, ok := currentDatabase.(sql.SchemaDatabase); ok && callbacks.iteratesOverSchemas() {
@@ -482,6 +485,7 @@ func RunCallback(ctx *sql.Context, internalID id.Id, callbacks Callbacks) error 
 	if err != nil {
 		return err
 	}
+	currentDatabase = tables.WrapSqlDatabase(currentDatabase)
 
 	if currentSchemaDatabase, ok := currentDatabase.(sql.SchemaDatabase); ok {
 		schemas, err := currentSchemaDatabase.AllSchemas(ctx)

--- a/server/node/create_sequence.go
+++ b/server/node/create_sequence.go
@@ -98,19 +98,13 @@ func (c *CreateSequence) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, erro
 			if schemaDb, found, dbErr := pgDb.GetSchema(ctx, schema); dbErr != nil {
 				return nil, dbErr
 			} else if found {
-				if v, ok := schemaDb.(sql.RelationNameValidator); ok {
-					exists, relationType, dbErr := v.DoesRelationExist(ctx, c.sequence.Id.SequenceName())
-					if dbErr != nil {
-						return nil, dbErr
-					}
-
-					if exists {
-						if c.ifNotExists && relationType == "sequence" {
+				if v, ok := schemaDb.(sql.SchemaObjectNameValidator); ok {
+					alreadyExists, err := v.ValidateNewSequenceName(ctx, c.sequence.Id.SequenceName())
+					if err != nil {
+						if alreadyExists && c.ifNotExists {
 							return sql.RowsToRowIter(), nil
-						} else {
-							return nil, fmt.Errorf(`relation "%s" already exists as a %s`,
-								c.sequence.Id.SequenceName(), relationType)
 						}
+						return nil, err
 					}
 				}
 			} else if !found {

--- a/server/node/create_sequence.go
+++ b/server/node/create_sequence.go
@@ -99,12 +99,11 @@ func (c *CreateSequence) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, erro
 				return nil, dbErr
 			} else if found {
 				if v, ok := schemaDb.(sql.SchemaObjectNameValidator); ok {
-					alreadyExists, err := v.ValidateNewSequenceName(ctx, c.sequence.Id.SequenceName())
+					nameAlreadyUsed, err := v.ValidateNewSequenceName(ctx, c.sequence.Id.SequenceName(), c.ifNotExists)
 					if err != nil {
-						if alreadyExists && c.ifNotExists {
-							return sql.RowsToRowIter(), nil
-						}
 						return nil, err
+					} else if nameAlreadyUsed && c.ifNotExists {
+						return sql.RowsToRowIter(), nil
 					}
 				}
 			} else if !found {

--- a/server/node/create_sequence.go
+++ b/server/node/create_sequence.go
@@ -16,6 +16,7 @@ package node
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"strings"
 
@@ -31,6 +32,7 @@ import (
 	"github.com/dolthub/doltgresql/core/sequences"
 	pgexprs "github.com/dolthub/doltgresql/server/expression"
 	"github.com/dolthub/doltgresql/server/functions/framework"
+	"github.com/dolthub/doltgresql/server/tables"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
@@ -82,17 +84,39 @@ func (c *CreateSequence) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, erro
 	// The sequence won't have the schema filled in, so we have to do that now
 	c.sequence.Id = id.NewSequence(schema, c.sequence.Id.SequenceName())
 
-	// Check that the sequence name is free
-	relationType, err := core.GetRelationType(ctx, schema, c.sequence.Id.SequenceName())
+	// Check that the sequence name is free across all relation types (tables, sequences, views, indexes).
+	// GetSqlDatabaseFromContext returns a plain sqle.Database (not a PgDatabase), so we wrap it
+	// with tables.WrapSqleDatabase before calling GetSchema so that ValidateNewRelationName is available.
+	// TODO: Consider always wrapping the returned db from GetSqlDatabaseFromContext()
+	rawDb, err := core.GetSqlDatabaseFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}
-	if relationType != core.RelationType_DoesNotExist && c.ifNotExists {
-		if c.ifNotExists {
-			// TODO: issue a notice
-			return sql.RowsToRowIter(), nil
+	if rawDb != nil {
+		if sdb, ok := rawDb.(sqle.Database); ok {
+			pgDb := tables.WrapSqleDatabase(sdb)
+			if schemaDb, found, dbErr := pgDb.GetSchema(ctx, schema); dbErr != nil {
+				return nil, dbErr
+			} else if found {
+				if v, ok := schemaDb.(sql.RelationNameValidator); ok {
+					exists, relationType, dbErr := v.DoesRelationExist(ctx, c.sequence.Id.SequenceName())
+					if dbErr != nil {
+						return nil, dbErr
+					}
+
+					if exists {
+						if c.ifNotExists && relationType == "sequence" {
+							return sql.RowsToRowIter(), nil
+						} else {
+							return nil, fmt.Errorf(`relation "%s" already exists as a %s`,
+								c.sequence.Id.SequenceName(), relationType)
+						}
+					}
+				}
+			} else if !found {
+				return nil, fmt.Errorf(`schema "%s" not found`, schema)
+			}
 		}
-		return nil, errors.Errorf(`relation "%s" already exists`, c.sequence.Id)
 	}
 	// Check that the OWNED BY is valid, if it exists
 	var table sql.Table
@@ -101,7 +125,7 @@ func (c *CreateSequence) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, erro
 	if c.sequence.OwnerTable.IsValid() {
 		// The table will only have its name set, so we need to fill in the schema as well
 		c.sequence.OwnerTable = id.NewTable(schema, c.sequence.OwnerTable.TableName())
-		relationType, err = core.GetRelationType(ctx, schema, c.sequence.OwnerTable.TableName())
+		relationType, err := core.GetRelationType(ctx, schema, c.sequence.OwnerTable.TableName())
 		if err != nil {
 			return nil, err
 		}

--- a/server/pg_provider.go
+++ b/server/pg_provider.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/tables"
+)
+
+// DoltgresDatabaseProvider wraps DoltDatabaseProvider to enforce PostgreSQL specific
+// requirements, such as requiring all relation names (e.g. tables, indexes, sequences, views)
+// are unique within a schema.
+type DoltgresDatabaseProvider struct {
+	*sqle.DoltDatabaseProvider
+}
+
+var _ sql.DatabaseProvider = (*DoltgresDatabaseProvider)(nil)
+
+// Database overrides DoltDatabaseProvider.Database to wrap the returned sql.Database
+// with PgDatabase, enabling relation-name uniqueness enforcement.
+func (p *DoltgresDatabaseProvider) Database(ctx *sql.Context, name string) (sql.Database, error) {
+	db, err := p.DoltDatabaseProvider.Database(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return tables.WrapSqlDatabase(db), nil
+}
+
+// AllDatabases overrides DoltDatabaseProvider.AllDatabases to wrap each returned database
+// with PgDatabase so that AllSchemas returns properly wrapped schemas (including pg_catalog
+// virtual-table schemas) regardless of which code path iterates the catalog.
+func (p *DoltgresDatabaseProvider) AllDatabases(ctx *sql.Context) []sql.Database {
+	all := p.DoltDatabaseProvider.AllDatabases(ctx)
+	for i, db := range all {
+		all[i] = tables.WrapSqlDatabase(db)
+	}
+	return all
+}
+
+// UnderlyingDoltProvider implements sqle.DoltProviderUnwrapper so that NewSqlEngine can
+// access the wrapped *DoltDatabaseProvider for Dolt-specific configuration.
+func (p *DoltgresDatabaseProvider) UnderlyingDoltProvider() *sqle.DoltDatabaseProvider {
+	return p.DoltDatabaseProvider
+}
+
+// DoltgresProviderFactory is the ProviderFactory for Doltgres. It embeds DoltProviderFactory
+// and overrides NewProvider to wrap the result in DoltgresDatabaseProvider, so that
+// Database() returns PgDatabase-wrapped databases enforcing PostgreSQL relation-name uniqueness.
+type DoltgresProviderFactory struct {
+	sqle.DoltProviderFactory
+}
+
+var _ sqle.ProviderFactory = DoltgresProviderFactory{}
+
+// NewProvider overrides DoltProviderFactory.NewProvider to wrap the created provider in
+// DoltgresDatabaseProvider before returning it.
+func (f DoltgresProviderFactory) NewProvider(defaultBranch string, fs filesys.Filesys, databases []dsess.SqlDatabase, locations []filesys.Filesys, overrides sql.EngineOverrides) (sql.DatabaseProvider, error) {
+	inner, err := f.DoltProviderFactory.NewProvider(defaultBranch, fs, databases, locations, overrides)
+	if err != nil {
+		return nil, err
+	}
+	return &DoltgresDatabaseProvider{inner.(*sqle.DoltDatabaseProvider)}, nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -170,6 +170,7 @@ func runServer(ctx context.Context, cfg *servercfg.DoltgresConfig, dEnv *env.Dol
 		Controller:              controller,
 		DoltEnv:                 dEnv,
 		ProtocolListenerFactory: protocolListenerFactory,
+		ProviderFactory:         DoltgresProviderFactory{},
 	})
 	go controller.Start(newCtx)
 

--- a/server/tables/information_schema/databases.go
+++ b/server/tables/information_schema/databases.go
@@ -30,10 +30,11 @@ func allDatabasesWithNames(ctx *sql.Context, cat sql.Catalog, privCheck bool) ([
 
 	allDbs := cat.AllDatabases(ctx)
 	for _, db := range allDbs {
-		if privCheck {
-			if privDatabase, ok := db.(mysql_db.PrivilegedDatabase); ok {
-				db = privDatabase.Unwrap()
-			}
+		// Always unwrap PrivilegedDatabase to reach the underlying SchemaDatabase implementation.
+		// PrivilegedDatabase does not implement sql.SchemaDatabase; unwrapping is required for
+		// schema iteration regardless of privilege-check mode.
+		if privDatabase, ok := db.(mysql_db.PrivilegedDatabase); ok {
+			db = privDatabase.Unwrap()
 		}
 
 		sdb, ok := db.(sql.SchemaDatabase)

--- a/server/tables/init.go
+++ b/server/tables/init.go
@@ -16,19 +16,11 @@ package tables
 
 import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
-	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
-	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/core"
 )
 
 // Init handles initialization of all Postgres-specific and Doltgres-specific tables.
 func Init() {
-	sqle.HandleSchema = func(ctx *sql.Context, schemaName string, db sqle.Database) (sql.DatabaseSchema, error) {
-		if _, ok := handlers[schemaName]; ok {
-			return Database{db}, nil
-		}
-		return db, nil
-	}
 	doltdb.IsValidIdentifier = core.IsValidPostgresIdentifier
 }

--- a/server/tables/pg_database.go
+++ b/server/tables/pg_database.go
@@ -259,7 +259,9 @@ func (d *PgDatabase) ValidateNewTableName(ctx *sql.Context, newTableName string,
 	return true, fmt.Errorf(`relation "%s" already exists`, newTableName)
 }
 
-// doesRelationExist implements the sql.SchemaObjectNameValidator interface
+// doesRelationExist tests if a relation with the specified |name| exists in this database. If any relation with that
+// name exists, this function returns true for |exists|, the relation type (e.g. index, view, table, sequence) for
+// |relationType|. If any problems are encountered looking up a relation, an error is returned in |err|.
 func (d *PgDatabase) doesRelationExist(ctx *sql.Context, name string) (exists bool, relationType string, err error) {
 	lowerName := strings.ToLower(name)
 

--- a/server/tables/pg_database.go
+++ b/server/tables/pg_database.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/resolve"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/core"
@@ -45,14 +46,7 @@ var _ sql.DatabaseSchema = &PgReadOnlyDatabase{}
 var _ sql.SchemaDatabase = &PgReadOnlyDatabase{}
 
 // WrapSqleDatabase creates a PgDatabase from a sqle.Database.
-// SchemaWrap is set on the embedded database so that internal sqle.Database methods
-// (e.g. checkForPgCatalogTable) that call db.GetSchema directly use the same wrapping
-// logic as PgDatabase.GetSchema. Without this, those internal calls would return raw
-// sqle.Database objects that cannot serve virtual tables.
 func WrapSqleDatabase(db sqle.Database) *PgDatabase {
-	db.SchemaWrap = func(requestedName string, sdb sqle.Database) sql.DatabaseSchema {
-		return applySchemaWrap(requestedName, sdb)
-	}
 	return &PgDatabase{db}
 }
 
@@ -61,9 +55,6 @@ func WrapSqleDatabase(db sqle.Database) *PgDatabase {
 // assertion does not match it; this function handles both cases.
 func WrapSqlDatabase(db sql.Database) sql.Database {
 	if rodb, ok := db.(sqle.ReadOnlyDatabase); ok {
-		rodb.Database.SchemaWrap = func(requestedName string, sdb sqle.Database) sql.DatabaseSchema {
-			return applySchemaWrap(requestedName, sdb)
-		}
 		return &PgReadOnlyDatabase{rodb}
 	}
 	if sdb, ok := db.(sqle.Database); ok {
@@ -108,6 +99,47 @@ func (d *PgDatabase) GetSchema(ctx *sql.Context, schemaName string) (sql.Databas
 	return applySchemaWrap(schemaName, schema), true, nil
 }
 
+// GetTableInsensitive overrides sqle.Database.GetTableInsensitive to check the pg_catalog
+// virtual schema before falling back to user tables.
+func (d *PgDatabase) GetTableInsensitive(ctx *sql.Context, tblName string) (sql.Table, bool, error) {
+	if resolve.UseSearchPath && d.Database.Schema() == "" && strings.HasPrefix(strings.ToLower(tblName), "pg_") {
+		sdb, found, err := d.GetSchema(ctx, "pg_catalog")
+		if err != nil {
+			return nil, false, err
+		}
+		if found {
+			tbl, foundTbl, err := sdb.GetTableInsensitive(ctx, tblName)
+			if err != nil {
+				return nil, false, err
+			}
+			if foundTbl {
+				return tbl, true, nil
+			}
+		}
+	}
+	return d.Database.GetTableInsensitive(ctx, tblName)
+}
+
+// DropTable overrides sqle.Database.DropTable to prevent dropping virtual pg_catalog tables.
+func (d *PgDatabase) DropTable(ctx *sql.Context, tableName string) error {
+	if resolve.UseSearchPath && d.Database.Schema() == "" && strings.HasPrefix(strings.ToLower(tableName), "pg_") {
+		sdb, found, err := d.GetSchema(ctx, "pg_catalog")
+		if err != nil {
+			return err
+		}
+		if found {
+			_, foundTbl, err := sdb.GetTableInsensitive(ctx, tableName)
+			if err != nil {
+				return err
+			}
+			if foundTbl {
+				return sql.ErrDropTableNotSupported.New("pg_catalog")
+			}
+		}
+	}
+	return d.Database.DropTable(ctx, tableName)
+}
+
 // AllSchemas overrides sqle.ReadOnlyDatabase.AllSchemas to apply Doltgres schema wrapping.
 func (d *PgReadOnlyDatabase) AllSchemas(ctx *sql.Context) ([]sql.DatabaseSchema, error) {
 	schemas, err := d.ReadOnlyDatabase.AllSchemas(ctx)
@@ -127,6 +159,27 @@ func (d *PgReadOnlyDatabase) GetSchema(ctx *sql.Context, schemaName string) (sql
 		return schema, ok, err
 	}
 	return applySchemaWrap(schemaName, schema), true, nil
+}
+
+// GetTableInsensitive overrides sqle.Database.GetTableInsensitive to check the pg_catalog
+// virtual schema before falling back to user tables.
+func (d *PgReadOnlyDatabase) GetTableInsensitive(ctx *sql.Context, tblName string) (sql.Table, bool, error) {
+	if resolve.UseSearchPath && d.ReadOnlyDatabase.Schema() == "" && strings.HasPrefix(strings.ToLower(tblName), "pg_") {
+		sdb, found, err := d.GetSchema(ctx, "pg_catalog")
+		if err != nil {
+			return nil, false, err
+		}
+		if found {
+			tbl, foundTbl, err := sdb.GetTableInsensitive(ctx, tblName)
+			if err != nil {
+				return nil, false, err
+			}
+			if foundTbl {
+				return tbl, true, nil
+			}
+		}
+	}
+	return d.ReadOnlyDatabase.GetTableInsensitive(ctx, tblName)
 }
 
 // ValidateNewIndexName implements the sql.SchemaObjectNameValidator interface

--- a/server/tables/pg_database.go
+++ b/server/tables/pg_database.go
@@ -15,6 +15,7 @@
 package tables
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
@@ -31,7 +32,7 @@ type PgDatabase struct {
 
 var _ sql.DatabaseSchema = &PgDatabase{}
 var _ sql.SchemaDatabase = &PgDatabase{}
-var _ sql.RelationNameValidator = &PgDatabase{}
+var _ sql.SchemaObjectNameValidator = &PgDatabase{}
 
 // PgReadOnlyDatabase is the read-only variant of PgDatabase, used for revision databases
 // such as "postgres/main" returned by sqle.DoltDatabaseProvider for detached-HEAD sessions.
@@ -128,8 +129,63 @@ func (d *PgReadOnlyDatabase) GetSchema(ctx *sql.Context, schemaName string) (sql
 	return applySchemaWrap(schemaName, schema), true, nil
 }
 
-// DoesRelationExist implements the sql.RelationNameValidator interface
-func (d *PgDatabase) DoesRelationExist(ctx *sql.Context, name string) (exists bool, relationType string, err error) {
+// ValidateNewIndexName implements the sql.SchemaObjectNameValidator interface
+func (d *PgDatabase) ValidateNewIndexName(ctx *sql.Context, newIndexName string) (bool, error) {
+	// TODO: Do we need to pass in the schema as well? It won't always be the current schema, right? But that
+	//       will be encoded in the database already, right?
+	exists, relationType, err := d.doesRelationExist(ctx, newIndexName)
+	if err != nil {
+		return false, err
+	}
+
+	if !exists {
+		return false, nil
+	}
+
+	return relationType == "index", fmt.Errorf(`relation "%s" already exists`, newIndexName)
+}
+
+func (d *PgDatabase) ValidateNewSequenceName(ctx *sql.Context, newSequenceName string) (bool, error) {
+	exists, relationType, err := d.doesRelationExist(ctx, newSequenceName)
+	if err != nil {
+		return false, err
+	}
+
+	if !exists {
+		return false, nil
+	}
+
+	return relationType == "sequence", fmt.Errorf(`relation "%s" already exists`, newSequenceName)
+}
+
+func (d *PgDatabase) ValidateNewViewName(ctx *sql.Context, newViewName string) (bool, error) {
+	exists, relationType, err := d.doesRelationExist(ctx, newViewName)
+	if err != nil {
+		return false, err
+	}
+
+	if !exists {
+		return false, nil
+	}
+
+	return relationType == "view", fmt.Errorf(`relation "%s" already exists`, newViewName)
+}
+
+func (d *PgDatabase) ValidateNewTableName(ctx *sql.Context, newTableName string) (bool, error) {
+	exists, relationType, err := d.doesRelationExist(ctx, newTableName)
+	if err != nil {
+		return false, err
+	}
+
+	if !exists {
+		return false, nil
+	}
+
+	return relationType == "table", fmt.Errorf(`relation "%s" already exists`, newTableName)
+}
+
+// doesRelationExist implements the sql.SchemaObjectNameValidator interface
+func (d *PgDatabase) doesRelationExist(ctx *sql.Context, name string) (exists bool, relationType string, err error) {
 	lowerName := strings.ToLower(name)
 
 	// Resolve the effective schema: when the database was obtained without a schema qualifier

--- a/server/tables/pg_database.go
+++ b/server/tables/pg_database.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tables
+
+import (
+	"strings"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle"
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/core"
+	"github.com/dolthub/doltgresql/core/id"
+)
+
+// PgDatabase wraps a sqle.Database to add PostgreSQL-specific behavior.
+type PgDatabase struct {
+	sqle.Database
+}
+
+var _ sql.DatabaseSchema = &PgDatabase{}
+var _ sql.SchemaDatabase = &PgDatabase{}
+var _ sql.RelationNameValidator = &PgDatabase{}
+
+// PgReadOnlyDatabase is the read-only variant of PgDatabase, used for revision databases
+// such as "postgres/main" returned by sqle.DoltDatabaseProvider for detached-HEAD sessions.
+// It applies the same schema-wrapping logic as PgDatabase.
+type PgReadOnlyDatabase struct {
+	sqle.ReadOnlyDatabase
+}
+
+var _ sql.DatabaseSchema = &PgReadOnlyDatabase{}
+var _ sql.SchemaDatabase = &PgReadOnlyDatabase{}
+
+// WrapSqleDatabase creates a PgDatabase from a sqle.Database.
+// SchemaWrap is set on the embedded database so that internal sqle.Database methods
+// (e.g. checkForPgCatalogTable) that call db.GetSchema directly use the same wrapping
+// logic as PgDatabase.GetSchema. Without this, those internal calls would return raw
+// sqle.Database objects that cannot serve virtual tables.
+func WrapSqleDatabase(db sqle.Database) *PgDatabase {
+	db.SchemaWrap = func(requestedName string, sdb sqle.Database) sql.DatabaseSchema {
+		return applySchemaWrap(requestedName, sdb)
+	}
+	return &PgDatabase{db}
+}
+
+// WrapSqlDatabase wraps any Dolt database variant as a Pg-aware database.
+// ReadOnlyDatabase embeds sqle.Database by value, so a plain sqle.Database type
+// assertion does not match it; this function handles both cases.
+func WrapSqlDatabase(db sql.Database) sql.Database {
+	if rodb, ok := db.(sqle.ReadOnlyDatabase); ok {
+		rodb.Database.SchemaWrap = func(requestedName string, sdb sqle.Database) sql.DatabaseSchema {
+			return applySchemaWrap(requestedName, sdb)
+		}
+		return &PgReadOnlyDatabase{rodb}
+	}
+	if sdb, ok := db.(sqle.Database); ok {
+		return WrapSqleDatabase(sdb)
+	}
+	return db
+}
+
+// applySchemaWrap wraps a single schema returned by the underlying sqle.Database methods.
+// System schemas (those with registered virtual-table handlers) get a Database wrapper
+// that exposes only virtual tables; all others get a PgDatabase wrapper.
+func applySchemaWrap(requestedName string, schema sql.DatabaseSchema) sql.DatabaseSchema {
+	sdb, ok := schema.(sqle.Database)
+	if !ok {
+		// information_schema and any other non-sqle schema: leave as-is.
+		return schema
+	}
+	if _, isSystem := handlers[requestedName]; isSystem {
+		return Database{sdb}
+	}
+	return &PgDatabase{sdb}
+}
+
+// AllSchemas overrides sqle.Database.AllSchemas to apply Doltgres schema wrapping.
+func (d *PgDatabase) AllSchemas(ctx *sql.Context) ([]sql.DatabaseSchema, error) {
+	schemas, err := d.Database.AllSchemas(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i, s := range schemas {
+		schemas[i] = applySchemaWrap(s.SchemaName(), s)
+	}
+	return schemas, nil
+}
+
+// GetSchema overrides sqle.Database.GetSchema to apply Doltgres schema wrapping.
+func (d *PgDatabase) GetSchema(ctx *sql.Context, schemaName string) (sql.DatabaseSchema, bool, error) {
+	schema, ok, err := d.Database.GetSchema(ctx, schemaName)
+	if !ok || err != nil {
+		return schema, ok, err
+	}
+	return applySchemaWrap(schemaName, schema), true, nil
+}
+
+// AllSchemas overrides sqle.ReadOnlyDatabase.AllSchemas to apply Doltgres schema wrapping.
+func (d *PgReadOnlyDatabase) AllSchemas(ctx *sql.Context) ([]sql.DatabaseSchema, error) {
+	schemas, err := d.ReadOnlyDatabase.AllSchemas(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i, s := range schemas {
+		schemas[i] = applySchemaWrap(s.SchemaName(), s)
+	}
+	return schemas, nil
+}
+
+// GetSchema overrides sqle.ReadOnlyDatabase.GetSchema to apply Doltgres schema wrapping.
+func (d *PgReadOnlyDatabase) GetSchema(ctx *sql.Context, schemaName string) (sql.DatabaseSchema, bool, error) {
+	schema, ok, err := d.ReadOnlyDatabase.GetSchema(ctx, schemaName)
+	if !ok || err != nil {
+		return schema, ok, err
+	}
+	return applySchemaWrap(schemaName, schema), true, nil
+}
+
+// DoesRelationExist implements the sql.RelationNameValidator interface
+func (d *PgDatabase) DoesRelationExist(ctx *sql.Context, name string) (exists bool, relationType string, err error) {
+	lowerName := strings.ToLower(name)
+
+	// Resolve the effective schema: when the database was obtained without a schema qualifier
+	// (e.g. from GMS's plan builder for CREATE INDEX), schemaName is "" and we must fall back to
+	// the session's current schema so that sequence/view checks use the right namespace.
+	schema := d.Database.Schema()
+	if schema == "" {
+		var err error
+		schema, err = core.GetCurrentSchema(ctx)
+		if err != nil || schema == "" {
+			schema = "public"
+		}
+	}
+
+	// Tables: use GetTableNames which reads the session's working root directly.
+	tableNames, err := d.Database.GetTableNames(ctx)
+	if err != nil {
+		return false, "", err
+	}
+	for _, tableName := range tableNames {
+		if strings.ToLower(tableName) == lowerName {
+			return true, "table", nil
+		}
+	}
+
+	// Sequences: use the session-cached collection so uncommitted sequences are visible.
+	seqCollection, err := core.GetSequencesCollectionFromContext(ctx, d.Database.Name())
+	if err != nil {
+		return false, "", err
+	}
+	if seqCollection.HasSequence(ctx, id.NewSequence(schema, name)) {
+		return true, "sequence", nil
+	}
+
+	// Views: sqle.Database implements sql.ViewDatabase, so call AllViews directly.
+	views, err := d.Database.AllViews(ctx)
+	if err != nil {
+		return false, "", err
+	}
+	for _, view := range views {
+		if strings.ToLower(view.Name) == lowerName {
+			return true, "view", nil
+		}
+	}
+
+	// Indexes are per-table; reuse the tableNames slice from the table check above.
+	for _, tableName := range tableNames {
+		tbl, ok, err := d.Database.GetTableInsensitive(ctx, tableName)
+		if err != nil {
+			return false, "", err
+		}
+		if !ok {
+			continue
+		}
+		idxTbl, ok := tbl.(sql.IndexAddressableTable)
+		if !ok {
+			continue
+		}
+		indexes, err := idxTbl.GetIndexes(ctx)
+		if err != nil {
+			return false, "", err
+		}
+		for _, idx := range indexes {
+			if strings.ToLower(idx.ID()) == lowerName {
+				return true, "index", nil
+			}
+		}
+	}
+
+	return false, "", nil
+}

--- a/server/tables/pg_database.go
+++ b/server/tables/pg_database.go
@@ -130,58 +130,80 @@ func (d *PgReadOnlyDatabase) GetSchema(ctx *sql.Context, schemaName string) (sql
 }
 
 // ValidateNewIndexName implements the sql.SchemaObjectNameValidator interface
-func (d *PgDatabase) ValidateNewIndexName(ctx *sql.Context, newIndexName string) (bool, error) {
-	// TODO: Do we need to pass in the schema as well? It won't always be the current schema, right? But that
-	//       will be encoded in the database already, right?
-	exists, relationType, err := d.doesRelationExist(ctx, newIndexName)
+func (d *PgDatabase) ValidateNewIndexName(ctx *sql.Context, newIndexName string, skipIfExists bool) (nameAlreadyUsed bool, err error) {
+	nameAlreadyUsed, _, err = d.doesRelationExist(ctx, newIndexName)
 	if err != nil {
 		return false, err
 	}
 
-	if !exists {
+	if !nameAlreadyUsed {
 		return false, nil
 	}
 
-	return relationType == "index", fmt.Errorf(`relation "%s" already exists`, newIndexName)
+	if skipIfExists {
+		return true, nil
+	}
+
+	return nameAlreadyUsed, fmt.Errorf(`relation "%s" already exists`, newIndexName)
 }
 
-func (d *PgDatabase) ValidateNewSequenceName(ctx *sql.Context, newSequenceName string) (bool, error) {
-	exists, relationType, err := d.doesRelationExist(ctx, newSequenceName)
+// ValidateNewSequenceName implements the sql.SchemaObjectNameValidator interface
+func (d *PgDatabase) ValidateNewSequenceName(ctx *sql.Context, newSequenceName string, skipIfExists bool) (nameAlreadyUsed bool, err error) {
+	nameAlreadyUsed, _, err = d.doesRelationExist(ctx, newSequenceName)
 	if err != nil {
 		return false, err
 	}
 
-	if !exists {
+	if !nameAlreadyUsed {
 		return false, nil
 	}
 
-	return relationType == "sequence", fmt.Errorf(`relation "%s" already exists`, newSequenceName)
+	if skipIfExists {
+		return true, nil
+	}
+
+	return nameAlreadyUsed, fmt.Errorf(`relation "%s" already exists`, newSequenceName)
 }
 
-func (d *PgDatabase) ValidateNewViewName(ctx *sql.Context, newViewName string) (bool, error) {
-	exists, relationType, err := d.doesRelationExist(ctx, newViewName)
+// ValidateNewViewName implements the sql.SchemaObjectNameValidator interface
+func (d *PgDatabase) ValidateNewViewName(ctx *sql.Context, newViewName string, replaceAllowed bool) error {
+	relationExists, relationType, err := d.doesRelationExist(ctx, newViewName)
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	if !exists {
-		return false, nil
+	if !relationExists {
+		return nil
 	}
 
-	return relationType == "view", fmt.Errorf(`relation "%s" already exists`, newViewName)
+	// When REPLACE is used, Postgres sends a different error message
+	if replaceAllowed {
+		if relationType == "view" {
+			return nil
+		} else {
+			return fmt.Errorf(`"%s" is not a view`, newViewName)
+		}
+	}
+
+	return fmt.Errorf(`relation "%s" already exists`, newViewName)
 }
 
-func (d *PgDatabase) ValidateNewTableName(ctx *sql.Context, newTableName string) (bool, error) {
-	exists, relationType, err := d.doesRelationExist(ctx, newTableName)
+// ValidateNewTableName implements the sql.SchemaObjectNameValidator interface
+func (d *PgDatabase) ValidateNewTableName(ctx *sql.Context, newTableName string, skipIfExists bool) (nameAlreadyUsed bool, err error) {
+	relationExists, _, err := d.doesRelationExist(ctx, newTableName)
 	if err != nil {
 		return false, err
 	}
 
-	if !exists {
+	if !relationExists {
 		return false, nil
 	}
 
-	return relationType == "table", fmt.Errorf(`relation "%s" already exists`, newTableName)
+	if skipIfExists {
+		return true, nil
+	}
+
+	return true, fmt.Errorf(`relation "%s" already exists`, newTableName)
 }
 
 // doesRelationExist implements the sql.SchemaObjectNameValidator interface

--- a/testing/go/create_table_test.go
+++ b/testing/go/create_table_test.go
@@ -431,6 +431,49 @@ func TestCreateTable(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "Table names must be unique across all relation types",
+			SetUpScript: []string{
+				"CREATE TABLE existing_tbl (pk int PRIMARY KEY, v1 int);",
+				"CREATE SEQUENCE seq1;",
+				"CREATE VIEW view1 AS SELECT pk FROM existing_tbl;",
+				"CREATE INDEX idx1 ON existing_tbl (v1);",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:       "CREATE TABLE existing_tbl (c1 int);",
+					ExpectedErr: `relation "existing_tbl" already exists`,
+				},
+				{
+					Query:    "CREATE TABLE IF NOT EXISTS existing_tbl (c1 int);",
+					Expected: []sql.Row{},
+				},
+				{
+					Query:       "CREATE TABLE seq1 (c1 int);",
+					ExpectedErr: `relation "seq1" already exists`,
+				},
+				{
+					Query:    "CREATE TABLE IF NOT EXISTS seq1 (c1 int);",
+					Expected: []sql.Row{},
+				},
+				{
+					Query:       "CREATE TABLE view1 (c1 int);",
+					ExpectedErr: `relation "view1" already exists`,
+				},
+				{
+					Query:    "CREATE TABLE IF NOT EXISTS view1 (c1 int);",
+					Expected: []sql.Row{},
+				},
+				{
+					Query:       "CREATE TABLE idx1 (c1 int);",
+					ExpectedErr: `relation "idx1" already exists`,
+				},
+				{
+					Query:    "CREATE TABLE IF NOT EXISTS idx1 (c1 int);",
+					Expected: []sql.Row{},
+				},
+			},
+		},
 	})
 }
 

--- a/testing/go/create_view_test.go
+++ b/testing/go/create_view_test.go
@@ -277,4 +277,31 @@ var createViewStmts = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "View names must be unique across all relation types",
+		SetUpScript: []string{
+			"CREATE TABLE tbl1 (pk int PRIMARY KEY, v1 int);",
+			"CREATE SEQUENCE seq1;",
+			"CREATE VIEW existing_view AS SELECT pk FROM tbl1;",
+			"CREATE INDEX idx1 ON tbl1 (v1);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "CREATE VIEW tbl1 AS SELECT pk FROM tbl1;",
+				ExpectedErr: `relation "tbl1" already exists`,
+			},
+			{
+				Query:       "CREATE VIEW seq1 AS SELECT pk FROM tbl1;",
+				ExpectedErr: `relation "seq1" already exists`,
+			},
+			{
+				Query:       "CREATE VIEW existing_view AS SELECT pk FROM tbl1;",
+				ExpectedErr: `relation "existing_view" already exists`,
+			},
+			{
+				Query:       "CREATE VIEW idx1 AS SELECT pk FROM tbl1;",
+				ExpectedErr: `relation "idx1" already exists`,
+			},
+		},
+	},
 }

--- a/testing/go/create_view_test.go
+++ b/testing/go/create_view_test.go
@@ -291,16 +291,32 @@ var createViewStmts = []ScriptTest{
 				ExpectedErr: `relation "tbl1" already exists`,
 			},
 			{
+				Query:       "CREATE OR REPLACE VIEW tbl1 AS SELECT pk FROM tbl1;",
+				ExpectedErr: `"tbl1" is not a view`,
+			},
+			{
 				Query:       "CREATE VIEW seq1 AS SELECT pk FROM tbl1;",
 				ExpectedErr: `relation "seq1" already exists`,
+			},
+			{
+				Query:       "CREATE OR REPLACE VIEW seq1 AS SELECT pk FROM tbl1;",
+				ExpectedErr: `"seq1" is not a view`,
 			},
 			{
 				Query:       "CREATE VIEW existing_view AS SELECT pk FROM tbl1;",
 				ExpectedErr: `relation "existing_view" already exists`,
 			},
 			{
+				Query:    "CREATE OR REPLACE VIEW existing_view AS SELECT pk FROM tbl1;",
+				Expected: []sql.Row{},
+			},
+			{
 				Query:       "CREATE VIEW idx1 AS SELECT pk FROM tbl1;",
 				ExpectedErr: `relation "idx1" already exists`,
+			},
+			{
+				Query:       "CREATE OR REPLACE VIEW idx1 AS SELECT pk FROM tbl1;",
+				ExpectedErr: `"idx1" is not a view`,
 			},
 		},
 	},

--- a/testing/go/enginetest/doltgres_engine_test.go
+++ b/testing/go/enginetest/doltgres_engine_test.go
@@ -532,6 +532,7 @@ func TestConvertPrepared(t *testing.T) {
 
 func TestScripts(t *testing.T) {
 	h := newDoltgresServerHarness(t).WithSkippedQueries([]string{
+		"can't create table with same name as existing view",      // Doltgres needs to return a different error message
 		"filter pushdown through join uppercase name",             // syntax error (join without on)
 		"issue 7958, update join uppercase table name validation", // update join syntax not supported
 		"Dolt issue 7957, update join matched rows",               // update join syntax not supported

--- a/testing/go/index_test.go
+++ b/testing/go/index_test.go
@@ -1371,29 +1371,35 @@ func TestBasicIndexing(t *testing.T) {
 			},
 		},
 		{
-			// TODO: MySQL allows duplicate index names on different tables, but Postgres requires
-			//       index names be unique. This test currently fails because GMS doesn't restrict
-			//       this. We should add a Postgres specific validation rule to enforce this.
-			Skip: true,
 			Name: "Index names must be unique",
 			SetUpScript: []string{
 				"CREATE TABLE t1 (pk int PRIMARY KEY, v1 int);",
 				"CREATE TABLE t2 (pk int PRIMARY KEY, v1 int);",
-				"CREATE TABLE idx1 (pk int PRIMARY KEY, v1 int);",
+				"CREATE TABLE tbl1 (pk int PRIMARY KEY, v1 int);",
+				"CREATE SEQUENCE seq1;",
+				"CREATE VIEW view1 AS SELECT pk FROM t1;",
+				"CREATE INDEX idx1 ON t1 (v1);",
 			},
 			Assertions: []ScriptTestAssertion{
 				{
-					Query:    "CREATE INDEX idx_same_name ON t1 (v1);",
+					Query:    "CREATE INDEX idx_unique ON t1 (v1);",
 					Expected: []sql.Row{},
 				},
 				{
-					Query:       "CREATE INDEX idx_same_name ON t2 (v1);",
-					ExpectedErr: `relation "idx_same_name" already exists`,
+					Query:       "CREATE INDEX idx_unique ON t2 (v1);",
+					ExpectedErr: `relation "idx_unique" already exists`,
 				},
 				{
-					// Just like tables, indexes are relations, and share a global namespace
-					Query:       "CREATE INDEX idx1 ON t2 (v1);",
-					ExpectedErr: `relation "idx1" already exists`,
+					Query:       "CREATE INDEX tbl1 ON t2 (v1);",
+					ExpectedErr: `relation "tbl1" already exists`,
+				},
+				{
+					Query:       "CREATE INDEX seq1 ON t2 (v1);",
+					ExpectedErr: `relation "seq1" already exists`,
+				},
+				{
+					Query:       "CREATE INDEX view1 ON t2 (v1);",
+					ExpectedErr: `relation "view1" already exists`,
 				},
 			},
 		},

--- a/testing/go/index_test.go
+++ b/testing/go/index_test.go
@@ -1371,7 +1371,7 @@ func TestBasicIndexing(t *testing.T) {
 			},
 		},
 		{
-			Name: "Index names must be unique",
+			Name: "Index names must be unique across all relation types",
 			SetUpScript: []string{
 				"CREATE TABLE t1 (pk int PRIMARY KEY, v1 int);",
 				"CREATE TABLE t2 (pk int PRIMARY KEY, v1 int);",
@@ -1386,20 +1386,40 @@ func TestBasicIndexing(t *testing.T) {
 					Expected: []sql.Row{},
 				},
 				{
+					Query:    "CREATE INDEX IF NOT EXISTS idx_unique ON t1 (v1);",
+					Expected: []sql.Row{},
+				},
+				{
 					Query:       "CREATE INDEX idx_unique ON t2 (v1);",
 					ExpectedErr: `relation "idx_unique" already exists`,
+				},
+				{
+					Query:    "CREATE INDEX IF NOT EXISTS idx_unique ON t2 (v1);",
+					Expected: []sql.Row{},
 				},
 				{
 					Query:       "CREATE INDEX tbl1 ON t2 (v1);",
 					ExpectedErr: `relation "tbl1" already exists`,
 				},
 				{
+					Query:    "CREATE INDEX IF NOT EXISTS tbl1 ON t2 (v1);",
+					Expected: []sql.Row{},
+				},
+				{
 					Query:       "CREATE INDEX seq1 ON t2 (v1);",
 					ExpectedErr: `relation "seq1" already exists`,
 				},
 				{
+					Query:    "CREATE INDEX IF NOT EXISTS seq1 ON t2 (v1);",
+					Expected: []sql.Row{},
+				},
+				{
 					Query:       "CREATE INDEX view1 ON t2 (v1);",
 					ExpectedErr: `relation "view1" already exists`,
+				},
+				{
+					Query:    "CREATE INDEX IF NOT EXISTS view1 ON t2 (v1);",
+					Expected: []sql.Row{},
 				},
 			},
 		},

--- a/testing/go/sequences_test.go
+++ b/testing/go/sequences_test.go
@@ -1359,16 +1359,32 @@ ORDER BY 1,2;`,
 					ExpectedErr: `relation "tbl1" already exists`,
 				},
 				{
+					Query:    "CREATE SEQUENCE IF NOT EXISTS tbl1;",
+					Expected: []sql.Row{},
+				},
+				{
 					Query:       "CREATE SEQUENCE existing_seq;",
 					ExpectedErr: `relation "existing_seq" already exists`,
+				},
+				{
+					Query:    "CREATE SEQUENCE IF NOT EXISTS existing_seq;",
+					Expected: []sql.Row{},
 				},
 				{
 					Query:       "CREATE SEQUENCE view1;",
 					ExpectedErr: `relation "view1" already exists`,
 				},
 				{
+					Query:    "CREATE SEQUENCE IF NOT EXISTS view1;",
+					Expected: []sql.Row{},
+				},
+				{
 					Query:       "CREATE SEQUENCE idx1;",
 					ExpectedErr: `relation "idx1" already exists`,
+				},
+				{
+					Query:    "CREATE SEQUENCE IF NOT EXISTS idx1;",
+					Expected: []sql.Row{},
 				},
 			},
 		},

--- a/testing/go/sequences_test.go
+++ b/testing/go/sequences_test.go
@@ -1345,5 +1345,32 @@ ORDER BY 1,2;`,
 				},
 			},
 		},
+		{
+			Name: "Sequence names must be unique across all relation types",
+			SetUpScript: []string{
+				"CREATE TABLE tbl1 (pk int PRIMARY KEY, v1 int);",
+				"CREATE SEQUENCE existing_seq;",
+				"CREATE VIEW view1 AS SELECT pk FROM tbl1;",
+				"CREATE INDEX idx1 ON tbl1 (v1);",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:       "CREATE SEQUENCE tbl1;",
+					ExpectedErr: `relation "tbl1" already exists`,
+				},
+				{
+					Query:       "CREATE SEQUENCE existing_seq;",
+					ExpectedErr: `relation "existing_seq" already exists`,
+				},
+				{
+					Query:       "CREATE SEQUENCE view1;",
+					ExpectedErr: `relation "view1" already exists`,
+				},
+				{
+					Query:       "CREATE SEQUENCE idx1;",
+					ExpectedErr: `relation "idx1" already exists`,
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
Adds DoltgresDatabaseProvider and PgDatabase that wrap types from Dolt and allow Doltgres to provide customized behavior.

I've spot checked the failing regression tests and they all appear to show existing problems that we weren't detecting before. 

Depends on:
* https://github.com/dolthub/go-mysql-server/pull/3563
* https://github.com/dolthub/dolt/pull/11111