### PR TITLE
Fix record comparisons to use lexicographic ordering

### DIFF
--- a/server/compare/utils.go
+++ b/server/compare/utils.go
@@ -29,90 +29,89 @@ import (
 //
 // More info on rules for comparing records:
 // https://www.postgresql.org/docs/current/functions-comparisons.html#ROW-WISE-COMPARISON
-func CompareRecords(ctx *sql.Context, op framework.Operator, v1 interface{}, v2 interface{}) (res any, err error) {
+func CompareRecords(ctx *sql.Context, op framework.Operator, v1 interface{}, v2 interface{}) (result any, err error) {
 	leftRecord, rightRecord, err := checkRecordArgs(v1, v2)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO: This can be a hot path when filtering a large table against a tuple, for example.
-	//  We can reduce branching by splitting each case into their individual functions, which will also make the code
-	//  more readable. A downside would be a ton of repeated code.
-	var hasNull bool
-	var leftLiteral, rightLiteral expression.Literal
 	for i := 0; i < len(leftRecord); i++ {
-		// NULL values are by definition not comparable
+		typ1 := leftRecord[i].Type
+		typ2 := rightRecord[i].Type
+
+		// NULL values are by definition not comparable, so they need special handling depending
+		// on what type of comparison we're performing.
 		if leftRecord[i].Value == nil || rightRecord[i].Value == nil {
 			switch op {
-			case framework.Operator_BinaryEqual, framework.Operator_BinaryNotEqual:
-				hasNull = true
-				continue
-			default:
+			case framework.Operator_BinaryLessThan, framework.Operator_BinaryGreaterThan,
+				framework.Operator_BinaryLessOrEqual, framework.Operator_BinaryGreaterOrEqual:
+				// The first non-equal field determines row ordering. A NULL at that
+				// position makes the comparison unknown.
 				return nil, nil
 			}
+
+			// Equality and inequality can still be determined if a later non-NULL
+			// field pair is unequal.
+			continue
 		}
-		leftLiteral.Val = leftRecord[i].Value
-		leftLiteral.Typ = leftRecord[i].Type
-		rightLiteral.Val = rightRecord[i].Value
-		rightLiteral.Typ = rightRecord[i].Type
+
+		leftLiteral := expression.NewLiteral(leftRecord[i].Value, typ1)
+		rightLiteral := expression.NewLiteral(rightRecord[i].Value, typ2)
+
+		equal, err := callComparisonFunction(ctx, framework.Operator_BinaryEqual, leftLiteral, rightLiteral)
+		if err != nil {
+			return false, err
+		}
+		if equal == true {
+			continue
+		}
 
 		switch op {
 		case framework.Operator_BinaryEqual:
-			res, err = callComparisonFunction(ctx, framework.Operator_BinaryEqual, &leftLiteral, &rightLiteral)
-			if err != nil {
-				return false, err
-			}
-			if res == false {
-				return false, nil
-			}
+			return false, nil
 		case framework.Operator_BinaryNotEqual:
-			res, err = callComparisonFunction(ctx, framework.Operator_BinaryNotEqual, &leftLiteral, &rightLiteral)
-			if err != nil {
+			return true, nil
+		case framework.Operator_BinaryLessThan, framework.Operator_BinaryLessOrEqual:
+			if res, err := callComparisonFunction(ctx, framework.Operator_BinaryLessThan, leftLiteral, rightLiteral); err != nil {
 				return false, err
+			} else {
+				return res, nil
 			}
-			if res == true {
-				return true, nil
-			}
-		// Records are compared by evaluating each field in order of significance, so if the fields are equal, we need
-		// to compare the next field.
-		case framework.Operator_BinaryLessThan, framework.Operator_BinaryLessOrEqual,
-			framework.Operator_BinaryGreaterThan, framework.Operator_BinaryGreaterOrEqual:
-			switch op {
-			case framework.Operator_BinaryLessThan, framework.Operator_BinaryLessOrEqual:
-				res, err = callComparisonFunction(ctx, framework.Operator_BinaryLessThan, &leftLiteral, &rightLiteral)
-			default:
-				res, err = callComparisonFunction(ctx, framework.Operator_BinaryGreaterThan, &leftLiteral, &rightLiteral)
-			}
-			if err != nil {
+		case framework.Operator_BinaryGreaterThan, framework.Operator_BinaryGreaterOrEqual:
+			if res, err := callComparisonFunction(ctx, framework.Operator_BinaryGreaterThan, leftLiteral, rightLiteral); err != nil {
 				return false, err
-			}
-			if res == true {
-				return true, nil
-			}
-			// If equals fields are equal, move onto the next field, else return false
-			res, err = callComparisonFunction(ctx, framework.Operator_BinaryEqual, &leftLiteral, &rightLiteral)
-			if err != nil {
-				return false, err
-			}
-			if res == false {
-				return false, nil
+			} else {
+				return res, nil
 			}
 		default:
 			return false, fmt.Errorf("unsupported binary operator: %s", op)
 		}
 	}
 
-	if hasNull {
+	// If no non-NULL field pair determined the result and at least one field
+	// pair is NULL, the comparison is unknown.
+	if recordsContainNull(leftRecord, rightRecord) {
 		return nil, nil
 	}
 
-	// Every field is equal
 	switch op {
 	case framework.Operator_BinaryEqual, framework.Operator_BinaryLessOrEqual, framework.Operator_BinaryGreaterOrEqual:
 		return true, nil
-	default:
+	case framework.Operator_BinaryNotEqual, framework.Operator_BinaryLessThan, framework.Operator_BinaryGreaterThan:
 		return false, nil
+	default:
+		return false, fmt.Errorf("unsupported binary operator: %s", op)
 	}
+}
+
+// recordsContainNull returns whether either record has a NULL value in any field.
+func recordsContainNull(leftRecord, rightRecord []pgtypes.RecordValue) bool {
+	for i := 0; i < len(leftRecord); i++ {
+		if leftRecord[i].Value == nil || rightRecord[i].Value == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // checkRecordArgs asserts that |v1| and |v2| are both []pgtypes.RecordValue, and that they have the same number of
@@ -140,5 +139,9 @@ func callComparisonFunction(ctx *sql.Context, op framework.Operator, leftLiteral
 	intermediateFunction := framework.GetBinaryFunction(op)
 	compiledFunction := intermediateFunction.Compile(
 		ctx, "_internal_record_comparison_function", leftLiteral, rightLiteral)
+	if compiledFunction == nil {
+		return nil, fmt.Errorf("could not find comparison function for operator %s and types %s, %s",
+			op, leftLiteral.Type(ctx).String(), rightLiteral.Type(ctx).String())
+	}
 	return compiledFunction.Eval(ctx, nil)
 }

--- a/server/compare/utils_test.go
+++ b/server/compare/utils_test.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compare_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/doltgresql/core"
+	"github.com/dolthub/doltgresql/server/compare"
+	"github.com/dolthub/doltgresql/server/functions"
+	"github.com/dolthub/doltgresql/server/functions/binary"
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+var compareRecordsInitOnce sync.Once
+
+func TestCompareRecordsUsesLexicographicRowComparison(t *testing.T) {
+	initCompareRecordsTests()
+
+	ctx := sql.NewEmptyContext()
+	tests := []struct {
+		name     string
+		op       framework.Operator
+		left     []pgtypes.RecordValue
+		right    []pgtypes.RecordValue
+		expected any
+	}{
+		{
+			name:     "greater than false when first field is less",
+			op:       framework.Operator_BinaryGreaterThan,
+			left:     recordValues(1, 1),
+			right:    recordValues(999, 999),
+			expected: false,
+		},
+		{
+			name:     "less than true when first field is less",
+			op:       framework.Operator_BinaryLessThan,
+			left:     recordValues(1, 1),
+			right:    recordValues(999, 999),
+			expected: true,
+		},
+		{
+			name:     "greater than true when later field decides",
+			op:       framework.Operator_BinaryGreaterThan,
+			left:     recordValues(1, 2),
+			right:    recordValues(1, 1),
+			expected: true,
+		},
+		{
+			name:     "less than or equal true for equal records",
+			op:       framework.Operator_BinaryLessOrEqual,
+			left:     recordValues(1, 1),
+			right:    recordValues(1, 1),
+			expected: true,
+		},
+		{
+			name:     "greater than or equal true for equal records",
+			op:       framework.Operator_BinaryGreaterOrEqual,
+			left:     recordValues(1, 1),
+			right:    recordValues(1, 1),
+			expected: true,
+		},
+		{
+			name:     "not equal false for equal records",
+			op:       framework.Operator_BinaryNotEqual,
+			left:     recordValues(1, 1),
+			right:    recordValues(1, 1),
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res, err := compare.CompareRecords(ctx, test.op, test.left, test.right)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, res)
+		})
+	}
+}
+
+func TestCompareRecordsHandlesNullRowComparison(t *testing.T) {
+	initCompareRecordsTests()
+
+	ctx := sql.NewEmptyContext()
+	tests := []struct {
+		name     string
+		op       framework.Operator
+		left     []pgtypes.RecordValue
+		right    []pgtypes.RecordValue
+		expected any
+	}{
+		{
+			name:     "equality false when later non null field differs",
+			op:       framework.Operator_BinaryEqual,
+			left:     recordValues(nil, 1),
+			right:    recordValues(nil, 2),
+			expected: false,
+		},
+		{
+			name:     "not equal true when later non null field differs",
+			op:       framework.Operator_BinaryNotEqual,
+			left:     recordValues(nil, 1),
+			right:    recordValues(nil, 2),
+			expected: true,
+		},
+		{
+			name:     "equality unknown when only null fields are inconclusive",
+			op:       framework.Operator_BinaryEqual,
+			left:     recordValues(1, nil),
+			right:    recordValues(1, nil),
+			expected: nil,
+		},
+		{
+			name:     "ordering unknown when decisive field contains null",
+			op:       framework.Operator_BinaryGreaterThan,
+			left:     recordValues(1, 2),
+			right:    recordValues(1, nil),
+			expected: nil,
+		},
+		{
+			name:     "ordering true when earlier non null field decides before null",
+			op:       framework.Operator_BinaryGreaterThan,
+			left:     recordValues(2, 1),
+			right:    recordValues(1, nil),
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res, err := compare.CompareRecords(ctx, test.op, test.left, test.right)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, res)
+		})
+	}
+}
+
+func initCompareRecordsTests() {
+	compareRecordsInitOnce.Do(func() {
+		core.Init()
+		pgtypes.Init()
+		functions.Init()
+		binary.Init()
+		framework.Initialize()
+	})
+}
+
+func recordValues(values ...any) []pgtypes.RecordValue {
+	record := make([]pgtypes.RecordValue, len(values))
+	for i, value := range values {
+		if intValue, ok := value.(int); ok {
+			value = int32(intValue)
+		}
+		record[i] = pgtypes.RecordValue{
+			Type:  pgtypes.Int32,
+			Value: value,
+		}
+	}
+	return record
+}

--- a/testing/go/issues_test.go
+++ b/testing/go/issues_test.go
@@ -461,6 +461,55 @@ limit 1`,
 				},
 			},
 		},
+		{
+			Name: "Issue #2807",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT (1, 1) = (999, 999);`,
+					Expected: []sql.Row{{"f"}},
+				},
+				{
+					Query:    `SELECT (1, 1) <> (999, 999);`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    `SELECT (1, 1) < (999, 999);`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    `SELECT (1, 1) <= (999, 999);`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    `SELECT (1, 1) > (999, 999);`,
+					Expected: []sql.Row{{"f"}},
+				},
+				{
+					Query:    `SELECT (1, 1) >= (999, 999);`,
+					Expected: []sql.Row{{"f"}},
+				},
+				{
+					Query:    `SELECT (1, 1) <= (1, 1);`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    `SELECT (1, 1) >= (1, 1);`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    `SELECT (NULL, 1) = (NULL, 2);`,
+					Expected: []sql.Row{{"f"}},
+				},
+				{
+					Query:    `SELECT (NULL, 1) <> (NULL, 2);`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    `SELECT (1, NULL) < (1, 2);`,
+					Expected: []sql.Row{{nil}},
+				},
+			},
+		},
 	})
 }
 


### PR DESCRIPTION
Fixes #2807

## Summary
- Update record comparison to follow PostgreSQL row-comparison semantics: fields are compared left-to-right, the first unequal non-NULL pair determines ordering, and a NULL at the decisive position makes the result unknown.
- Keep equality and inequality from short-circuiting on an early NULL when a later non-NULL field pair can still determine the result.
- Fix `record_le` so `<=` dispatches as `Operator_BinaryLessOrEqual` instead of `<`.
- Return a clear error if a record field comparison has no matching binary operator overload instead of risking a nil compiled function.
- Add an issue regression covering all six tuple comparison operators plus relevant NULL behavior, and add direct `server/compare` tests for the row-comparison algorithm.

## Validation
- `postgres/parser/build.sh`
- `PATH="/Users/wondr/go/bin:$PATH" scripts/format_repo.sh`
- `git diff --check`
- `CGO_CPPFLAGS="-I/opt/homebrew/opt/icu4c@78/include" CGO_LDFLAGS="-L/opt/homebrew/opt/icu4c@78/lib" TZ=America/Los_Angeles go test ./server/compare ./server/functions/binary --count=1`
- `CGO_CPPFLAGS="-I/opt/homebrew/opt/icu4c@78/include" CGO_LDFLAGS="-L/opt/homebrew/opt/icu4c@78/lib" TZ=America/Los_Angeles go test ./testing/go -run 'TestIssues$' --count=1`

I also attempted the broader `testing/go` package locally with the same ICU flags and fixed timezone. The Issue #2807 focused test passes, but the full package still has unrelated local-environment failures around `uuid-ossp` extension setup and TimeZone expectation tests, followed by wire-test EOFs after those failures. Those are outside the record comparison path changed here.
