### PR TITLE
Added CREATE CAST alongside general bug fixes

### DIFF
--- a/core/casts/collection.go
+++ b/core/casts/collection.go
@@ -26,6 +26,8 @@ import (
 	"github.com/dolthub/dolt/go/store/prolly"
 	"github.com/dolthub/dolt/go/store/prolly/tree"
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/procedures"
 
 	"github.com/dolthub/doltgresql/core/id"
 	"github.com/dolthub/doltgresql/core/rootobject/objinterface"
@@ -58,6 +60,8 @@ type Cast struct {
 	Function id.Function
 	BuiltIn  pgtypes.TypeCastFunction
 	UseInOut bool
+
+	request CastType // This contains the type of cast that was requested, as we may request an EXPLICIT cast and receive an IMPLICIT (which is valid)
 }
 
 var _ objinterface.Collection = (*Collection)(nil)
@@ -98,7 +102,9 @@ func (pgc *Collection) GetExplicitCast(ctx *sql.Context, sourceType *pgtypes.Dol
 			ID:       castID,
 			CastType: CastType_Explicit,
 			Function: id.NullFunction,
+			BuiltIn:  nil,
 			UseInOut: true,
+			request:  CastType_Explicit,
 		}, nil
 	} else if targetType.TypCategory == pgtypes.TypeCategory_StringTypes {
 		// All types have a built-in assignment cast to string types, which we can reference in an explicit cast
@@ -106,7 +112,9 @@ func (pgc *Collection) GetExplicitCast(ctx *sql.Context, sourceType *pgtypes.Dol
 			ID:       castID,
 			CastType: CastType_Explicit,
 			Function: id.NullFunction,
+			BuiltIn:  nil,
 			UseInOut: true,
+			request:  CastType_Explicit,
 		}, nil
 	}
 	// It is always valid to convert from the `unknown` type
@@ -115,7 +123,9 @@ func (pgc *Collection) GetExplicitCast(ctx *sql.Context, sourceType *pgtypes.Dol
 			ID:       castID,
 			CastType: CastType_Explicit,
 			Function: id.NullFunction,
+			BuiltIn:  nil,
 			UseInOut: true,
+			request:  CastType_Explicit,
 		}, nil
 	}
 	return Cast{}, nil
@@ -149,7 +159,9 @@ func (pgc *Collection) GetAssignmentCast(ctx *sql.Context, sourceType *pgtypes.D
 			ID:       castID,
 			CastType: CastType_Assignment,
 			Function: id.NullFunction,
+			BuiltIn:  nil,
 			UseInOut: true,
+			request:  CastType_Assignment,
 		}, nil
 	}
 	// It is always valid to convert from the `unknown` type
@@ -158,7 +170,9 @@ func (pgc *Collection) GetAssignmentCast(ctx *sql.Context, sourceType *pgtypes.D
 			ID:       castID,
 			CastType: CastType_Assignment,
 			Function: id.NullFunction,
+			BuiltIn:  nil,
 			UseInOut: true,
+			request:  CastType_Assignment,
 		}, nil
 	}
 	return Cast{}, nil
@@ -192,7 +206,9 @@ func (pgc *Collection) GetImplicitCast(ctx *sql.Context, sourceType *pgtypes.Dol
 			ID:       castID,
 			CastType: CastType_Implicit,
 			Function: id.NullFunction,
+			BuiltIn:  nil,
 			UseInOut: true,
+			request:  CastType_Implicit,
 		}, nil
 	}
 	return Cast{}, nil
@@ -263,6 +279,7 @@ func (pgc *Collection) getCast(ctx context.Context, castID id.Cast, sourceType *
 					Function: id.NullFunction,
 					BuiltIn:  evalFunc,
 					UseInOut: false,
+					request:  castType,
 				}, nil
 			}
 		}
@@ -272,7 +289,12 @@ func (pgc *Collection) getCast(ctx context.Context, castID id.Cast, sourceType *
 	if err != nil {
 		return Cast{}, err
 	}
-	return DeserializeCast(ctx, data)
+	c, err := DeserializeCast(ctx, data)
+	if err != nil {
+		return Cast{}, err
+	}
+	c.request = castType
+	return c, nil
 }
 
 // getSizingOrIdentityCast returns an identity cast if the two types are exactly the same, and a sizing cast if they
@@ -299,7 +321,9 @@ func (pgc *Collection) getSizingOrIdentityCast(sourceType *pgtypes.DoltgresType,
 			ID:       id.NewCast(sourceType.ID, targetType.ID),
 			CastType: castType,
 			Function: id.NullFunction,
+			BuiltIn:  nil,
 			UseInOut: true,
+			request:  castType,
 		}
 	}
 	// If there is no sizing cast, then we simply use the identity cast
@@ -307,7 +331,9 @@ func (pgc *Collection) getSizingOrIdentityCast(sourceType *pgtypes.DoltgresType,
 		ID:       id.NewCast(sourceType.ID, targetType.ID),
 		CastType: castType,
 		Function: id.NullFunction,
+		BuiltIn:  nil,
 		UseInOut: false,
+		request:  castType,
 	}
 }
 
@@ -324,7 +350,9 @@ func (pgc *Collection) getRecordCast(sourceType *pgtypes.DoltgresType, targetTyp
 				ID:       id.NewCast(sourceType.ID, targetType.ID),
 				CastType: castType,
 				Function: id.NullFunction,
+				BuiltIn:  nil,
 				UseInOut: false,
+				request:  castType,
 			}
 		} else {
 			evalFunc := func(ctx *sql.Context, val any, sourceType *pgtypes.DoltgresType, targetType *pgtypes.DoltgresType) (_ any, err error) {
@@ -383,6 +411,7 @@ func (pgc *Collection) getRecordCast(sourceType *pgtypes.DoltgresType, targetTyp
 				Function: id.NullFunction,
 				BuiltIn:  evalFunc,
 				UseInOut: false,
+				request:  castType,
 			}
 		}
 	}
@@ -442,7 +471,7 @@ func (pgc *Collection) DropCast(ctx context.Context, castIDs ...id.Cast) error {
 	}
 	// Check that each name exists before performing any deletions
 	for _, castID := range castIDs {
-		if _, ok := builtInCasts[castID]; !ok {
+		if _, ok := builtInCasts[castID]; ok {
 			return errors.Errorf(`cannot delete built-in cast from type %s to type %s`,
 				castID.SourceType().TypeName(), castID.TargetType().TypeName())
 		}
@@ -611,12 +640,54 @@ func (cast Cast) Eval(ctx *sql.Context, val any, sourceType *pgtypes.DoltgresTyp
 		return targetType.IoInput(ctx, output)
 	}
 	if cast.BuiltIn != nil {
+		// It may not be strictly true that all built-in casts are STRICT, but it seems true so we'll hold the assumption
+		if val == nil {
+			return nil, nil
+		}
 		return cast.BuiltIn(ctx, val, sourceType, targetType)
 	}
 	if cast.Function != id.NullFunction {
-		// TODO: get the function collection and call the pointed-to function (argument count determines parameters)
-		return nil, errors.Errorf(`cannot cast from type %s to type %s as CREATE CAST is not yet implemented`,
-			cast.ID.SourceType().TypeName(), cast.ID.TargetType().TypeName())
+		castFunc, ok := functionProvider.Function(ctx, cast.Function.SchemaName(), cast.Function.FunctionName())
+		if !ok {
+			return nil, sql.ErrFunctionNotFound.New(cast.Function.FunctionName())
+		}
+		var exprs []sql.Expression
+		switch cast.Function.ParameterCount() {
+		case 1:
+			exprs = []sql.Expression{
+				expression.NewLiteral(val, sourceType),
+			}
+		case 2:
+			exprs = []sql.Expression{
+				expression.NewLiteral(val, sourceType),
+				expression.NewLiteral(targetType.GetAttTypMod(), pgtypes.Int32),
+			}
+		case 3:
+			exprs = []sql.Expression{
+				expression.NewLiteral(val, sourceType),
+				expression.NewLiteral(targetType.GetAttTypMod(), pgtypes.Int32),
+				expression.NewLiteral(cast.request == CastType_Explicit, pgtypes.Bool),
+			}
+		default:
+			return nil, errors.New("invalid parameter count for cast function") // TODO: figure out the actual error
+		}
+		castFuncInstance, err := castFunc.NewInstance(ctx, exprs)
+		if err != nil {
+			return nil, err
+		}
+		if val == nil {
+			if getIsStrictFromFunction(castFuncInstance) {
+				return nil, nil
+			}
+		}
+		if setRunner, ok := castFuncInstance.(procedures.InterpreterExpr); ok {
+			runner, err := getRunnerFromContext(ctx)
+			if err != nil {
+				return nil, err
+			}
+			castFuncInstance = setRunner.SetStatementRunner(ctx, runner)
+		}
+		return castFuncInstance.Eval(ctx, nil)
 	}
 	// In this case, the values are binary-coercible, but we still check as we may deviate from Postgres for some reason
 	if _, _, err := targetType.Convert(ctx, val); err != nil {
@@ -638,3 +709,12 @@ func CastIDToTableName(castID id.Cast) doltdb.TableName {
 		Schema: "",
 	}
 }
+
+// functionProvider is set by init and is used to avoid import cycles
+var functionProvider sql.FunctionProvider
+
+// getRunnerFromContext is set by init and is used to avoid import cycles
+var getRunnerFromContext func(ctx *sql.Context) (sql.StatementRunner, error)
+
+// getIsStrictFromFunction is set by init and is used to avoid import cycles
+var getIsStrictFromFunction func(f sql.Expression) bool

--- a/core/context.go
+++ b/core/context.go
@@ -40,13 +40,15 @@ import (
 type contextValues struct {
 	seqs map[string]*sequences.Collection
 	// TODO: all these collection fields need to be mapped by database name as seqs above
-	types          *typecollection.TypeCollection
-	funcs          *functions.Collection
-	procs          *procedures.Collection
-	trigs          *triggers.Collection
-	exts           *extensions.Collection
-	casts          *casts.Collection
+	types *typecollection.TypeCollection
+	funcs *functions.Collection
+	procs *procedures.Collection
+	trigs *triggers.Collection
+	exts  *extensions.Collection
+	casts *casts.Collection
+
 	pgCatalogCache any
+	runner         sql.StatementRunner
 }
 
 // getContextValues accesses the contextValues in the given context. If the context does not have a contextValues, then
@@ -71,7 +73,14 @@ func getContextValues(ctx *sql.Context) (*contextValues, error) {
 func ClearContextValues(ctx *sql.Context) {
 	sess := dsess.DSessFromSess(ctx.Session)
 	if sess.DoltgresSessObj != nil {
-		sess.DoltgresSessObj = &contextValues{}
+		// We want to persist the runner between clears since it's static
+		var runner sql.StatementRunner
+		if cv, ok := sess.DoltgresSessObj.(*contextValues); ok {
+			runner = cv.runner
+		}
+		sess.DoltgresSessObj = &contextValues{
+			runner: runner,
+		}
 	}
 }
 
@@ -133,6 +142,28 @@ func SetPgCatalogCache(ctx *sql.Context, pgCatalogCache any) error {
 	}
 	cv.pgCatalogCache = pgCatalogCache
 	return nil
+}
+
+// SetRunnerOnContext sets the given runner within the context values.
+func SetRunnerOnContext(ctx *sql.Context, runner sql.StatementRunner) error {
+	if runner == nil {
+		return nil
+	}
+	cv, err := getContextValues(ctx)
+	if err != nil {
+		return err
+	}
+	cv.runner = runner
+	return nil
+}
+
+// GetRunnerFromContext returns the sql.StatementRunner from within the context.
+func GetRunnerFromContext(ctx *sql.Context) (sql.StatementRunner, error) {
+	cv, err := getContextValues(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return cv.runner, nil
 }
 
 // GetDoltTableFromContext returns the Dolt table from the context. Returns nil if no table was found.
@@ -441,6 +472,8 @@ func CloseContextRootFinalizer(ctx *sql.Context) error {
 	return nil
 }
 
+// updateSessionRootForDatabase updates the root for all changes made to root object collections within the context
+// values.
 func updateSessionRootForDatabase(ctx *sql.Context, db string, cv *contextValues) error {
 	session, root, err := getRootFromContextForDatabase(ctx, db)
 	if err != nil {
@@ -546,6 +579,7 @@ func rootValueChanged(newRoot *RootValue, root *RootValue) (error, bool) {
 	return nil, true
 }
 
+// databasesInContext returns all databases found within the context values.
 func databasesInContext(ctx *sql.Context, cv *contextValues) []string {
 	dbs := make(map[string]struct{})
 	if cv.seqs != nil {
@@ -553,7 +587,10 @@ func databasesInContext(ctx *sql.Context, cv *contextValues) []string {
 			dbs[db] = struct{}{}
 		}
 	}
-	dbs[ctx.GetCurrentDatabase()] = struct{}{}
+	currentDb := ctx.GetCurrentDatabase()
+	if len(currentDb) > 0 {
+		dbs[currentDb] = struct{}{}
+	}
 
 	return slices.Sorted(maps.Keys(dbs))
 }

--- a/core/id/id_wrappers.go
+++ b/core/id/id_wrappers.go
@@ -14,7 +14,11 @@
 
 package id
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 // AccessMethod is an Id wrapper for access methods. This wrapper must not be returned to the client.
 type AccessMethod Id
@@ -322,6 +326,19 @@ func (id ForeignKey) SchemaName() string {
 // TableName returns the name of the table that the foreign key belongs to.
 func (id ForeignKey) TableName() string {
 	return Id(id).Segment(1)
+}
+
+// DisplayString returns the function ID as a suitable display name.
+// For example, the output will generally look like: "func_name(param1, param2)"
+func (id Function) DisplayString() string {
+	if !id.IsValid() {
+		return ""
+	}
+	params := make([]string, id.ParameterCount())
+	for i, paramID := range id.Parameters() {
+		params[i] = paramID.TypeName()
+	}
+	return fmt.Sprintf("%s(%s)", id.FunctionName(), strings.Join(params, ", "))
 }
 
 // FunctionName returns the function's name.

--- a/postgres/parser/parser/sql.y
+++ b/postgres/parser/parser/sql.y
@@ -147,6 +147,9 @@ func (u *sqlSymUnion) newTableIndexNames() tree.TableIndexNames {
 func (u *sqlSymUnion) nameList() tree.NameList {
     return u.val.(tree.NameList)
 }
+func (u *sqlSymUnion) createCastScope() tree.CreateCastScope {
+    return u.val.(tree.CreateCastScope)
+}
 func (u *sqlSymUnion) unresolvedName() *tree.UnresolvedName {
     return u.val.(*tree.UnresolvedName)
 }
@@ -709,7 +712,7 @@ func (u *sqlSymUnion) vacuumTableAndColsList() tree.VacuumTableAndColsList {
 // Ordinary key words in alphabetical order.
 %token <str> ABORT ACCESS ACTION ADD ADMIN AFTER AGGREGATE
 %token <str> ALIGNMENT ALL ALLOW_CONNECTIONS ALTER ALWAYS ANALYSE ANALYZE AND AND_AND ANY ANNOTATE_TYPE ARRAY AS ASC
-%token <str> ASYMMETRIC AT ATOMIC ATTACH ATTRIBUTE AUTHORIZATION AUTO AUTOMATIC
+%token <str> ASSIGNMENT ASYMMETRIC AT ATOMIC ATTACH ATTRIBUTE AUTHORIZATION AUTO AUTOMATIC
 
 %token <str> BACKUP BACKUPS BASETYPE BEFORE BEGIN BETWEEN BIGINT BIGSERIAL BINARY BIT
 %token <str> FORMAT CSV HEADER
@@ -748,7 +751,7 @@ func (u *sqlSymUnion) vacuumTableAndColsList() tree.VacuumTableAndColsList {
 %token <str> HANDLER HASH HAVING HIGH HISTOGRAM HOUR HYPOTHETICAL
 
 %token <str> ICU_LOCALE ICU_RULES IDENTITY
-%token <str> IF IFERROR IFNULL IGNORE_FOREIGN_KEYS ILIKE IMMEDIATE IMMUTABLE IMPORT
+%token <str> IF IFERROR IFNULL IGNORE_FOREIGN_KEYS ILIKE IMMEDIATE IMPLICIT IMMUTABLE IMPORT
 %token <str> IN INCLUDE INCLUDING INCREMENT INCREMENTAL INET INET_CONTAINED_BY_OR_EQUALS
 %token <str> INET_CONTAINS_OR_EQUALS INDEX INDEX_CLEANUP INDEXES INHERIT INHERITS INITCOND INJECT INLINE INPUT INTERLEAVE INITIALLY
 %token <str> INNER INOUT INSERT INSTEAD INT INTEGER INTERNALLENGTH
@@ -915,6 +918,7 @@ func (u *sqlSymUnion) vacuumTableAndColsList() tree.VacuumTableAndColsList {
 %type <tree.Statement> copy_from_stmt
 
 %type <tree.Statement> create_stmt
+%type <tree.Statement> create_cast_stmt
 %type <tree.Statement> create_changefeed_stmt
 %type <tree.Statement> create_ddl_stmt
 %type <tree.Statement> create_ddl_stmt_schema_element
@@ -950,6 +954,7 @@ func (u *sqlSymUnion) vacuumTableAndColsList() tree.VacuumTableAndColsList {
 %type <tree.Statement> discard_stmt
 
 %type <tree.Statement> drop_stmt
+%type <tree.Statement> drop_cast_stmt
 %type <tree.Statement> drop_ddl_stmt
 %type <tree.Statement> drop_database_stmt
 %type <tree.Statement> drop_index_stmt
@@ -1103,6 +1108,7 @@ func (u *sqlSymUnion) vacuumTableAndColsList() tree.VacuumTableAndColsList {
 %type <tree.CreateAggOption> create_agg_old_syntax_option create_agg_common_option create_agg_parallel_option
 %type <[]tree.CreateAggOption> create_agg_args_only_option_list create_agg_order_by_args_option_list create_agg_old_syntax_option_list
 %type <[]tree.AggregateToDrop> drop_aggregates
+%type <tree.CreateCastScope> create_cast_scope_opt
 
 %type <tree.DatabaseOption> opt_database_options
 %type <[]tree.DatabaseOption> opt_database_options_list opt_database_with_options
@@ -4038,7 +4044,7 @@ comment_text:
 // %Text:
 // CREATE DATABASE, CREATE TABLE, CREATE INDEX, CREATE TABLE AS,
 // CREATE USER, CREATE VIEW, CREATE SEQUENCE, CREATE STATISTICS,
-// CREATE ROLE, CREATE TYPE
+// CREATE ROLE, CREATE TYPE, CREATE CAST
 create_stmt:
   create_role_stmt     // EXTEND WITH HELP: CREATE ROLE
 | create_ddl_stmt      // help texts in sub-rule
@@ -4049,12 +4055,12 @@ create_stmt:
 | create_extension_stmt // EXTEND WITH HELP: CREATE EXTENSION
 | create_language_stmt  // EXTEND WITH HELP: CREATE LANGUAGE
 | create_aggregate_stmt // EXTEND WITH HELP: CREATE AGGREGATE
+| create_cast_stmt      // EXTEND WITH HELP: CREATE CAST
 | create_unsupported   {}
 | CREATE error         // SHOW HELP: CREATE
 
 create_unsupported:
-  CREATE CAST error { return unimplemented(sqllex, "create cast") }
-| CREATE CONVERSION error { return unimplemented(sqllex, "create conversion") }
+  CREATE CONVERSION error { return unimplemented(sqllex, "create conversion") }
 | CREATE DEFAULT CONVERSION error { return unimplemented(sqllex, "create def conv") }
 | CREATE FOREIGN TABLE error { return unimplemented(sqllex, "create foreign table") }
 | CREATE OPERATOR error { return unimplemented(sqllex, "create operator") }
@@ -4179,6 +4185,62 @@ create_agg_parallel_option:
   { $$.val = tree.CreateAggOption{Option: tree.AggOptTypeParallel, Parallel: tree.ParallelRestricted} }
 | PARALLEL '=' UNSAFE
   { $$.val = tree.CreateAggOption{Option: tree.AggOptTypeParallel, Parallel: tree.ParallelSafe} }
+
+// %Help: CREATE CAST - define a new cast
+// %Category: DDL
+// %Text: CREATE CAST (source_type AS target_type) WITH FUNCTION function_name [ (argument_type [, ...]) ] [ AS ASSIGNMENT | AS IMPLICIT ]
+//        CREATE CAST (source_type AS target_type) WITHOUT FUNCTION [ AS ASSIGNMENT | AS IMPLICIT ]
+//        CREATE CAST (source_type AS target_type) WITH INOUT [ AS ASSIGNMENT | AS IMPLICIT ]
+// %SeeAlso: WEBDOCS/sql-createcast.html
+create_cast_stmt:
+  CREATE CAST '(' typename AS typename ')' WITH FUNCTION routine_name opt_routine_arg_with_default_list create_cast_scope_opt
+  {
+    $$.val = &tree.CreateCast{
+      Source:   $4.typeReference(),
+      Target:   $6.typeReference(),
+      Scope:    $12.createCastScope(),
+      Type:     tree.CreateCastType_WithFunction,
+      FuncName: $10.unresolvedObjectName(),
+      FuncArgs: $11.routineArgs(),
+    }
+  }
+| CREATE CAST '(' typename AS typename ')' WITHOUT FUNCTION create_cast_scope_opt
+  {
+    $$.val = &tree.CreateCast{
+      Source:   $4.typeReference(),
+      Target:   $6.typeReference(),
+      Scope:    $10.createCastScope(),
+      Type:     tree.CreateCastType_WithoutFunction,
+      FuncName: nil,
+      FuncArgs: nil,
+    }
+  }
+| CREATE CAST '(' typename AS typename ')' WITH INOUT create_cast_scope_opt
+  {
+    $$.val = &tree.CreateCast{
+      Source:   $4.typeReference(),
+      Target:   $6.typeReference(),
+      Scope:    $10.createCastScope(),
+      Type:     tree.CreateCastType_Inout,
+      FuncName: nil,
+      FuncArgs: nil,
+    }
+  }
+| CREATE CAST error // SHOW HELP: CREATE CAST
+
+create_cast_scope_opt:
+  /* EMPTY */
+  {
+    $$.val = tree.CreateCastScope_Explicit
+  }
+| AS ASSIGNMENT
+  {
+    $$.val = tree.CreateCastScope_Assignment
+  }
+| AS IMPLICIT
+  {
+    $$.val = tree.CreateCastScope_Implicit
+  }
 
 create_domain_stmt:
   CREATE DOMAIN type_name opt_as typename opt_collate opt_arg_default opt_domain_constraint_list
@@ -4671,8 +4733,7 @@ opt_procedural:
   }
 
 drop_unsupported:
-  DROP CAST error { return unimplemented(sqllex, "drop cast") }
-| DROP COLLATION error { return unimplemented(sqllex, "drop collation") }
+  DROP COLLATION error { return unimplemented(sqllex, "drop collation") }
 | DROP CONVERSION error { return unimplemented(sqllex, "drop conversion") }
 | DROP FOREIGN TABLE error { return unimplemented(sqllex, "drop foreign table") }
 | DROP FOREIGN DATA error { return unimplemented(sqllex, "drop fdw") }
@@ -4969,23 +5030,24 @@ discard_stmt:
 // %Help: DROP
 // %Category: Group
 // %Text:
-// DROP DATABASE, DROP INDEX, DROP TABLE, DROP VIEW, DROP SEQUENCE,
+// DROP CAST, DROP DATABASE, DROP INDEX, DROP TABLE, DROP VIEW, DROP SEQUENCE,
 // DROP USER, DROP ROLE, DROP TYPE
 drop_stmt:
-  drop_ddl_stmt      // help texts in sub-rule
-| drop_role_stmt     // EXTEND WITH HELP: DROP ROLE
-| drop_schedule_stmt // EXTEND WITH HELP: DROP SCHEDULES
-| drop_function_stmt // EXTEND WITH HELP: DROP FUNCTION
+  drop_ddl_stmt       // help texts in sub-rule
+| drop_role_stmt      // EXTEND WITH HELP: DROP ROLE
+| drop_schedule_stmt  // EXTEND WITH HELP: DROP SCHEDULES
+| drop_function_stmt  // EXTEND WITH HELP: DROP FUNCTION
 | drop_procedure_stmt // EXTEND WITH HELP: DROP PROCEDURE
-| drop_domain_stmt   // EXTEND WITH HELP: DROP DOMAIN
+| drop_domain_stmt    // EXTEND WITH HELP: DROP DOMAIN
 | drop_extension_stmt // EXTEND WITH HELP: DROP EXTENSION
-| drop_language_stmt // EXTEND WITH HELP: DROP LANGUAGE
+| drop_language_stmt  // EXTEND WITH HELP: DROP LANGUAGE
 | drop_aggregate_stmt // EXTEND WITH HELP: DROP AGGREGATE
 | drop_unsupported   {}
 | DROP error         // SHOW HELP: DROP
 
 drop_ddl_stmt:
   drop_database_stmt // EXTEND WITH HELP: DROP DATABASE
+| drop_cast_stmt     // EXTEND WITH HELP: DROP CAST
 | drop_index_stmt    // EXTEND WITH HELP: DROP INDEX
 | drop_table_stmt    // EXTEND WITH HELP: DROP TABLE
 | drop_trigger_stmt  // EXTEND WITH HELP: DROP TRIGGER
@@ -4993,6 +5055,23 @@ drop_ddl_stmt:
 | drop_sequence_stmt // EXTEND WITH HELP: DROP SEQUENCE
 | drop_schema_stmt   // EXTEND WITH HELP: DROP SCHEMA
 | drop_type_stmt     // EXTEND WITH HELP: DROP TYPE
+
+// %Help: DROP CAST - remove a cast
+// %Category: DDL
+// %Text: DROP CAST [ IF EXISTS ] (source_type AS target_type) [ CASCADE | RESTRICT ]
+// %SeeAlso: WEBDOCS/sql-dropcast.html
+drop_cast_stmt:
+  DROP CAST '(' typename AS typename ')' opt_drop_behavior
+  {
+    // Drop behavior is ignored and only exists as it's mandated by the SQL standard
+    $$.val = &tree.DropCast{Source: $4.typeReference(), Target: $6.typeReference(), IfExists: false}
+  }
+| DROP CAST IF EXISTS '(' typename AS typename ')' opt_drop_behavior
+  {
+    // Drop behavior is ignored and only exists as it's mandated by the SQL standard
+    $$.val = &tree.DropCast{Source: $6.typeReference(), Target: $8.typeReference(), IfExists: true}
+  }
+| DROP CAST error // SHOW HELP: DROP VIEW
 
 // %Help: DROP VIEW - remove a view
 // %Category: DDL
@@ -14726,6 +14805,7 @@ unreserved_keyword:
 | ALLOW_CONNECTIONS
 | ALTER
 | ALWAYS
+| ASSIGNMENT
 | AT
 | ATOMIC
 | ATTACH
@@ -14874,6 +14954,7 @@ unreserved_keyword:
 | IGNORE_FOREIGN_KEYS
 | IMMEDIATE
 | IMMUTABLE
+| IMPLICIT
 | IMPORT
 | INCLUDE
 | INCLUDING

--- a/postgres/parser/sem/tree/create_cast.go
+++ b/postgres/parser/sem/tree/create_cast.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tree
+
+// CreateCastType states the type of the CREATE CAST statement.
+type CreateCastType byte
+
+const (
+	CreateCastType_WithFunction CreateCastType = iota
+	CreateCastType_WithoutFunction
+	CreateCastType_Inout
+)
+
+// CreateCastScope states whether the CREATE CAST statement is explicit, assignment, or implicit.
+type CreateCastScope byte
+
+const (
+	CreateCastScope_Explicit CreateCastScope = iota
+	CreateCastScope_Assignment
+	CreateCastScope_Implicit
+)
+
+// CreateCast represents a CREATE CAST statement.
+type CreateCast struct {
+	Source   ResolvableTypeReference
+	Target   ResolvableTypeReference
+	Scope    CreateCastScope
+	Type     CreateCastType
+	FuncName *UnresolvedObjectName
+	FuncArgs RoutineArgs
+}
+
+var _ Statement = &CreateCast{}
+
+// Format implements the NodeFormatter interface.
+func (node *CreateCast) Format(ctx *FmtCtx) {
+	ctx.WriteString("CREATE CAST (")
+	ctx.WriteString(node.Source.SQLString())
+	ctx.WriteString(" AS ")
+	ctx.WriteString(node.Target.SQLString())
+	ctx.WriteString(") ")
+	switch node.Type {
+	case CreateCastType_WithFunction:
+		ctx.WriteString("WITH FUNCTION ")
+		ctx.FormatNode(node.FuncName)
+		if len(node.FuncArgs) > 0 {
+			ctx.WriteString("(")
+			ctx.FormatNode(node.FuncArgs)
+			ctx.WriteString(")")
+		}
+	case CreateCastType_WithoutFunction:
+		ctx.WriteString("WITHOUT FUNCTION")
+	case CreateCastType_Inout:
+		ctx.WriteString("WITH INOUT")
+	}
+	switch node.Scope {
+	case CreateCastScope_Explicit:
+		// Nothing to write
+	case CreateCastScope_Assignment:
+		ctx.WriteString(" AS ASSIGNMENT")
+	case CreateCastScope_Implicit:
+		ctx.WriteString(" AS IMPLICIT")
+	}
+}

--- a/postgres/parser/sem/tree/create_function.go
+++ b/postgres/parser/sem/tree/create_function.go
@@ -17,8 +17,6 @@ package tree
 import (
 	"strings"
 
-	"github.com/lib/pq"
-
 	"github.com/dolthub/doltgresql/postgres/parser/types"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
@@ -303,10 +301,11 @@ func (node *Return) Format(ctx *FmtCtx) {
 // It is not used directly during parsing, but replaces the ColumnItem
 // or Placeholder input.
 type FunctionColumn struct {
-	Name   string
-	Idx    uint16
-	Typ    *pgtypes.DoltgresType
-	StrVal string // Do not set it for CREATE FUNCTION
+	Name       string
+	Idx        uint16
+	Typ        *pgtypes.DoltgresType
+	FromCreate bool
+	Val        any
 }
 
 // ResolvedType implements the TypedExpr interface.
@@ -316,14 +315,5 @@ func (f FunctionColumn) ResolvedType() *types.T {
 
 // Format implements the NodeFormatter interface.
 func (f FunctionColumn) Format(ctx *FmtCtx) {
-	if f.StrVal == "" {
-		ctx.WriteString(f.Name)
-	}
-	// only used when generating query with parameters replaced with actual value
-	switch f.Typ.TypCategory {
-	case pgtypes.TypeCategory_ArrayTypes, pgtypes.TypeCategory_DateTimeTypes, pgtypes.TypeCategory_StringTypes, pgtypes.TypeCategory_UserDefinedTypes:
-		ctx.WriteString(pq.QuoteLiteral(f.StrVal))
-	default:
-		ctx.WriteString(f.StrVal)
-	}
+	ctx.WriteString(f.Name)
 }

--- a/postgres/parser/sem/tree/drop.go
+++ b/postgres/parser/sem/tree/drop.go
@@ -90,6 +90,28 @@ func (node *DropAggregate) Format(ctx *FmtCtx) {
 	}
 }
 
+// DropCast represents a DROP CAST statement.
+type DropCast struct {
+	Source   ResolvableTypeReference
+	Target   ResolvableTypeReference
+	IfExists bool
+}
+
+var _ Statement = &DropCast{}
+
+// Format implements the NodeFormatter interface.
+func (node *DropCast) Format(ctx *FmtCtx) {
+	ctx.WriteString("DROP CAST ")
+	if node.IfExists {
+		ctx.WriteString("IF EXISTS ")
+	}
+	ctx.WriteString("(")
+	ctx.WriteString(node.Source.SQLString())
+	ctx.WriteString(" AS ")
+	ctx.WriteString(node.Target.SQLString())
+	ctx.WriteString(")")
+}
+
 var _ Statement = &DropDatabase{}
 
 // DropDatabase represents a DROP DATABASE statement.

--- a/postgres/parser/sem/tree/stmt.go
+++ b/postgres/parser/sem/tree/stmt.go
@@ -465,6 +465,12 @@ func (*CreateAggregate) StatementType() StatementType { return DDL }
 func (*CreateAggregate) StatementTag() string { return "CREATE AGGREGATE" }
 
 // StatementType implements the Statement interface.
+func (*CreateCast) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*CreateCast) StatementTag() string { return "CREATE CAST" }
+
+// StatementType implements the Statement interface.
 func (*CreateChangefeed) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
@@ -621,6 +627,12 @@ func (*DropAggregate) StatementType() StatementType { return DDL }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*DropAggregate) StatementTag() string { return "DROP AGGREGATE" }
+
+// StatementType implements the Statement interface.
+func (*DropCast) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*DropCast) StatementTag() string { return "DROP CAST" }
 
 // StatementType implements the Statement interface.
 func (*DropDatabase) StatementType() StatementType { return DDL }
@@ -1217,6 +1229,7 @@ func (n *Comment) String() string                   { return AsString(n) }
 func (n *CommitTransaction) String() string         { return AsString(n) }
 func (n *CopyFrom) String() string                  { return AsString(n) }
 func (n *CreateAggregate) String() string           { return AsString(n) }
+func (n *CreateCast) String() string                { return AsString(n) }
 func (n *CreateChangefeed) String() string          { return AsString(n) }
 func (n *CreateDatabase) String() string            { return AsString(n) }
 func (n *CreateDomain) String() string              { return AsString(n) }
@@ -1237,6 +1250,7 @@ func (n *CreateView) String() string                { return AsString(n) }
 func (n *Deallocate) String() string                { return AsString(n) }
 func (n *Delete) String() string                    { return AsString(n) }
 func (n *DropAggregate) String() string             { return AsString(n) }
+func (n *DropCast) String() string                  { return AsString(n) }
 func (n *DropDatabase) String() string              { return AsString(n) }
 func (n *DropDomain) String() string                { return AsString(n) }
 func (n *DropExtension) String() string             { return AsString(n) }

--- a/server/analyzer/init.go
+++ b/server/analyzer/init.go
@@ -51,6 +51,7 @@ const (
 	ruleId_ValidateCreateFunction                                        // validateCreateFunction
 	ruleId_ResolveValuesTypes                                            // resolveValuesTypes
 	ruleId_ResolveProcedureDefaults                                      // resolveProcedureDefaults
+	ruleId_SetRunner                                                     // setRunner
 )
 
 // Init adds additional rules to the analyzer to handle Doltgres-specific functionality.
@@ -66,6 +67,7 @@ func Init() {
 		// ResolveType rule must run in this batch in addition to OnceBeforeDefault batch
 		// because of custom batch set optimization in GMS skipping OnceBeforeDefault batch for some nodes.
 		analyzer.Rule{Id: ruleId_ResolveType, Apply: ResolveType},
+		analyzer.Rule{Id: ruleId_SetRunner, Apply: SetRunner},
 		analyzer.Rule{Id: ruleId_TypeSanitizer, Apply: TypeSanitizer},
 		analyzer.Rule{Id: ruleId_ResolveValuesTypes, Apply: ResolveValuesTypes},
 		analyzer.Rule{Id: ruleId_GenerateForeignKeyName, Apply: generateForeignKeyName},

--- a/server/analyzer/resolve_routine_defaults.go
+++ b/server/analyzer/resolve_routine_defaults.go
@@ -109,6 +109,7 @@ func ResolveProcedureDefaults(ctx *sql.Context, a *analyzer.Analyzer, node sql.N
 					Variadic:           false,
 					IsNonDeterministic: true,
 					Strict:             false,
+					SRF:                false,
 					Statements:         overload.Operations,
 				}); err != nil {
 					return nil, transform.SameTree, err

--- a/server/analyzer/resolve_type.go
+++ b/server/analyzer/resolve_type.go
@@ -65,19 +65,54 @@ func ResolveTypeForNodes(ctx *sql.Context, a *analyzer.Analyzer, node sql.Node, 
 				col.Type = dt
 			}
 			return node, same, nil
-		case *pgnodes.CreateFunction:
-			retType, err := resolveType(ctx, db, n.ReturnType)
-			if err != nil {
-				return nil, transform.NewTree, err
-			}
-			for i := range n.Parameters {
-				n.Parameters[i].Type, err = resolveType(ctx, db, n.Parameters[i].Type)
+		case *pgnodes.CreateCast:
+			if !n.Source.IsResolvedType() {
+				source, err := resolveType(ctx, db, n.Source)
 				if err != nil {
 					return nil, transform.NewTree, err
 				}
+				same = transform.NewTree
+				n.Source = source
 			}
-			n.ReturnType = retType
-			return node, transform.NewTree, nil
+			if !n.Target.IsResolvedType() {
+				target, err := resolveType(ctx, db, n.Target)
+				if err != nil {
+					return nil, transform.NewTree, err
+				}
+				same = transform.NewTree
+				n.Target = target
+			}
+			for i, param := range n.FuncParams {
+				if !param.Type.IsResolvedType() {
+					target, err := resolveType(ctx, db, param.Type)
+					if err != nil {
+						return nil, transform.NewTree, err
+					}
+					same = transform.NewTree
+					n.FuncParams[i].Type = target
+				}
+			}
+			return node, same, nil
+		case *pgnodes.CreateFunction:
+			if !n.ReturnType.IsResolvedType() {
+				retType, err := resolveType(ctx, db, n.ReturnType)
+				if err != nil {
+					return nil, transform.NewTree, err
+				}
+				same = transform.NewTree
+				n.ReturnType = retType
+			}
+			for i, param := range n.Parameters {
+				if !param.Type.IsResolvedType() {
+					paramType, err := resolveType(ctx, db, param.Type)
+					if err != nil {
+						return nil, transform.NewTree, err
+					}
+					same = transform.NewTree
+					n.Parameters[i].Type = paramType
+				}
+			}
+			return node, same, nil
 		case *pgnodes.CreateProcedure:
 			for i := range n.Parameters {
 				var err error
@@ -112,6 +147,24 @@ func ResolveTypeForNodes(ctx *sql.Context, a *analyzer.Analyzer, node sql.Node, 
 				if resolvedDefault || resolvedGenerated || resolvedOnUpdate {
 					same = transform.NewTree
 				}
+			}
+			return node, same, nil
+		case *pgnodes.DropCast:
+			if !n.Source.IsResolvedType() {
+				source, err := resolveType(ctx, db, n.Source)
+				if err != nil {
+					return nil, transform.NewTree, err
+				}
+				same = transform.NewTree
+				n.Source = source
+			}
+			if !n.Target.IsResolvedType() {
+				target, err := resolveType(ctx, db, n.Target)
+				if err != nil {
+					return nil, transform.NewTree, err
+				}
+				same = transform.NewTree
+				n.Target = target
 			}
 			return node, same, nil
 		case *pgnodes.DropFunction:
@@ -183,6 +236,17 @@ func ResolveTypeForExprs(ctx *sql.Context, a *analyzer.Analyzer, node sql.Node, 
 				return nil, transform.NewTree, err
 			}
 			return expr.WithType(newType), transform.NewTree, nil
+		case *pgnodes.FunctionColumn:
+			if expr.Typ.IsResolvedType() {
+				// The type has already been resolved
+				return expr, transform.SameTree, nil
+			}
+			newType, err := resolveType(ctx, db, expr.Typ)
+			if err != nil {
+				return nil, transform.NewTree, err
+			}
+			expr.Typ = newType
+			return expr, transform.NewTree, nil
 		default:
 			// TODO: add expressions that use unresolved types like domain
 			return expr, transform.SameTree, nil
@@ -202,21 +266,21 @@ func resolveType(ctx *sql.Context, db sql.Database, typ *pgtypes.DoltgresType) (
 
 	// schema name can be empty
 	schema, _ := core.GetSchemaName(ctx, db, typ.ID.SchemaName())
-	resolvedTyp, _ := typs.GetType(ctx, id.NewType(schema, typ.ID.TypeName()))
-	if resolvedTyp == nil {
+	resolvedType, _ := typs.GetType(ctx, id.NewType(schema, typ.ID.TypeName()))
+	if resolvedType == nil {
 		// If a blank schema is provided, then we'll also try the pg_catalog, since a type is most likely to be there
 		if typ.ID.SchemaName() == "" {
-			resolvedTyp, err = typs.GetType(ctx, id.NewType("pg_catalog", typ.ID.TypeName()))
+			resolvedType, err = typs.GetType(ctx, id.NewType("pg_catalog", typ.ID.TypeName()))
 			if err != nil {
 				return nil, err
 			}
-			if resolvedTyp != nil && (typ.ID.TypeName() == "unknown" || resolvedTyp.ID != pgtypes.Unknown.ID) {
-				return resolvedTyp, nil
+			if resolvedType != nil && (typ.ID.TypeName() == "unknown" || resolvedType.ID != pgtypes.Unknown.ID) {
+				return resolvedType, nil
 			}
 		}
 		return nil, pgtypes.ErrTypeDoesNotExist.New(typ.Name())
 	}
-	return resolvedTyp, nil
+	return resolvedType, nil
 }
 
 // resolveDefaultColumnType resolves the OutType of a *sql.ColumnDefaultValue if it's not nil (and not already resolved).

--- a/server/analyzer/set_runner.go
+++ b/server/analyzer/set_runner.go
@@ -12,22 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package casts
+package analyzer
 
 import (
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/analyzer"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/transform"
 
-	"github.com/dolthub/doltgresql/core/id"
+	"github.com/dolthub/doltgresql/core"
 )
 
-// Init initializes this package.
-func Init(
-	getRunnerFromCtx func(ctx *sql.Context) (sql.StatementRunner, error),
-	getIsStrictFromFunc func(f sql.Expression) bool,
-	provider sql.FunctionProvider,
-) map[id.Cast]Cast {
-	functionProvider = provider
-	getRunnerFromContext = getRunnerFromCtx
-	getIsStrictFromFunction = getIsStrictFromFunc
-	return builtInCasts
+// SetRunner sets the StatementRunner in the context.
+func SetRunner(ctx *sql.Context, a *analyzer.Analyzer, node sql.Node, scope *plan.Scope, selector analyzer.RuleSelector, qFlags *sql.QueryFlags) (sql.Node, transform.TreeIdentity, error) {
+	return node, transform.SameTree, core.SetRunnerOnContext(ctx, a.Runner)
 }

--- a/server/ast/convert.go
+++ b/server/ast/convert.go
@@ -87,6 +87,8 @@ func Convert(postgresStmt parser.Statement) (vitess.Statement, error) {
 		return nodeCopyFrom(ctx, stmt)
 	case *tree.CreateAggregate:
 		return nodeCreateAggregate(ctx, stmt)
+	case *tree.CreateCast:
+		return nodeCreateCast(ctx, stmt)
 	case *tree.CreateChangefeed:
 		return nodeCreateChangefeed(ctx, stmt)
 	case *tree.CreateDatabase:
@@ -127,6 +129,8 @@ func Convert(postgresStmt parser.Statement) (vitess.Statement, error) {
 		return nodeDiscard(ctx, stmt)
 	case *tree.DropAggregate:
 		return nodeDropAggregate(ctx, stmt)
+	case *tree.DropCast:
+		return nodeDropCast(ctx, stmt)
 	case *tree.DropDatabase:
 		return nodeDropDatabase(ctx, stmt)
 	case *tree.DropDomain:

--- a/server/ast/create_cast.go
+++ b/server/ast/create_cast.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast
+
+import (
+	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
+
+	"github.com/dolthub/doltgresql/core/casts"
+	"github.com/dolthub/doltgresql/postgres/parser/sem/tree"
+	"github.com/dolthub/doltgresql/server/auth"
+	pgnodes "github.com/dolthub/doltgresql/server/node"
+)
+
+// nodeCreateCast handles *tree.CreateCast nodes.
+func nodeCreateCast(ctx *Context, node *tree.CreateCast) (vitess.Statement, error) {
+	if node == nil {
+		return nil, nil
+	}
+	_, sourceType, err := nodeResolvableTypeReference(ctx, node.Source, false)
+	if err != nil {
+		return nil, err
+	}
+	_, targetType, err := nodeResolvableTypeReference(ctx, node.Target, false)
+	if err != nil {
+		return nil, err
+	}
+	var funcName tree.TableName
+	var funcParams []pgnodes.RoutineParam
+	switch node.Type {
+	case tree.CreateCastType_WithFunction:
+		funcName = node.FuncName.ToTableName()
+		funcParams = make([]pgnodes.RoutineParam, len(node.FuncArgs))
+		for i, arg := range node.FuncArgs {
+			funcParams[i].Name = arg.Name.String()
+			_, funcParams[i].Type, err = nodeResolvableTypeReference(ctx, arg.Type, false)
+			if err != nil {
+				return nil, err
+			}
+		}
+	case tree.CreateCastType_WithoutFunction:
+		// TODO: restrict to superusers only with error: "must be superuser to create a cast WITHOUT FUNCTION"
+	case tree.CreateCastType_Inout:
+		// Nothing to do
+	default:
+		panic("unhandled case")
+	}
+	var scope casts.CastType
+	switch node.Scope {
+	case tree.CreateCastScope_Explicit:
+		scope = casts.CastType_Explicit
+	case tree.CreateCastScope_Assignment:
+		scope = casts.CastType_Assignment
+	case tree.CreateCastScope_Implicit:
+		scope = casts.CastType_Implicit
+	}
+	return vitess.InjectedStatement{
+		Statement: pgnodes.NewCreateCast(
+			sourceType,
+			targetType,
+			scope,
+			node.Type,
+			funcName.Schema(),
+			funcName.Table(),
+			funcParams,
+		),
+		Auth: vitess.AuthInformation{
+			AuthType:    auth.AuthType_CREATE,
+			TargetType:  auth.AuthTargetType_TODO,
+			TargetNames: []string{},
+		},
+	}, nil
+}

--- a/server/ast/create_function.go
+++ b/server/ast/create_function.go
@@ -167,7 +167,7 @@ func nodeCreateFunction(ctx *Context, node *tree.CreateFunction) (vitess.Stateme
 			parsedBody,
 			sqlDef,
 			sqlDefParsedStmts,
-			node.ReturnsSetOf,
+			node.ReturnsSetOf || node.ReturnsTable,
 		),
 		Auth: vitess.AuthInformation{
 			AuthType:    auth.AuthType_CREATE,
@@ -222,8 +222,9 @@ func convertSQLStmts(stmts parser.Statements, params []pgnodes.RoutineParam) (st
 	paramMap := make(map[string]*framework.ParamTypAndValue, len(params))
 	for i, param := range params {
 		tv := &framework.ParamTypAndValue{
-			Typ:    param.Type,
-			StrVal: "", // must be empty string
+			Typ:        param.Type,
+			Val:        nil,
+			FromCreate: true,
 		}
 		// placeholder name is empty
 		if param.Name == "\"\"" {

--- a/server/ast/drop_cast.go
+++ b/server/ast/drop_cast.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast
+
+import (
+	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
+
+	"github.com/dolthub/doltgresql/postgres/parser/sem/tree"
+	"github.com/dolthub/doltgresql/server/auth"
+	pgnodes "github.com/dolthub/doltgresql/server/node"
+)
+
+// nodeDropCast handles *tree.DropCast nodes.
+func nodeDropCast(ctx *Context, node *tree.DropCast) (vitess.Statement, error) {
+	if node == nil {
+		return nil, nil
+	}
+	_, sourceType, err := nodeResolvableTypeReference(ctx, node.Source, false)
+	if err != nil {
+		return nil, err
+	}
+	_, targetType, err := nodeResolvableTypeReference(ctx, node.Target, false)
+	if err != nil {
+		return nil, err
+	}
+	return vitess.InjectedStatement{
+		Statement: pgnodes.NewDropCast(
+			sourceType,
+			targetType,
+			node.IfExists,
+		),
+		Auth: vitess.AuthInformation{
+			AuthType:    auth.AuthType_DELETE,
+			TargetType:  auth.AuthTargetType_TODO,
+			TargetNames: []string{},
+		},
+	}, nil
+}

--- a/server/ast/expr.go
+++ b/server/ast/expr.go
@@ -599,9 +599,15 @@ func nodeExpr(ctx *Context, node tree.Expr) (vitess.Expr, error) {
 			Expression: &pgnodes.DomainColumn{Typ: dataType},
 		}, nil
 	case tree.FunctionColumn:
-		return vitess.InjectedExpr{
-			Expression: &pgnodes.FunctionColumn{Name: node.Name, Typ: node.Typ, Idx: node.Idx},
-		}, nil
+		if !node.FromCreate {
+			return vitess.InjectedExpr{
+				Expression: pgexprs.NewUnsafeLiteral(node.Val, node.Typ),
+			}, nil
+		} else {
+			return vitess.InjectedExpr{
+				Expression: &pgnodes.FunctionColumn{Name: node.Name, Typ: node.Typ, Idx: node.Idx},
+			}, nil
+		}
 	case *tree.FuncExpr:
 		return nodeFuncExpr(ctx, node)
 	case *tree.IfErrExpr:

--- a/server/expression/column_access.go
+++ b/server/expression/column_access.go
@@ -20,8 +20,10 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
 	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
 
+	"github.com/dolthub/doltgresql/core"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
@@ -112,7 +114,11 @@ func (expr *ColumnAccess) Type(ctx *sql.Context) sql.Type {
 	if expr.child == nil {
 		return nil
 	}
-	return expr.child.Type(ctx).(*pgtypes.DoltgresType).CompositeAttrs[expr.colNameIdx].Type
+	typ, ok := expr.child.Type(ctx).(*pgtypes.DoltgresType)
+	if !ok {
+		return pgtypes.Unknown
+	}
+	return typ.CompositeAttrs[expr.colNameIdx].Type
 }
 
 // WithChildren implements the sql.Expression interface.
@@ -120,18 +126,41 @@ func (expr *ColumnAccess) WithChildren(ctx *sql.Context, children ...sql.Express
 	if len(children) != 1 {
 		return nil, sql.ErrInvalidChildrenNumber.New(expr, len(children), 1)
 	}
-	childType := children[0].Type(ctx)
+	child := children[0]
+	childType := child.Type(ctx)
 	doltgresType, ok := childType.(*pgtypes.DoltgresType)
 	if !ok {
+		if _, ok := child.(*expression.BindVar); ok {
+			return &ColumnAccess{
+				colName:    expr.colName,
+				colNameIdx: expr.colNameIdx,
+				colTyp:     expr.colTyp,
+				child:      child,
+			}, nil
+		}
 		return nil, errors.New("column access is only valid for Doltgres types")
+	}
+	if !doltgresType.IsResolvedType() {
+		typeColl, err := core.GetTypesCollectionFromContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+		resolvedType, err := typeColl.ResolveType(ctx, doltgresType.ID)
+		if err != nil {
+			return nil, err
+		}
+		doltgresType = resolvedType
+	}
+	if !doltgresType.IsDefined {
+		return nil, pgtypes.ErrTypeIsOnlyAShell.New(doltgresType.Name())
 	}
 	if !doltgresType.IsCompositeType() {
 		if len(expr.colName) > 0 {
 			return nil, errors.Errorf("column notation .%s applied to type %s, which is not a composite type",
-				expr.colName, children[0].Type(ctx).String())
+				expr.colName, child.Type(ctx).String())
 		} else {
 			return nil, errors.Errorf("column notation .@%d applied to type %s, which is not a composite type",
-				expr.colNameIdx+1, children[0].Type(ctx).String())
+				expr.colNameIdx+1, child.Type(ctx).String())
 		}
 	}
 	var idx int
@@ -150,15 +179,15 @@ func (expr *ColumnAccess) WithChildren(ctx *sql.Context, children ...sql.Express
 	} else {
 		if expr.colNameIdx < 0 || expr.colNameIdx >= len(doltgresType.CompositeAttrs) {
 			return nil, errors.Errorf("column notation .@%d applied to type %s is out of bounds",
-				expr.colNameIdx+1, children[0].Type(ctx).String())
+				expr.colNameIdx+1, child.Type(ctx).String())
 		}
 		idx = expr.colNameIdx
 	}
 	return &ColumnAccess{
 		colName:    expr.colName,
 		colNameIdx: idx,
-		colTyp:     expr.colTyp,
-		child:      children[0],
+		colTyp:     doltgresType.CompositeAttrs[idx].Type,
+		child:      child,
 	}, nil
 }
 

--- a/server/expression/explicit_cast.go
+++ b/server/expression/explicit_cast.go
@@ -91,12 +91,6 @@ func (c *ExplicitCast) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 		}
 		sourceType = gmsCast.DoltgresType(ctx)
 	}
-	if val == nil {
-		if c.castToType.TypType == pgtypes.TypeType_Domain && !c.domainNullable {
-			return nil, pgtypes.ErrDomainDoesNotAllowNullValues.New(c.castToType.Name())
-		}
-		return nil, nil
-	}
 
 	baseCastToType := checkForDomainType(c.castToType)
 	castsColl, err := core.GetCastsCollectionFromContext(ctx)
@@ -112,6 +106,14 @@ func (c *ExplicitCast) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 			"EXPLICIT CAST: cast from `%s` to `%s` does not exist: %s",
 			sourceType.String(), c.castToType.String(), c.sqlChild.String(),
 		)
+	}
+	if val == nil {
+		if c.castToType.TypType == pgtypes.TypeType_Domain && !c.domainNullable {
+			return nil, pgtypes.ErrDomainDoesNotAllowNullValues.New(c.castToType.Name())
+		}
+		if !cast.Function.IsValid() {
+			return nil, nil
+		}
 	}
 	castResult, err := cast.Eval(ctx, val, sourceType, c.castToType)
 	if err != nil {

--- a/server/functions/framework/catalog.go
+++ b/server/functions/framework/catalog.go
@@ -22,7 +22,9 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/analyzer"
 	"github.com/dolthub/go-mysql-server/sql/expression/function"
+	"github.com/dolthub/vitess/go/vt/sqlparser"
 
+	"github.com/dolthub/doltgresql/postgres/parser/parser"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
@@ -97,7 +99,7 @@ func RegisterAggregateFunction(f AggregateFunctionInterface) {
 
 // Initialize handles the initialization of the catalog by overwriting the built-in GMS functions, since they do not
 // apply to PostgreSQL (and functions of the same name often have different behavior).
-func Initialize() {
+func Initialize(astConvert func(parser.Statement) (sqlparser.Statement, error)) {
 	// This should only be called once. We don't use sync.Once since we also want to panic if someone attempts to
 	// register a function after initialization.
 	if initializedFunctions {
@@ -105,6 +107,7 @@ func Initialize() {
 	}
 	initializedFunctions = true
 
+	convertToVitess = astConvert
 	pgtypes.LoadFunctionFromCatalog = getQuickFunctionForTypes
 	analyzer.ExternalFunctionProvider = &FunctionProvider{}
 	replaceGmsBuiltIns()

--- a/server/functions/framework/compiled_function.go
+++ b/server/functions/framework/compiled_function.go
@@ -248,6 +248,14 @@ func (c *CompiledFunction) IsNonDeterministic() bool {
 	return true
 }
 
+// IsStrict returns whether this function has the STRICT property regarding nulls.
+func (c *CompiledFunction) IsStrict() bool {
+	if c.overload.Valid() {
+		return c.overload.Function().IsStrict()
+	}
+	return false
+}
+
 // IsSRF returns whether this function is a set returning function.
 func (c *CompiledFunction) IsSRF() bool {
 	if c.overload.Valid() {

--- a/server/functions/framework/interpreted_function.go
+++ b/server/functions/framework/interpreted_function.go
@@ -39,6 +39,7 @@ type InterpretedFunction struct {
 	Variadic           bool
 	IsNonDeterministic bool
 	Strict             bool
+	SRF                bool
 	Statements         []plpgsql.InterpreterOperation
 }
 
@@ -87,12 +88,7 @@ func (iFunc InterpretedFunction) IsStrict() bool {
 
 // IsSRF implements the interface FunctionInterface.
 func (iFunc InterpretedFunction) IsSRF() bool {
-	switch iFunc.ReturnType.TypCategory {
-	case pgtypes.TypeCategory_CompositeTypes:
-		return true
-	default:
-		return false
-	}
+	return iFunc.SRF
 }
 
 // NonDeterministic implements the interface FunctionInterface.
@@ -220,7 +216,7 @@ func (InterpretedFunction) ApplyBindings(ctx *sql.Context, stack plpgsql.Interpr
 			}
 			if enforceType {
 				switch variable.Type.TypCategory {
-				case pgtypes.TypeCategory_ArrayTypes, pgtypes.TypeCategory_DateTimeTypes, pgtypes.TypeCategory_StringTypes, pgtypes.TypeCategory_UserDefinedTypes:
+				case pgtypes.TypeCategory_ArrayTypes, pgtypes.TypeCategory_CompositeTypes, pgtypes.TypeCategory_DateTimeTypes, pgtypes.TypeCategory_StringTypes, pgtypes.TypeCategory_UserDefinedTypes:
 					formattedVar = pq.QuoteLiteral(formattedVar)
 				}
 			}
@@ -228,7 +224,11 @@ func (InterpretedFunction) ApplyBindings(ctx *sql.Context, stack plpgsql.Interpr
 			formattedVar = "NULL"
 		}
 		if enforceType {
-			newStmt = strings.Replace(newStmt, "$"+strconv.Itoa(i+1), fmt.Sprintf(`((%s)::%s)`, formattedVar, variable.Type.String()), 1)
+			if variable.Type.TypCategory == pgtypes.TypeCategory_CompositeTypes {
+				newStmt = strings.Replace(newStmt, "$"+strconv.Itoa(i+1), fmt.Sprintf(`(%s::%s)`, formattedVar, variable.Type.String()), 1)
+			} else {
+				newStmt = strings.Replace(newStmt, "$"+strconv.Itoa(i+1), fmt.Sprintf(`((%s)::%s)`, formattedVar, variable.Type.String()), 1)
+			}
 		} else {
 			newStmt = strings.Replace(newStmt, "$"+strconv.Itoa(i+1), formattedVar, 1)
 		}

--- a/server/functions/framework/interpreted_function_test.go
+++ b/server/functions/framework/interpreted_function_test.go
@@ -35,7 +35,7 @@ import (
 func TestApplyBindings_RendersRegclassVariableThroughSessionContext(t *testing.T) {
 	t.Parallel()
 	functions.Init()
-	framework.Initialize()
+	framework.Initialize(nil)
 	ctx := sql.NewEmptyContext()
 	stack := plpgsql.NewInterpreterStack(nil)
 	stack.NewVariableWithValue("rel", pgtypes.Regclass, id.NewOID(1259).AsId())

--- a/server/functions/framework/provider.go
+++ b/server/functions/framework/provider.go
@@ -118,6 +118,7 @@ func (fp *FunctionProvider) Function(ctx *sql.Context, schema, name string) (sql
 				Variadic:           overload.Variadic,
 				IsNonDeterministic: overload.IsNonDeterministic,
 				Strict:             overload.Strict,
+				SRF:                overload.SetOf,
 				Statements:         overload.Operations,
 			}); err != nil {
 				return nil, false

--- a/server/functions/framework/sql_function.go
+++ b/server/functions/framework/sql_function.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/doltgresql/core/id"
 	"github.com/dolthub/doltgresql/postgres/parser/parser"
@@ -102,17 +103,14 @@ func (sqlFunc SQLFunction) enforceInterfaceInheritance(error) {}
 func CallSqlFunction(ctx *sql.Context, f SQLFunction, runner sql.StatementRunner, args []any) (any, error) {
 	paramMap := make(map[string]*ParamTypAndValue)
 	for i, name := range f.ParameterNames {
-		formattedVar, err := f.ParameterTypes[i].FormatValueWithContext(ctx, args[i])
-		if err != nil {
-			return nil, err
-		}
 		if name == "" {
-			// sanity check
+			// This allows for positional references such as $1, $2, etc.
 			name = fmt.Sprintf("$%d", i+1)
 		}
 		paramMap[name] = &ParamTypAndValue{
-			Typ:    f.ParameterTypes[i],
-			StrVal: formattedVar,
+			Typ:        f.ParameterTypes[i],
+			Val:        args[i],
+			FromCreate: false,
 		}
 	}
 
@@ -133,8 +131,12 @@ func CallSqlFunction(ctx *sql.Context, f SQLFunction, runner sql.StatementRunner
 			if err != nil {
 				return nil, err
 			}
+			convertedAST, err := convertToVitess(parsed)
+			if err != nil {
+				return nil, err
+			}
 			res, err = sql.RunInterpreted(ctx, func(subCtx *sql.Context) (any, error) {
-				sch, rowIter, _, err := runner.QueryWithBindings(ctx, parsed.AST.String(), nil, nil, nil)
+				sch, rowIter, _, err := runner.QueryWithBindings(ctx, parsed.AST.String(), convertedAST, nil, nil)
 				if err != nil {
 					return nil, err
 				}
@@ -169,9 +171,13 @@ func CallSqlFunction(ctx *sql.Context, f SQLFunction, runner sql.StatementRunner
 	if err != nil {
 		return nil, err
 	}
+	convertedAST, err := convertToVitess(parsed)
+	if err != nil {
+		return nil, err
+	}
 	// stmt.AST is updated at this point with FunctionColumn
 	return sql.RunInterpreted(ctx, func(subCtx *sql.Context) (any, error) {
-		sch, rowIter, _, err := runner.QueryWithBindings(ctx, parsed.AST.String(), nil, nil, nil)
+		sch, rowIter, _, err := runner.QueryWithBindings(ctx, parsed.AST.String(), convertedAST, nil, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -205,8 +211,9 @@ func CallSqlFunction(ctx *sql.Context, f SQLFunction, runner sql.StatementRunner
 // ParamTypAndValue contains the parameter type and
 // string value of argument if applicable
 type ParamTypAndValue struct {
-	Typ    *pgtypes.DoltgresType
-	StrVal string
+	Typ        *pgtypes.DoltgresType
+	Val        any
+	FromCreate bool
 }
 
 // ReplaceFunctionColumn parses and replaces UnresolvedName and Placeholder expressions
@@ -275,19 +282,21 @@ func ReplaceUnresolvedToFunctionColumn(paramMap map[string]*ParamTypAndValue, ex
 			name := fmt.Sprintf("$%d", v.Idx+1)
 			if tv, ok := paramMap[name]; ok {
 				return false, tree.FunctionColumn{
-					Name:   name,
-					Typ:    tv.Typ,
-					Idx:    uint16(v.Idx),
-					StrVal: tv.StrVal,
+					Name:       name,
+					Typ:        tv.Typ,
+					Idx:        uint16(v.Idx),
+					FromCreate: tv.FromCreate,
+					Val:        tv.Val,
 				}, nil
 			}
 		case *tree.UnresolvedName:
 			name := v.String()
 			if tv, ok := paramMap[name]; ok {
 				return false, tree.FunctionColumn{
-					Name:   name,
-					Typ:    tv.Typ,
-					StrVal: tv.StrVal,
+					Name:       name,
+					Typ:        tv.Typ,
+					FromCreate: tv.FromCreate,
+					Val:        tv.Val,
 				}, nil
 			}
 		}
@@ -318,3 +327,6 @@ func rowIterToRecord(ctx *sql.Context, rowIter sql.RowIter, sch sql.Schema) (sql
 	}
 	return sql.RowsToRowIter(newRows...), nil
 }
+
+// convertToVitess is set by init and is used to avoid import cycles
+var convertToVitess func(postgresStmt parser.Statement) (sqlparser.Statement, error)

--- a/server/hook/delete_table.go
+++ b/server/hook/delete_table.go
@@ -31,6 +31,7 @@ import (
 // BeforeTableDeletion performs all validation necessary to ensure that table deletion does not leave the database in an
 // invalid state.
 func BeforeTableDeletion(ctx *sql.Context, _ sql.StatementRunner, nodeInterface sql.Node) (sql.Node, error) {
+	// TODO: handle casts using a table name
 	n, ok := nodeInterface.(*plan.DropTable)
 	if !ok {
 		return nil, errors.Newf("DROP TABLE pre-hook expected `*plan.DropTable` but received `%T`", nodeInterface)

--- a/server/hook/rename_table.go
+++ b/server/hook/rename_table.go
@@ -30,6 +30,7 @@ import (
 // AfterTableRename handles updating various columns using the table type, alongside other validation that's unique
 // to Doltgres.
 func AfterTableRename(ctx *sql.Context, runner sql.StatementRunner, nodeInterface sql.Node) error {
+	// TODO: handle casts using table names
 	n, ok := nodeInterface.(*plan.RenameTable)
 	if !ok {
 		return errors.Errorf("RENAME TABLE post-hook expected `*plan.RenameTable` but received `%T`", nodeInterface)

--- a/server/initialization/initialization.go
+++ b/server/initialization/initialization.go
@@ -19,11 +19,13 @@ import (
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/env"
 	"github.com/dolthub/dolt/go/libraries/doltcore/servercfg"
+	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/core"
 	"github.com/dolthub/doltgresql/core/casts"
 	"github.com/dolthub/doltgresql/core/rootobject"
 	"github.com/dolthub/doltgresql/server/analyzer"
+	"github.com/dolthub/doltgresql/server/ast"
 	"github.com/dolthub/doltgresql/server/auth"
 	"github.com/dolthub/doltgresql/server/cast"
 	"github.com/dolthub/doltgresql/server/config"
@@ -56,9 +58,14 @@ func Initialize(dEnv *env.DoltEnv, cfg *doltgresservercfg.DoltgresConfig) {
 		unary.Init()
 		functions.Init()
 		aggregate.Init()
-		builtInCasts := casts.Init()
+		builtInCasts := casts.Init(core.GetRunnerFromContext, func(f sql.Expression) bool {
+			if cf, ok := f.(*framework.CompiledFunction); ok {
+				return cf.IsStrict()
+			}
+			return false
+		}, &framework.FunctionProvider{})
 		cast.Init(builtInCasts)
-		framework.Initialize()
+		framework.Initialize(ast.Convert)
 		servercfg.DefaultUnixSocketFilePath = cfgdetails.DefaultPostgresUnixSocketFilePath
 		tables.Init()
 		pgcatalog.Init()

--- a/server/node/create_cast.go
+++ b/server/node/create_cast.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
+
+	"github.com/dolthub/doltgresql/core"
+	"github.com/dolthub/doltgresql/core/casts"
+	"github.com/dolthub/doltgresql/core/id"
+	"github.com/dolthub/doltgresql/postgres/parser/sem/tree"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// CreateCast implements CREATE CAST.
+type CreateCast struct {
+	Source     *pgtypes.DoltgresType
+	Target     *pgtypes.DoltgresType
+	Type       casts.CastType
+	CreateType tree.CreateCastType
+	FuncSchema string
+	FuncName   string
+	FuncParams []RoutineParam
+}
+
+var _ sql.ExecSourceRel = (*CreateCast)(nil)
+var _ vitess.Injectable = (*CreateCast)(nil)
+
+// NewCreateCast returns a new *CreateCast.
+func NewCreateCast(
+	source, target *pgtypes.DoltgresType,
+	typ casts.CastType,
+	createType tree.CreateCastType,
+	funcSch, funcName string,
+	params []RoutineParam) *CreateCast {
+	return &CreateCast{
+		Source:     source,
+		Target:     target,
+		Type:       typ,
+		CreateType: createType,
+		FuncSchema: funcSch,
+		FuncName:   funcName,
+		FuncParams: params,
+	}
+}
+
+// Children implements the interface sql.ExecSourceRel.
+func (c *CreateCast) Children() []sql.Node {
+	return nil
+}
+
+// IsReadOnly implements the interface sql.ExecSourceRel.
+func (c *CreateCast) IsReadOnly() bool {
+	return false
+}
+
+// Resolved implements the interface sql.ExecSourceRel.
+func (c *CreateCast) Resolved() bool {
+	return true
+}
+
+// RowIter implements the interface sql.ExecSourceRel.
+func (c *CreateCast) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error) {
+	castCollection, err := core.GetCastsCollectionFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	newCast := casts.Cast{
+		ID:       id.NewCast(c.Source.ID, c.Target.ID),
+		CastType: c.Type,
+	}
+	if c.Source.ID == c.Target.ID {
+		return nil, errors.New("source data type and target data type are the same")
+	}
+	switch c.CreateType {
+	case tree.CreateCastType_WithFunction:
+		if len(c.FuncParams) < 1 || len(c.FuncParams) > 3 {
+			return nil, errors.New("cast function must take one to three arguments")
+		}
+		if len(c.FuncParams) >= 2 && c.FuncParams[1].Type.ID != pgtypes.Int32.ID {
+			return nil, errors.New("second argument of cast function must be type integer")
+		}
+		if len(c.FuncParams) >= 3 && c.FuncParams[2].Type.ID != pgtypes.Bool.ID {
+			return nil, errors.New("third argument of cast function must be type boolean")
+		}
+		schemaName, err := core.GetSchemaName(ctx, nil, c.FuncSchema)
+		if err != nil {
+			return nil, err
+		}
+		paramTypes := make([]id.Type, len(c.FuncParams))
+		for i, param := range c.FuncParams {
+			paramTypes[i] = param.Type.ID
+		}
+		funcID := id.NewFunction(schemaName, c.FuncName, paramTypes...)
+		funcCollection, err := core.GetFunctionsCollectionFromContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if !funcCollection.HasFunction(ctx, funcID) {
+			return nil, errors.Errorf("function %s does not exist", funcID.DisplayString())
+		}
+		f, err := funcCollection.GetFunction(ctx, funcID)
+		if err != nil {
+			return nil, err
+		}
+		if f.ParameterTypes[0] != c.Source.ID {
+			// Although the error mentions binary-coercible, we can't actually support that due to how types work in Go.
+			// Our bit representations of values will differ from Postgres.
+			return nil, errors.New("argument of cast function must match or be binary-coercible from source data type")
+		}
+		if f.ReturnType != c.Target.ID {
+			// Although the error mentions binary-coercible, we can't actually support that due to how types work in Go.
+			// Our bit representations of values will differ from Postgres.
+			return nil, errors.New("return data type of cast function must match or be binary-coercible to target data type")
+		}
+		newCast.Function = funcID
+	case tree.CreateCastType_WithoutFunction:
+		if c.Source.IsCompositeType() || c.Target.IsCompositeType() {
+			return nil, errors.New("composite data types are not binary-compatible")
+		}
+		// Due to the differences in how we handle values at the bit level compared to Postgres, we must mark all of
+		// these types of casts as physically incompatible
+		return nil, errors.New("source and target data types are not physically compatible")
+	case tree.CreateCastType_Inout:
+		newCast.UseInOut = true
+	}
+	if castCollection.HasCast(ctx, newCast.ID) {
+		return nil, errors.Errorf("cast from type %s to type %s already exists", c.Source.ID.TypeName(), c.Target.ID.TypeName())
+	}
+	if err = castCollection.AddCast(ctx, newCast); err != nil {
+		return nil, err
+	}
+	return sql.RowsToRowIter(), nil
+}
+
+// Schema implements the interface sql.ExecSourceRel.
+func (c *CreateCast) Schema(ctx *sql.Context) sql.Schema {
+	return nil
+}
+
+// String implements the interface sql.ExecSourceRel.
+func (c *CreateCast) String() string {
+	return "CREATE CAST"
+}
+
+// WithChildren implements the interface sql.ExecSourceRel.
+func (c *CreateCast) WithChildren(ctx *sql.Context, children ...sql.Node) (sql.Node, error) {
+	return plan.NillaryWithChildren(c, children...)
+}
+
+// WithResolvedChildren implements the interface vitess.Injectable.
+func (c *CreateCast) WithResolvedChildren(ctx context.Context, children []any) (any, error) {
+	if len(children) != 0 {
+		return nil, ErrVitessChildCount.New(0, len(children))
+	}
+	return c, nil
+}

--- a/server/node/drop_cast.go
+++ b/server/node/drop_cast.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
+
+	"github.com/dolthub/doltgresql/core"
+	"github.com/dolthub/doltgresql/core/id"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// DropCast implements DROP CAST.
+type DropCast struct {
+	Source   *pgtypes.DoltgresType
+	Target   *pgtypes.DoltgresType
+	IfExists bool
+}
+
+var _ sql.ExecSourceRel = (*DropCast)(nil)
+var _ vitess.Injectable = (*DropCast)(nil)
+
+// NewDropCast returns a new *DropCast.
+func NewDropCast(source *pgtypes.DoltgresType, target *pgtypes.DoltgresType, ifExists bool) *DropCast {
+	return &DropCast{
+		Source:   source,
+		Target:   target,
+		IfExists: ifExists,
+	}
+}
+
+// Children implements the interface sql.ExecSourceRel.
+func (c *DropCast) Children() []sql.Node {
+	return nil
+}
+
+// IsReadOnly implements the interface sql.ExecSourceRel.
+func (c *DropCast) IsReadOnly() bool {
+	return false
+}
+
+// Resolved implements the interface sql.ExecSourceRel.
+func (c *DropCast) Resolved() bool {
+	return true
+}
+
+// RowIter implements the interface sql.ExecSourceRel.
+func (c *DropCast) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error) {
+	castCollection, err := core.GetCastsCollectionFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	castID := id.NewCast(c.Source.ID, c.Target.ID)
+	if !castCollection.HasCast(ctx, castID) {
+		if c.IfExists {
+			// TODO: send notice "cast from type SOURCE_NAME to type TARGET_NAME does not exist, skipping"
+			return sql.RowsToRowIter(), nil
+		}
+		return nil, errors.Errorf("cast from type %s to type %s does not exist", c.Source.Name(), c.Target.Name())
+	}
+	if err = castCollection.DropCast(ctx, castID); err != nil {
+		return nil, err
+	}
+	return sql.RowsToRowIter(), nil
+}
+
+// Schema implements the interface sql.ExecSourceRel.
+func (c *DropCast) Schema(ctx *sql.Context) sql.Schema {
+	return nil
+}
+
+// String implements the interface sql.ExecSourceRel.
+func (c *DropCast) String() string {
+	return "DROP CAST"
+}
+
+// WithChildren implements the interface sql.ExecSourceRel.
+func (c *DropCast) WithChildren(ctx *sql.Context, children ...sql.Node) (sql.Node, error) {
+	return plan.NillaryWithChildren(c, children...)
+}
+
+// WithResolvedChildren implements the interface vitess.Injectable.
+func (c *DropCast) WithResolvedChildren(ctx context.Context, children []any) (any, error) {
+	if len(children) != 0 {
+		return nil, ErrVitessChildCount.New(0, len(children))
+	}
+	return c, nil
+}

--- a/server/node/trigger_execution.go
+++ b/server/node/trigger_execution.go
@@ -175,6 +175,7 @@ func (te *TriggerExecution) loadTriggerFunction(ctx *sql.Context, trigger trigge
 		Variadic:           function.Variadic,
 		IsNonDeterministic: function.IsNonDeterministic,
 		Strict:             function.Strict,
+		SRF:                false,
 		Statements:         function.Operations,
 	}, nil
 }

--- a/server/plpgsql/interpreter_logic.go
+++ b/server/plpgsql/interpreter_logic.go
@@ -323,6 +323,9 @@ func call(ctx *sql.Context, iFunc InterpretedFunction, stack InterpreterStack) (
 				}
 			}
 			val, err := iFunc.QuerySingleReturn(ctx, stack, operation.PrimaryData, iFunc.GetReturn(), operation.SecondaryData)
+			if err != nil {
+				return nil, err
+			}
 
 			// If this is a set returning function, then we need to return a RowIter and wrap
 			// the composite value in a sql.Row.
@@ -330,7 +333,6 @@ func call(ctx *sql.Context, iFunc InterpretedFunction, stack InterpreterStack) (
 				return sql.RowsToRowIter(sql.Row{val}), nil
 			}
 			return val, err
-
 		case OpCode_ForQueryInit:
 			schema, rows, err := iFunc.QueryMultiReturn(ctx, stack, operation.PrimaryData, operation.SecondaryData)
 			if err != nil {
@@ -358,7 +360,6 @@ func call(ctx *sql.Context, iFunc InterpretedFunction, stack InterpreterStack) (
 				return nil, err
 			}
 			stack.BufferReturnQueryResults(records)
-
 		case OpCode_ScopeBegin:
 			stack.PushScope()
 		case OpCode_ScopeEnd:

--- a/server/tables/pgcatalog/pg_cast.go
+++ b/server/tables/pgcatalog/pg_cast.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/dolthub/go-mysql-server/sql"
 
+	"github.com/dolthub/doltgresql/core"
+	"github.com/dolthub/doltgresql/core/casts"
 	"github.com/dolthub/doltgresql/server/tables"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
@@ -43,11 +45,25 @@ func (p PgCastHandler) Name() string {
 
 // RowIter implements the interface tables.Handler.
 func (p PgCastHandler) RowIter(ctx *sql.Context, partition sql.Partition) (sql.RowIter, error) {
-	// TODO: Implement pg_cast row iter
-	return emptyRowIter()
+	castsColl, err := core.GetCastsCollectionFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var allCasts []casts.Cast
+	err = castsColl.IterateCasts(ctx, func(c casts.Cast) (stop bool, err error) {
+		allCasts = append(allCasts, c)
+		return false, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &pgCastRowIter{
+		allCasts: allCasts,
+		idx:      0,
+	}, nil
 }
 
-// Schema implements the interface tables.Handler.
+// PkSchema implements the interface tables.Handler.
 func (p PgCastHandler) PkSchema() sql.PrimaryKeySchema {
 	return sql.PrimaryKeySchema{
 		Schema:     pgCastSchema,
@@ -67,13 +83,44 @@ var pgCastSchema = sql.Schema{
 
 // pgCastRowIter is the sql.RowIter for the pg_cast table.
 type pgCastRowIter struct {
+	allCasts []casts.Cast
+	idx      int
 }
 
 var _ sql.RowIter = (*pgCastRowIter)(nil)
 
 // Next implements the interface sql.RowIter.
 func (iter *pgCastRowIter) Next(ctx *sql.Context) (sql.Row, error) {
-	return nil, io.EOF
+	if iter.idx >= len(iter.allCasts) {
+		return nil, io.EOF
+	}
+	cast := iter.allCasts[iter.idx]
+	iter.idx++
+	var castContext string
+	switch cast.CastType {
+	case casts.CastType_Explicit:
+		castContext = "e"
+	case casts.CastType_Assignment:
+		castContext = "a"
+	case casts.CastType_Implicit:
+		castContext = "i"
+	}
+	var castMethod string
+	if cast.Function.IsValid() || cast.BuiltIn != nil {
+		castMethod = "f"
+	} else if cast.UseInOut {
+		castMethod = "i"
+	} else {
+		castMethod = "b"
+	}
+	return sql.Row{
+		cast.ID.AsId(),
+		cast.ID.SourceType().AsId(),
+		cast.ID.TargetType().AsId(),
+		cast.Function.AsId(),
+		castContext,
+		castMethod,
+	}, nil
 }
 
 // Close implements the interface sql.RowIter.

--- a/server/tables/pgcatalog/pg_type.go
+++ b/server/tables/pgcatalog/pg_type.go
@@ -86,17 +86,6 @@ func cachePgTypes(ctx *sql.Context, pgCatalogCache *pgCatalogCache) error {
 	nameIdx := NewUniqueInMemIndexStorage[*pgType](lessTypeName)
 	oidIdx := NewUniqueInMemIndexStorage[*pgType](lessTypeOid)
 
-	schemasToOid := make(map[string]id.Namespace)
-	err := functions.IterateCurrentDatabase(ctx, functions.Callbacks{
-		Schema: func(ctx *sql.Context, schema functions.ItemSchema) (cont bool, err error) {
-			schemasToOid[schema.Item.SchemaName()] = schema.OID
-			return true, nil
-		},
-	})
-	if err != nil {
-		return err
-	}
-
 	allTypes := pgtypes.GetAllBuitInTypes()
 	typeColl, err := core.GetTypesCollectionFromContext(ctx)
 	if err != nil {
@@ -112,6 +101,30 @@ func cachePgTypes(ctx *sql.Context, pgCatalogCache *pgCatalogCache) error {
 				allTypes = append(allTypes, userTypes[schema]...)
 			}
 		}
+	}
+
+	schemasToOid := make(map[string]id.Namespace)
+	err = functions.IterateCurrentDatabase(ctx, functions.Callbacks{
+		Schema: func(ctx *sql.Context, schema functions.ItemSchema) (cont bool, err error) {
+			schemasToOid[schema.Item.SchemaName()] = schema.OID
+			return true, nil
+		},
+		Table: func(ctx *sql.Context, schema functions.ItemSchema, table functions.ItemTable) (cont bool, err error) {
+			// Tables create an accompanying composite type, so we must represent those here as well since they're not stored
+			if table.OID.SchemaName() != "information_schema" && table.OID.SchemaName() != PgCatalogName {
+				typ, err := typeColl.GetType(ctx, id.NewType(table.OID.SchemaName(), table.OID.TableName()))
+				if err == nil && typ != nil {
+					allTypes = append(allTypes, typ)
+					if typ.Array.ID.IsValid() {
+						allTypes = append(allTypes, typ.Array)
+					}
+				}
+			}
+			return true, nil
+		},
+	})
+	if err != nil {
+		return err
 	}
 
 	for _, typ := range allTypes {

--- a/testing/generation/command_docs/output/create_cast_test.go
+++ b/testing/generation/command_docs/output/create_cast_test.go
@@ -18,21 +18,21 @@ import "testing"
 
 func TestCreateCast(t *testing.T) {
 	tests := []QueryParses{
-		Unimplemented("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name"),
-		Unimplemented("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name ( argument_type )"),
-		Unimplemented("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name ( argument_type , argument_type )"),
-		Unimplemented("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name AS ASSIGNMENT"),
-		Unimplemented("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name ( argument_type ) AS ASSIGNMENT"),
-		Unimplemented("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name ( argument_type , argument_type ) AS ASSIGNMENT"),
-		Unimplemented("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name AS IMPLICIT"),
-		Unimplemented("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name ( argument_type ) AS IMPLICIT"),
-		Unimplemented("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name ( argument_type , argument_type ) AS IMPLICIT"),
-		Unimplemented("CREATE CAST ( source_type AS target_type ) WITHOUT FUNCTION"),
-		Unimplemented("CREATE CAST ( source_type AS target_type ) WITHOUT FUNCTION AS ASSIGNMENT"),
-		Unimplemented("CREATE CAST ( source_type AS target_type ) WITHOUT FUNCTION AS IMPLICIT"),
-		Unimplemented("CREATE CAST ( source_type AS target_type ) WITH INOUT"),
-		Unimplemented("CREATE CAST ( source_type AS target_type ) WITH INOUT AS ASSIGNMENT"),
-		Unimplemented("CREATE CAST ( source_type AS target_type ) WITH INOUT AS IMPLICIT"),
+		Converts("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name"),
+		Converts("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name ( argument_type )"),
+		Converts("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name ( argument_type , argument_type )"),
+		Converts("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name AS ASSIGNMENT"),
+		Converts("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name ( argument_type ) AS ASSIGNMENT"),
+		Converts("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name ( argument_type , argument_type ) AS ASSIGNMENT"),
+		Converts("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name AS IMPLICIT"),
+		Converts("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name ( argument_type ) AS IMPLICIT"),
+		Converts("CREATE CAST ( source_type AS target_type ) WITH FUNCTION function_name ( argument_type , argument_type ) AS IMPLICIT"),
+		Converts("CREATE CAST ( source_type AS target_type ) WITHOUT FUNCTION"),
+		Converts("CREATE CAST ( source_type AS target_type ) WITHOUT FUNCTION AS ASSIGNMENT"),
+		Converts("CREATE CAST ( source_type AS target_type ) WITHOUT FUNCTION AS IMPLICIT"),
+		Converts("CREATE CAST ( source_type AS target_type ) WITH INOUT"),
+		Converts("CREATE CAST ( source_type AS target_type ) WITH INOUT AS ASSIGNMENT"),
+		Converts("CREATE CAST ( source_type AS target_type ) WITH INOUT AS IMPLICIT"),
 	}
 	RunTests(t, tests)
 }

--- a/testing/generation/command_docs/output/drop_cast_test.go
+++ b/testing/generation/command_docs/output/drop_cast_test.go
@@ -18,12 +18,12 @@ import "testing"
 
 func TestDropCast(t *testing.T) {
 	tests := []QueryParses{
-		Unimplemented("DROP CAST ( source_type AS target_type )"),
-		Unimplemented("DROP CAST IF EXISTS ( source_type AS target_type )"),
-		Unimplemented("DROP CAST ( source_type AS target_type ) CASCADE"),
-		Unimplemented("DROP CAST IF EXISTS ( source_type AS target_type ) CASCADE"),
-		Unimplemented("DROP CAST ( source_type AS target_type ) RESTRICT"),
-		Unimplemented("DROP CAST IF EXISTS ( source_type AS target_type ) RESTRICT"),
+		Converts("DROP CAST ( source_type AS target_type )"),
+		Converts("DROP CAST IF EXISTS ( source_type AS target_type )"),
+		Converts("DROP CAST ( source_type AS target_type ) CASCADE"),
+		Converts("DROP CAST IF EXISTS ( source_type AS target_type ) CASCADE"),
+		Converts("DROP CAST ( source_type AS target_type ) RESTRICT"),
+		Converts("DROP CAST IF EXISTS ( source_type AS target_type ) RESTRICT"),
 	}
 	RunTests(t, tests)
 }

--- a/testing/go/create_cast_test.go
+++ b/testing/go/create_cast_test.go
@@ -1,0 +1,452 @@
+/// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _go
+
+import (
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+func TestCasts(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "CREATE CAST with function creates explicit-only cast",
+			SetUpScript: []string{
+				`CREATE TABLE cast_explicit_src (v text);`,
+				`CREATE TABLE cast_explicit_dst (v text, tag text);`,
+				`CREATE FUNCTION cast_explicit_fn(src cast_explicit_src) RETURNS cast_explicit_dst
+					AS $$ SELECT ROW((src).v, 'explicit')::cast_explicit_dst $$ LANGUAGE SQL;`,
+				`CREATE FUNCTION cast_explicit_accept(dst cast_explicit_dst) RETURNS text
+					AS $$ SELECT (dst).v || ':' || (dst).tag $$ LANGUAGE SQL;`,
+				`CREATE TABLE cast_explicit_holder (v cast_explicit_dst);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `CREATE CAST (cast_explicit_src AS cast_explicit_dst) WITH FUNCTION cast_explicit_fn(cast_explicit_src);`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT cast_explicit_accept((ROW('one')::cast_explicit_src)::cast_explicit_dst);`,
+					Expected: []sql.Row{{"one:explicit"}},
+				},
+				{
+					Query:       `SELECT cast_explicit_accept(ROW('one')::cast_explicit_src);`,
+					ExpectedErr: "does not exist",
+				},
+				{
+					Query:       `INSERT INTO cast_explicit_holder VALUES (ROW('one')::cast_explicit_src);`,
+					ExpectedErr: "cast_explicit_src",
+				},
+				{
+					Query: `SELECT c.castcontext::text, c.castmethod::text
+						FROM pg_cast c
+						JOIN pg_type src ON src.oid = c.castsource
+						JOIN pg_type dst ON dst.oid = c.casttarget
+						WHERE src.typname = 'cast_explicit_src'
+						  AND dst.typname = 'cast_explicit_dst';`,
+					Expected: []sql.Row{{"e", "f"}},
+				},
+				{
+					Query:       `CREATE CAST (cast_explicit_src AS cast_explicit_dst) WITH FUNCTION cast_explicit_fn(cast_explicit_src);`,
+					ExpectedErr: "already exists",
+				},
+			},
+		},
+		{
+			Name: "CREATE CAST with PL/pgSQL function creates explicit-only cast",
+			SetUpScript: []string{
+				`CREATE TABLE cast_explicit_src (v text);`,
+				`CREATE TABLE cast_explicit_dst (v text, tag text);`,
+				`CREATE FUNCTION cast_explicit_fn(src cast_explicit_src) RETURNS cast_explicit_dst AS $$ BEGIN
+						RETURN ROW((src).v, 'explicit')::cast_explicit_dst;
+					END; $$ LANGUAGE plpgsql;`,
+				`CREATE FUNCTION cast_explicit_accept(dst cast_explicit_dst) RETURNS text AS $$ BEGIN
+						RETURN (dst).v || ':' || (dst).tag;
+					END; $$ LANGUAGE plpgsql;`,
+				`CREATE TABLE cast_explicit_holder (v cast_explicit_dst);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `CREATE CAST (cast_explicit_src AS cast_explicit_dst) WITH FUNCTION cast_explicit_fn(cast_explicit_src);`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT cast_explicit_accept((ROW('one')::cast_explicit_src)::cast_explicit_dst);`,
+					Expected: []sql.Row{{"one:explicit"}},
+				},
+				{
+					Query:       `SELECT cast_explicit_accept(ROW('one')::cast_explicit_src);`,
+					ExpectedErr: "does not exist",
+				},
+				{
+					Query:       `INSERT INTO cast_explicit_holder VALUES (ROW('one')::cast_explicit_src);`,
+					ExpectedErr: "cast_explicit_src",
+				},
+				{
+					Query: `SELECT c.castcontext::text, c.castmethod::text
+						FROM pg_cast c
+						JOIN pg_type src ON src.oid = c.castsource
+						JOIN pg_type dst ON dst.oid = c.casttarget
+						WHERE src.typname = 'cast_explicit_src'
+						  AND dst.typname = 'cast_explicit_dst';`,
+					Expected: []sql.Row{{"e", "f"}},
+				},
+				{
+					Query:       `CREATE CAST (cast_explicit_src AS cast_explicit_dst) WITH FUNCTION cast_explicit_fn(cast_explicit_src);`,
+					ExpectedErr: "already exists",
+				},
+			},
+		},
+		{
+			Name: "CREATE CAST AS ASSIGNMENT works for assignment contexts only",
+			SetUpScript: []string{
+				`CREATE TABLE cast_assignment_src (v text);`,
+				`CREATE TABLE cast_assignment_dst (v text, tag text);`,
+				`CREATE FUNCTION cast_assignment_fn(cast_assignment_src) RETURNS cast_assignment_dst
+					AS $$ SELECT ROW(($1).v, 'assignment')::cast_assignment_dst $$ LANGUAGE SQL;`,
+				`CREATE FUNCTION cast_assignment_accept(cast_assignment_dst) RETURNS text
+					AS $$ SELECT ($1).v || ':' || ($1).tag $$ LANGUAGE SQL;`,
+				`CREATE TABLE cast_assignment_holder (v cast_assignment_dst);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `CREATE CAST (cast_assignment_src AS cast_assignment_dst) WITH FUNCTION cast_assignment_fn(cast_assignment_src) AS ASSIGNMENT;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT cast_assignment_accept((ROW('on')::cast_assignment_src)::cast_assignment_dst);`,
+					Expected: []sql.Row{{"on:assignment"}},
+				},
+				{
+					Query:    `INSERT INTO cast_assignment_holder VALUES (ROW('on')::cast_assignment_src);`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT cast_assignment_accept(v) FROM cast_assignment_holder;`,
+					Expected: []sql.Row{{"on:assignment"}},
+				},
+				{
+					Query:       `SELECT cast_assignment_accept(ROW('off')::cast_assignment_src);`,
+					ExpectedErr: "does not exist",
+				},
+				{
+					Query: `SELECT c.castcontext::text, c.castmethod::text
+						FROM pg_cast c
+						JOIN pg_type src ON src.oid = c.castsource
+						JOIN pg_type dst ON dst.oid = c.casttarget
+						WHERE src.typname = 'cast_assignment_src'
+						  AND dst.typname = 'cast_assignment_dst';`,
+					Expected: []sql.Row{{"a", "f"}},
+				},
+			},
+		},
+		{
+			Name: "CREATE CAST AS IMPLICIT works for function resolution",
+			SetUpScript: []string{
+				`CREATE TABLE cast_implicit_src (v text);`,
+				`CREATE TABLE cast_implicit_dst (v text, tag text);`,
+				`CREATE FUNCTION cast_implicit_fn(cast_implicit_src) RETURNS cast_implicit_dst
+					AS $$ SELECT ROW(($1).v, 'implicit')::cast_implicit_dst $$ LANGUAGE SQL;`,
+				`CREATE FUNCTION cast_implicit_accept(cast_implicit_dst) RETURNS text
+					AS $$ SELECT ($1).v || ':' || ($1).tag $$ LANGUAGE SQL;`,
+				`CREATE TABLE cast_implicit_holder (v cast_implicit_dst);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `CREATE CAST (cast_implicit_src AS cast_implicit_dst) WITH FUNCTION cast_implicit_fn(cast_implicit_src) AS IMPLICIT;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT cast_implicit_accept((ROW('x')::cast_implicit_src)::cast_implicit_dst);`,
+					Expected: []sql.Row{{"x:implicit"}},
+				},
+				{
+					Query:    `SELECT cast_implicit_accept(ROW('y')::cast_implicit_src);`,
+					Expected: []sql.Row{{"y:implicit"}},
+				},
+				{
+					Query:    `INSERT INTO cast_implicit_holder VALUES (ROW('z')::cast_implicit_src);`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT cast_implicit_accept(v) FROM cast_implicit_holder;`,
+					Expected: []sql.Row{{"z:implicit"}},
+				},
+				{
+					Query: `SELECT c.castcontext::text, c.castmethod::text
+						FROM pg_cast c
+						JOIN pg_type src ON src.oid = c.castsource
+						JOIN pg_type dst ON dst.oid = c.casttarget
+						WHERE src.typname = 'cast_implicit_src'
+						  AND dst.typname = 'cast_implicit_dst';`,
+					Expected: []sql.Row{{"i", "f"}},
+				},
+			},
+		},
+		{
+			Name: "CREATE CAST WITH INOUT",
+			SetUpScript: []string{
+				`CREATE TABLE cast_inout_src (v text);`,
+				`CREATE TABLE cast_inout_dst (v int);`,
+				`CREATE FUNCTION cast_inout_accept(cast_inout_dst) RETURNS text
+					AS $$ SELECT (($1).v)::text $$ LANGUAGE SQL;`,
+				`CREATE TABLE cast_inout_holder (v cast_inout_dst);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `CREATE CAST (cast_inout_src AS cast_inout_dst) WITH INOUT AS ASSIGNMENT;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT cast_inout_accept((ROW('42')::cast_inout_src)::cast_inout_dst);`,
+					Expected: []sql.Row{{"42"}},
+				},
+				{
+					Query:    `INSERT INTO cast_inout_holder VALUES (ROW('99')::cast_inout_src);`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT cast_inout_accept(v) FROM cast_inout_holder;`,
+					Expected: []sql.Row{{"99"}},
+				},
+				{
+					Query:       `SELECT cast_inout_accept((ROW('not_an_int')::cast_inout_src)::cast_inout_dst);`,
+					ExpectedErr: "invalid input syntax",
+				},
+				{
+					Query: `SELECT c.castcontext::text, c.castmethod::text
+						FROM pg_cast c
+						JOIN pg_type src ON src.oid = c.castsource
+						JOIN pg_type dst ON dst.oid = c.casttarget
+						WHERE src.typname = 'cast_inout_src'
+						  AND dst.typname = 'cast_inout_dst';`,
+					Expected: []sql.Row{{"a", "i"}},
+				},
+			},
+		},
+		{
+			Name: "CREATE CAST with three-argument function receives explicit flag",
+			SetUpScript: []string{
+				`CREATE TABLE cast_three_arg_src (v text);`,
+				`CREATE TABLE cast_three_arg_dst (v text, tag text);`,
+				`CREATE FUNCTION cast_three_arg_fn(cast_three_arg_src, integer, boolean) RETURNS cast_three_arg_dst
+					AS $$
+						SELECT ROW(
+							($1).v,
+							CASE WHEN $3 THEN 'explicit' ELSE 'implicit_or_assignment' END
+						)::cast_three_arg_dst
+					$$ LANGUAGE SQL;`,
+				`CREATE FUNCTION cast_three_arg_accept(cast_three_arg_dst) RETURNS text
+					AS $$ SELECT ($1).v || ':' || ($1).tag $$ LANGUAGE SQL;`,
+				`CREATE TABLE cast_three_arg_holder (v cast_three_arg_dst);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `CREATE CAST (cast_three_arg_src AS cast_three_arg_dst) WITH FUNCTION cast_three_arg_fn(cast_three_arg_src, integer, boolean) AS IMPLICIT;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT cast_three_arg_accept((ROW('a')::cast_three_arg_src)::cast_three_arg_dst);`,
+					Expected: []sql.Row{{"a:explicit"}},
+				},
+				{
+					Query:    `SELECT cast_three_arg_accept(ROW('b')::cast_three_arg_src);`,
+					Expected: []sql.Row{{"b:implicit_or_assignment"}},
+				},
+				{
+					Query:    `INSERT INTO cast_three_arg_holder VALUES (ROW('c')::cast_three_arg_src);`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT cast_three_arg_accept(v) FROM cast_three_arg_holder;`,
+					Expected: []sql.Row{{"c:implicit_or_assignment"}},
+				},
+				{
+					Query: `SELECT c.castcontext::text, c.castmethod::text
+						FROM pg_cast c
+						JOIN pg_type src ON src.oid = c.castsource
+						JOIN pg_type dst ON dst.oid = c.casttarget
+						WHERE src.typname = 'cast_three_arg_src'
+						  AND dst.typname = 'cast_three_arg_dst';`,
+					Expected: []sql.Row{{"i", "f"}},
+				},
+			},
+		},
+		{
+			Name: "DROP CAST removes catalog entry and allows recreation",
+			SetUpScript: []string{
+				`CREATE TABLE cast_drop_src (v text);`,
+				`CREATE TABLE cast_drop_dst (v text, tag text);`,
+				`CREATE FUNCTION cast_drop_fn(cast_drop_src) RETURNS cast_drop_dst
+					AS $$ SELECT ROW(($1).v, 'drop')::cast_drop_dst $$ LANGUAGE SQL;`,
+				`CREATE FUNCTION cast_drop_accept(cast_drop_dst) RETURNS text
+					AS $$ SELECT ($1).v || ':' || ($1).tag $$ LANGUAGE SQL;`,
+				`CREATE CAST (cast_drop_src AS cast_drop_dst) WITH FUNCTION cast_drop_fn(cast_drop_src);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT cast_drop_accept((ROW('before')::cast_drop_src)::cast_drop_dst);`,
+					Expected: []sql.Row{{"before:drop"}},
+				},
+				{
+					Query: `SELECT EXISTS (
+						SELECT 1
+						FROM pg_cast c
+						JOIN pg_type src ON src.oid = c.castsource
+						JOIN pg_type dst ON dst.oid = c.casttarget
+						WHERE src.typname = 'cast_drop_src'
+						  AND dst.typname = 'cast_drop_dst'
+					);`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    `DROP CAST (cast_drop_src AS cast_drop_dst);`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query: `SELECT EXISTS (
+						SELECT 1
+						FROM pg_cast c
+						JOIN pg_type src ON src.oid = c.castsource
+						JOIN pg_type dst ON dst.oid = c.casttarget
+						WHERE src.typname = 'cast_drop_src'
+						  AND dst.typname = 'cast_drop_dst'
+					);`,
+					Expected: []sql.Row{{"f"}},
+				},
+				{
+					Query:       `SELECT cast_drop_accept((ROW('after')::cast_drop_src)::cast_drop_dst);`,
+					ExpectedErr: "cast_drop_src",
+				},
+				{
+					Query:    `CREATE CAST (cast_drop_src AS cast_drop_dst) WITH FUNCTION cast_drop_fn(cast_drop_src);`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT cast_drop_accept((ROW('after')::cast_drop_src)::cast_drop_dst);`,
+					Expected: []sql.Row{{"after:drop"}},
+				},
+			},
+		},
+		{
+			Name: "CREATE CAST function is invoked for NULL when function is not STRICT",
+			SetUpScript: []string{
+				`CREATE TABLE cast_null_src (v text);`,
+				`CREATE TABLE cast_null_dst (v text, tag text);`,
+				`CREATE FUNCTION cast_null_fn(cast_null_src) RETURNS cast_null_dst
+					AS $$ SELECT CASE
+						WHEN $1 IS NULL THEN ROW('saw_null', 'called')::cast_null_dst
+						ELSE ROW('hi', 'nonnull')::cast_null_dst
+					END $$ LANGUAGE SQL;`,
+				`CREATE CAST (cast_null_src AS cast_null_dst) WITH FUNCTION cast_null_fn(cast_null_src);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT ((NULL::cast_null_src)::cast_null_dst);`,
+					Expected: []sql.Row{{"(saw_null,called)"}},
+				},
+				{
+					Query:    `SELECT ((ROW('hi')::cast_null_src)::cast_null_dst);`,
+					Expected: []sql.Row{{"(hi,nonnull)"}},
+				},
+			},
+		},
+		{
+			Name: "CREATE CAST STRICT function is not invoked for NULL",
+			SetUpScript: []string{
+				`CREATE TABLE cast_strict_null_src (v text);`,
+				`CREATE TABLE cast_strict_null_dst (v text, tag text);`,
+				`CREATE FUNCTION cast_strict_null_fn(cast_strict_null_src) RETURNS cast_strict_null_dst
+					AS $$ SELECT ROW('bad', 'called')::cast_strict_null_dst $$ LANGUAGE SQL STRICT;`,
+				`CREATE CAST (cast_strict_null_src AS cast_strict_null_dst) WITH FUNCTION cast_strict_null_fn(cast_strict_null_src);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT ((NULL::cast_strict_null_src)::cast_strict_null_dst) IS NULL;`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    `SELECT ((ROW('there')::cast_strict_null_src)::cast_strict_null_dst);`,
+					Expected: []sql.Row{{"(bad,called)"}},
+				},
+			},
+		},
+		{
+			Name: "CREATE CAST validation",
+			SetUpScript: []string{
+				`CREATE TABLE cast_bad_src (v text);`,
+				`CREATE TABLE cast_bad_dst (v text, tag text);`,
+				`CREATE FUNCTION cast_bad_wrong_return(cast_bad_src) RETURNS text
+					AS $$ SELECT ($1).v $$ LANGUAGE SQL;`,
+				`CREATE FUNCTION cast_bad_wrong_source(text) RETURNS cast_bad_dst
+					AS $$ SELECT ROW($1, 'wrong_source')::cast_bad_dst $$ LANGUAGE SQL;`,
+				`CREATE FUNCTION cast_bad_wrong_second(cast_bad_src, text) RETURNS cast_bad_dst
+					AS $$ SELECT ROW(($1).v, 'wrong_second')::cast_bad_dst $$ LANGUAGE SQL;`,
+				`CREATE FUNCTION cast_bad_wrong_third(cast_bad_src, integer, integer) RETURNS cast_bad_dst
+					AS $$ SELECT ROW(($1).v, 'wrong_third')::cast_bad_dst $$ LANGUAGE SQL;`,
+				`CREATE FUNCTION cast_bad_too_many(cast_bad_src, integer, boolean, integer) RETURNS cast_bad_dst
+					AS $$ SELECT ROW(($1).v, 'too_many')::cast_bad_dst $$ LANGUAGE SQL;`,
+				`CREATE FUNCTION cast_good(cast_bad_src) RETURNS cast_bad_dst
+					AS $$ SELECT ROW(($1).v, 'good')::cast_bad_dst $$ LANGUAGE SQL;`,
+				`CREATE TABLE cast_without_src (v text);`,
+				`CREATE TABLE cast_without_dst (v text, tag text);`,
+				`CREATE CAST (cast_bad_src AS cast_bad_dst) WITH FUNCTION cast_good(cast_bad_src);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:       `CREATE CAST (cast_bad_src AS cast_bad_dst) WITH FUNCTION cast_bad_missing(cast_bad_src);`,
+					ExpectedErr: "does not exist",
+				},
+				{
+					Query:       `CREATE CAST (cast_bad_src AS cast_bad_dst) WITH FUNCTION cast_bad_wrong_return(cast_bad_src);`,
+					ExpectedErr: "return data type",
+				},
+				{
+					Query:       `CREATE CAST (cast_bad_src AS cast_bad_dst) WITH FUNCTION cast_bad_wrong_source(text);`,
+					ExpectedErr: "source data type",
+				},
+				{
+					Query:       `CREATE CAST (cast_bad_src AS cast_bad_dst) WITH FUNCTION cast_bad_wrong_second(cast_bad_src, text);`,
+					ExpectedErr: "second argument",
+				},
+				{
+					Query:       `CREATE CAST (cast_bad_src AS cast_bad_dst) WITH FUNCTION cast_bad_wrong_third(cast_bad_src, integer, integer);`,
+					ExpectedErr: "third argument",
+				},
+				{
+					Query:       `CREATE CAST (cast_bad_src AS cast_bad_dst) WITH FUNCTION cast_bad_too_many(cast_bad_src, integer, boolean, integer);`,
+					ExpectedErr: "one to three arguments",
+				},
+				{
+					Query:       `CREATE CAST (cast_without_src AS cast_without_dst) WITHOUT FUNCTION;`,
+					ExpectedErr: "composite data types are not binary-compatible",
+				},
+				{
+					Query:       `CREATE CAST (int4 AS float8) WITHOUT FUNCTION;`,
+					ExpectedErr: "source and target data types are not physically compatible",
+				},
+				{
+					Query:       `CREATE CAST (cast_bad_src AS cast_bad_src) WITH INOUT;`,
+					ExpectedErr: "source data type and target data type are the same",
+				},
+				{
+					Query:       `CREATE CAST (cast_bad_src AS cast_bad_dst) WITH FUNCTION cast_good(cast_bad_src);`,
+					ExpectedErr: "cast from type cast_bad_src to type cast_bad_dst already exists",
+				},
+			},
+		},
+	})
+}

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -483,8 +483,8 @@ func TestPgCast(t *testing.T) {
 			Name: "pg_cast",
 			Assertions: []ScriptTestAssertion{
 				{
-					Query:    `SELECT * FROM "pg_catalog"."pg_cast";`,
-					Expected: []sql.Row{},
+					Query:    `SELECT COUNT(*) FROM "pg_catalog"."pg_cast";`,
+					Expected: []sql.Row{{117}},
 				},
 				{ // Different cases and quoted, so it fails
 					Query:       `SELECT * FROM "PG_catalog"."pg_cast";`,
@@ -495,8 +495,8 @@ func TestPgCast(t *testing.T) {
 					ExpectedErr: "not",
 				},
 				{ // Different cases but non-quoted, so it works
-					Query:    "SELECT oid FROM PG_catalog.pg_CAST ORDER BY oid;",
-					Expected: []sql.Row{},
+					Query:    "SELECT COUNT(*) FROM PG_catalog.pg_CAST ORDER BY oid;",
+					Expected: []sql.Row{{117}},
 				},
 			},
 		},


### PR DESCRIPTION
This implements `CREATE CAST` and `DROP CAST`, as well as fixes a number of bug that were surfaced by the tests (some fixed through other PRs, such as full type initialization, while others such as nested composite types in created functions are fixed here).