### PR TITLE
Format missing operator error correctly (fixes #2160)

### DIFF
--- a/server/functions/framework/compiled_function.go
+++ b/server/functions/framework/compiled_function.go
@@ -100,6 +100,28 @@ func newCompiledFunctionInternal(
 	}
 	// If we do not receive an overload, then the parameters given did not result in a valid match
 	if !overload.Valid() {
+		if isOperator {
+			if strings.HasPrefix(name, "internal_binary_operator_func_") {
+				opStr := strings.TrimPrefix(name, "internal_binary_operator_func_")
+				var leftType, rightType string
+				if len(originalTypes) > 0 {
+					leftType = originalTypes[0].String()
+				}
+				if len(originalTypes) > 1 {
+					rightType = originalTypes[1].String()
+				}
+				c.stashedErr = cerrors.Errorf("operator does not exist: %s %s %s", leftType, opStr, rightType)
+				return c
+			} else if strings.HasPrefix(name, "internal_unary_operator_func_") {
+				opStr := strings.TrimPrefix(name, "internal_unary_operator_func_")
+				var childType string
+				if len(originalTypes) > 0 {
+					childType = originalTypes[0].String()
+				}
+				c.stashedErr = cerrors.Errorf("operator does not exist: %s%s", opStr, childType)
+				return c
+			}
+		}
 		c.stashedErr = ErrFunctionDoesNotExist.New(c.OverloadString(originalTypes))
 		return c
 	}

--- a/testing/go/issues_test.go
+++ b/testing/go/issues_test.go
@@ -461,6 +461,19 @@ limit 1`,
 				},
 			},
 		},
+		{
+			Name: "Issue #2160",
+			SetUpScript: []string{
+				"CREATE TABLE t (id INT, v VARCHAR);",
+				"INSERT INTO t VALUES (1, 'true');",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:       `SELECT * FROM t WHERE v = true;`,
+					ExpectedErr: "operator does not exist: varchar = bool",
+				},
+			},
+		},
 	})
 }
 

--- a/testing/go/issues_test.go
+++ b/testing/go/issues_test.go
@@ -461,19 +461,6 @@ limit 1`,
 				},
 			},
 		},
-		{
-			Name: "Issue #2160",
-			SetUpScript: []string{
-				"CREATE TABLE t (id INT, v VARCHAR);",
-				"INSERT INTO t VALUES (1, 'true');",
-			},
-			Assertions: []ScriptTestAssertion{
-				{
-					Query:       `SELECT * FROM t WHERE v = true;`,
-					ExpectedErr: "operator does not exist: varchar = bool",
-				},
-			},
-		},
 	})
 }
 

--- a/testing/go/operators_test.go
+++ b/testing/go/operators_test.go
@@ -4022,5 +4022,19 @@ func TestOperators(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "Error cases",
+			SetUpScript: []string{
+				"CREATE TABLE t (id INT, v VARCHAR);",
+				"INSERT INTO t VALUES (1, 'true');",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					// https://github.com/dolthub/doltgresql/issues/2160
+					Query:       `SELECT * FROM t WHERE v = true;`,
+					ExpectedErr: "operator does not exist: varchar = bool",
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
This PR formats the internal function missing error into the standard Postgres 'operator does not exist' format when the function corresponds to an operator. This ensures that errors such as comparing a varchar to a boolean are surfaced with proper feedback rather than an internal function error. Fixes #2160.