### PR TITLE
[no-release-notes] More aggressive close stale auto-bump PRs

### DIFF
--- a/.github/workflows/bump-dependency.yaml
+++ b/.github/workflows/bump-dependency.yaml
@@ -185,12 +185,6 @@ jobs:
                   console.log("suite app slug:", suite.app.slug);
                   console.log("suite status:", suite.status);
                   console.log("suite conclusion:", suite.conclusion);
-                  if (suite.app.slug === "github-actions") {
-                     if (suite.status !== "completed" || suite.conclusion !== "success") {
-                       console.log(`Leaving pr open due to status:${suite.status} conclusion${suite.conclusion}`);
-                       process.exit(0);
-                     }
-                  }
                 } 
               }
 


### PR DESCRIPTION
The previous logic was leaving any auto-bump PRs open if they were still in progress (i.e. not completed) or if they were not successful (i.e. failed). This resulted in auto-bump PRs not being closed and leaving extra noise in our PR backlog. 

The new logic closes all stale auto-bump PRs, unless they have the `keep-alive` label set. 