### PR TITLE
Context collections accept a database

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -38,14 +38,13 @@ import (
 // and may be refreshed at any point, including during the middle of a query. Callers should not assume that
 // data stored in contextValues is persisted, and other types of data should not be added to contextValues.
 type contextValues struct {
-	seqs map[string]*sequences.Collection
-	// TODO: all these collection fields need to be mapped by database name as seqs above
-	types *typecollection.TypeCollection
-	funcs *functions.Collection
-	procs *procedures.Collection
-	trigs *triggers.Collection
-	exts  *extensions.Collection
-	casts *casts.Collection
+	seqs  map[string]*sequences.Collection
+	types map[string]*typecollection.TypeCollection
+	funcs map[string]*functions.Collection
+	procs map[string]*procedures.Collection
+	trigs map[string]*triggers.Collection
+	exts  map[string]*extensions.Collection
+	casts map[string]*casts.Collection
 
 	pgCatalogCache any
 	runner         sql.StatementRunner
@@ -292,72 +291,75 @@ func GetExtensionsCollectionFromContext(ctx *sql.Context, database string) (*ext
 	if err != nil {
 		return nil, err
 	}
-	_, root, err := getRootFromContextForDatabase(ctx, database)
-	if err != nil {
-		return nil, err
-	}
 	if cv.exts == nil {
-		cv.exts, err = extensions.LoadExtensions(ctx, root)
+		cv.exts = make(map[string]*extensions.Collection)
+	}
+	if len(database) == 0 {
+		database = ctx.GetCurrentDatabase()
+	}
+	if cv.exts[database] == nil {
+		_, root, err := getRootFromContextForDatabase(ctx, database)
 		if err != nil {
 			return nil, err
 		}
-	} else if cv.exts.DiffersFrom(ctx, root) {
-		cv.exts, err = extensions.LoadExtensions(ctx, root)
+		cv.exts[database], err = extensions.LoadExtensions(ctx, root)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return cv.exts, nil
+	return cv.exts[database], nil
 }
 
 // GetFunctionsCollectionFromContext returns the functions collection from the given context. Will always return a
 // collection if no error is returned.
-func GetFunctionsCollectionFromContext(ctx *sql.Context) (*functions.Collection, error) {
+func GetFunctionsCollectionFromContext(ctx *sql.Context, database string) (*functions.Collection, error) {
 	cv, err := getContextValues(ctx)
-	if err != nil {
-		return nil, err
-	}
-	_, root, err := GetRootFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 	if cv.funcs == nil {
-		cv.funcs, err = functions.LoadFunctions(ctx, root)
+		cv.funcs = make(map[string]*functions.Collection)
+	}
+	if len(database) == 0 {
+		database = ctx.GetCurrentDatabase()
+	}
+	if cv.funcs[database] == nil {
+		_, root, err := getRootFromContextForDatabase(ctx, database)
 		if err != nil {
 			return nil, err
 		}
-	} else if cv.funcs.DiffersFrom(ctx, root) {
-		cv.funcs, err = functions.LoadFunctions(ctx, root)
+		cv.funcs[database], err = functions.LoadFunctions(ctx, root)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return cv.funcs, nil
+	return cv.funcs[database], nil
 }
 
 // GetProceduresCollectionFromContext returns the procedures collection from the given context. Will always return a
 // collection if no error is returned.
-func GetProceduresCollectionFromContext(ctx *sql.Context) (*procedures.Collection, error) {
+func GetProceduresCollectionFromContext(ctx *sql.Context, database string) (*procedures.Collection, error) {
 	cv, err := getContextValues(ctx)
 	if err != nil {
 		return nil, err
 	}
-	_, root, err := GetRootFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
 	if cv.procs == nil {
-		cv.procs, err = procedures.LoadProcedures(ctx, root)
+		cv.procs = make(map[string]*procedures.Collection)
+	}
+	if len(database) == 0 {
+		database = ctx.GetCurrentDatabase()
+	}
+	if cv.procs[database] == nil {
+		_, root, err := getRootFromContextForDatabase(ctx, database)
 		if err != nil {
 			return nil, err
 		}
-	} else if cv.procs.DiffersFrom(ctx, root) {
-		cv.procs, err = procedures.LoadProcedures(ctx, root)
+		cv.procs[database], err = procedures.LoadProcedures(ctx, root)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return cv.procs, nil
+	return cv.procs[database], nil
 }
 
 // GetSequencesCollectionFromContext returns the given sequence collection from the context for the database
@@ -370,6 +372,9 @@ func GetSequencesCollectionFromContext(ctx *sql.Context, database string) (*sequ
 	}
 	if cv.seqs == nil {
 		cv.seqs = make(map[string]*sequences.Collection)
+	}
+	if len(database) == 0 {
+		database = ctx.GetCurrentDatabase()
 	}
 	if cv.seqs[database] == nil {
 		_, root, err := getRootFromContextForDatabase(ctx, database)
@@ -391,62 +396,75 @@ func GetTriggersCollectionFromContext(ctx *sql.Context, database string) (*trigg
 	if err != nil {
 		return nil, err
 	}
-	_, root, err := getRootFromContextForDatabase(ctx, database)
-	if err != nil {
-		return nil, err
-	}
 	if cv.trigs == nil {
-		cv.trigs, err = triggers.LoadTriggers(ctx, root)
+		cv.trigs = make(map[string]*triggers.Collection)
+	}
+	if len(database) == 0 {
+		database = ctx.GetCurrentDatabase()
+	}
+	if cv.trigs[database] == nil {
+		_, root, err := getRootFromContextForDatabase(ctx, database)
 		if err != nil {
 			return nil, err
 		}
-	} else if cv.trigs.DiffersFrom(ctx, root) {
-		cv.trigs, err = triggers.LoadTriggers(ctx, root)
+		cv.trigs[database], err = triggers.LoadTriggers(ctx, root)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return cv.trigs, nil
+	return cv.trigs[database], nil
 }
 
 // GetTypesCollectionFromContext returns the given type collection from the context.
 // Will always return a collection if no error is returned.
-func GetTypesCollectionFromContext(ctx *sql.Context) (*typecollection.TypeCollection, error) {
+func GetTypesCollectionFromContext(ctx *sql.Context, database string) (*typecollection.TypeCollection, error) {
 	cv, err := getContextValues(ctx)
 	if err != nil {
 		return nil, err
 	}
 	if cv.types == nil {
-		_, root, err := GetRootFromContext(ctx)
+		cv.types = make(map[string]*typecollection.TypeCollection)
+	}
+	if len(database) == 0 {
+		database = ctx.GetCurrentDatabase()
+	}
+	if cv.types[database] == nil {
+		_, root, err := getRootFromContextForDatabase(ctx, database)
 		if err != nil {
 			return nil, err
 		}
-		cv.types, err = typecollection.LoadTypes(ctx, root)
+		cv.types[database], err = typecollection.LoadTypes(ctx, root)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return cv.types, nil
+	return cv.types[database], nil
 }
 
 // GetCastsCollectionFromContext returns the given casts collection from the context.
 // Will always return a collection if no error is returned.
-func GetCastsCollectionFromContext(ctx *sql.Context) (*casts.Collection, error) {
+func GetCastsCollectionFromContext(ctx *sql.Context, database string) (*casts.Collection, error) {
 	cv, err := getContextValues(ctx)
 	if err != nil {
 		return nil, err
 	}
 	if cv.casts == nil {
-		_, root, err := GetRootFromContext(ctx)
+		cv.casts = make(map[string]*casts.Collection)
+	}
+	if len(database) == 0 {
+		database = ctx.GetCurrentDatabase()
+	}
+	if cv.casts[database] == nil {
+		_, root, err := getRootFromContextForDatabase(ctx, database)
 		if err != nil {
 			return nil, err
 		}
-		cv.casts, err = casts.LoadCasts(ctx, root)
+		cv.casts[database], err = casts.LoadCasts(ctx, root)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return cv.casts, nil
+	return cv.casts[database], nil
 }
 
 // CloseContextRootFinalizer finalizes any changes persisted within the context by writing them to the working root.
@@ -490,52 +508,59 @@ func updateSessionRootForDatabase(ctx *sql.Context, db string, cv *contextValues
 		delete(cv.seqs, db)
 	}
 
-	if cv.funcs != nil && cv.funcs.DiffersFrom(ctx, root) {
-		retRoot, err := cv.funcs.UpdateRoot(ctx, newRoot)
+	if cv.funcs != nil && cv.funcs[db] != nil && cv.funcs[db].DiffersFrom(ctx, root) {
+		retRoot, err := cv.funcs[db].UpdateRoot(ctx, newRoot)
 		if err != nil {
 			return err
 		}
 		newRoot = retRoot.(*RootValue)
-		cv.funcs = nil
+		delete(cv.funcs, db)
 	}
 
-	if cv.procs != nil && cv.procs.DiffersFrom(ctx, root) {
-		retRoot, err := cv.procs.UpdateRoot(ctx, newRoot)
+	if cv.procs != nil && cv.procs[db] != nil && cv.procs[db].DiffersFrom(ctx, root) {
+		retRoot, err := cv.procs[db].UpdateRoot(ctx, newRoot)
 		if err != nil {
 			return err
 		}
 		newRoot = retRoot.(*RootValue)
-		cv.procs = nil
+		delete(cv.procs, db)
 	}
 
-	if cv.trigs != nil && cv.trigs.DiffersFrom(ctx, root) {
-		retRoot, err := cv.trigs.UpdateRoot(ctx, newRoot)
+	if cv.trigs != nil && cv.trigs[db] != nil && cv.trigs[db].DiffersFrom(ctx, root) {
+		retRoot, err := cv.trigs[db].UpdateRoot(ctx, newRoot)
 		if err != nil {
 			return err
 		}
 		newRoot = retRoot.(*RootValue)
-		cv.trigs = nil
+		delete(cv.trigs, db)
 	}
 
-	if cv.exts != nil && cv.exts.DiffersFrom(ctx, root) {
-		retRoot, err := cv.exts.UpdateRoot(ctx, newRoot)
+	if cv.exts != nil && cv.exts[db] != nil && cv.exts[db].DiffersFrom(ctx, root) {
+		retRoot, err := cv.exts[db].UpdateRoot(ctx, newRoot)
 		if err != nil {
 			return err
 		}
 		newRoot = retRoot.(*RootValue)
-		cv.exts = nil
+		delete(cv.exts, db)
 	}
 
-	if cv.types != nil {
-		retRoot, err := cv.types.UpdateRoot(ctx, newRoot)
+	if cv.types != nil && cv.types[db] != nil {
+		retRoot, err := cv.types[db].UpdateRoot(ctx, newRoot)
 		if err != nil {
 			return err
 		}
 		newRoot = retRoot.(*RootValue)
-		cv.types = nil
+		delete(cv.types, db)
 	}
 
-	// TODO: need to be able to persist cv.casts without an empty collection updating the root (no value != empty value)
+	if cv.casts != nil && cv.casts[db] != nil && cv.casts[db].DiffersFrom(ctx, root) {
+		retRoot, err := cv.casts[db].UpdateRoot(ctx, newRoot)
+		if err != nil {
+			return err
+		}
+		newRoot = retRoot.(*RootValue)
+		delete(cv.casts, db)
+	}
 
 	// Setting the session working root doesn't do a check to see if anything actually changed or not before marking that
 	// branch state dirty, and dolt only allows a single dirty working set per commit. So it's important here to only

--- a/core/init.go
+++ b/core/init.go
@@ -37,11 +37,11 @@ func Init() {
 	id.RegisterListener(sequenceIDListener{}, id.Section_Table)
 	typecollection.GetSqlTableFromContext = GetSqlTableFromContext
 	typecollection.GetSchemaName = GetSchemaName
-	pgtypes.GetTypesCollectionFromContext = func(ctx *sql.Context) (pgtypes.TypeCollection, error) {
-		return GetTypesCollectionFromContext(ctx)
+	pgtypes.GetTypesCollectionFromContext = func(ctx *sql.Context, database string) (pgtypes.TypeCollection, error) {
+		return GetTypesCollectionFromContext(ctx, database)
 	}
 	pgtypes.GetAssignmentCast = func(ctx *sql.Context, sourceType *pgtypes.DoltgresType, targetType *pgtypes.DoltgresType) (pgtypes.Cast, error) {
-		castsColl, err := GetCastsCollectionFromContext(ctx)
+		castsColl, err := GetCastsCollectionFromContext(ctx, "")
 		if err != nil {
 			return nil, err
 		}

--- a/server/analyzer/foreign_key.go
+++ b/server/analyzer/foreign_key.go
@@ -32,7 +32,8 @@ func validateForeignKeyDefinition(ctx *sql.Context, fkDef sql.ForeignKeyConstrai
 	var castsColl *casts.Collection
 	if len(fkDef.Columns) > 0 {
 		var err error
-		castsColl, err = core.GetCastsCollectionFromContext(ctx)
+		// TODO: which database is this supposed to use?
+		castsColl, err = core.GetCastsCollectionFromContext(ctx, "")
 		if err != nil {
 			return err
 		}

--- a/server/analyzer/resolve_routine_defaults.go
+++ b/server/analyzer/resolve_routine_defaults.go
@@ -36,11 +36,11 @@ import (
 func ResolveProcedureDefaults(ctx *sql.Context, a *analyzer.Analyzer, node sql.Node, scope *plan.Scope, selector analyzer.RuleSelector, qFlags *sql.QueryFlags) (sql.Node, transform.TreeIdentity, error) {
 	switch n := node.(type) {
 	case *pgnodes.Call:
-		procCollection, err := core.GetProceduresCollectionFromContext(ctx)
+		procCollection, err := core.GetProceduresCollectionFromContext(ctx, "")
 		if err != nil {
 			return nil, transform.SameTree, err
 		}
-		typesCollection, err := core.GetTypesCollectionFromContext(ctx)
+		typesCollection, err := core.GetTypesCollectionFromContext(ctx, "")
 		if err != nil {
 			return nil, transform.SameTree, err
 		}

--- a/server/analyzer/resolve_type.go
+++ b/server/analyzer/resolve_type.go
@@ -259,7 +259,11 @@ func resolveType(ctx *sql.Context, db sql.Database, typ *pgtypes.DoltgresType) (
 	if typ.IsResolvedType() {
 		return typ, nil
 	}
-	typs, err := core.GetTypesCollectionFromContext(ctx)
+	var dbname string
+	if db != nil {
+		dbname = db.Name()
+	}
+	typs, err := core.GetTypesCollectionFromContext(ctx, dbname)
 	if err != nil {
 		return nil, err
 	}

--- a/server/doltgres_handler.go
+++ b/server/doltgres_handler.go
@@ -304,7 +304,7 @@ func (h *DoltgresHandler) convertBindParameters(ctx *sql.Context, types []uint32
 	if err != nil {
 		return nil, err
 	}
-	typeColl, err := core.GetTypesCollectionFromContext(ctx)
+	typeColl, err := core.GetTypesCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/expression/array.go
+++ b/server/expression/array.go
@@ -66,7 +66,7 @@ func (array *Array) Children() []sql.Expression {
 func (array *Array) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 	resultTyp := array.coercedType.ArrayBaseType()
 	values := make([]any, len(array.children))
-	castsColl, err := core.GetCastsCollectionFromContext(ctx)
+	castsColl, err := core.GetCastsCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func (array *Array) getTargetType(ctx *sql.Context, children ...sql.Expression) 
 		if schemaName == "" {
 			schemaName, _ = core.GetCurrentSchema(ctx)
 		}
-		if typeColl, tcErr := core.GetTypesCollectionFromContext(ctx); tcErr == nil && typeColl != nil {
+		if typeColl, tcErr := core.GetTypesCollectionFromContext(ctx, ""); tcErr == nil && typeColl != nil {
 			if resolved, rErr := typeColl.GetType(ctx, id.NewType(schemaName, targetType.ID.TypeName())); rErr == nil && resolved != nil {
 				targetType = resolved
 			}

--- a/server/expression/assignment_cast.go
+++ b/server/expression/assignment_cast.go
@@ -53,7 +53,7 @@ func (ac *AssignmentCast) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 	if err != nil || val == nil {
 		return val, err
 	}
-	castsColl, err := core.GetCastsCollectionFromContext(ctx)
+	castsColl, err := core.GetCastsCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/expression/column_access.go
+++ b/server/expression/column_access.go
@@ -141,7 +141,7 @@ func (expr *ColumnAccess) WithChildren(ctx *sql.Context, children ...sql.Express
 		return nil, errors.New("column access is only valid for Doltgres types")
 	}
 	if !doltgresType.IsResolvedType() {
-		typeColl, err := core.GetTypesCollectionFromContext(ctx)
+		typeColl, err := core.GetTypesCollectionFromContext(ctx, "")
 		if err != nil {
 			return nil, err
 		}

--- a/server/expression/explicit_cast.go
+++ b/server/expression/explicit_cast.go
@@ -93,7 +93,7 @@ func (c *ExplicitCast) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 	}
 
 	baseCastToType := checkForDomainType(c.castToType)
-	castsColl, err := core.GetCastsCollectionFromContext(ctx)
+	castsColl, err := core.GetCastsCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +203,7 @@ func (c *ExplicitCast) WithResolvedChildren(ctx context.Context, children []any)
 		if !ok {
 			return nil, errors.Errorf("%T requires a SQL context for type resolution", c)
 		}
-		typeColl, err := core.GetTypesCollectionFromContext(sqlCtx)
+		typeColl, err := core.GetTypesCollectionFromContext(sqlCtx, "")
 		if err != nil {
 			return nil, err
 		}

--- a/server/expression/implicit_cast.go
+++ b/server/expression/implicit_cast.go
@@ -53,7 +53,7 @@ func (ic *ImplicitCast) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 	if err != nil || val == nil {
 		return val, err
 	}
-	castsColl, err := core.GetCastsCollectionFromContext(ctx)
+	castsColl, err := core.GetCastsCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/expression/table_to_composite.go
+++ b/server/expression/table_to_composite.go
@@ -35,7 +35,7 @@ var _ sql.Expression = (*TableToComposite)(nil)
 
 // NewTableToComposite creates a new composite table type.
 func NewTableToComposite(ctx *sql.Context, tableName string, fields []sql.Expression) (sql.Expression, error) {
-	coll, err := core.GetTypesCollectionFromContext(ctx)
+	coll, err := core.GetTypesCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/functions/array.go
+++ b/server/functions/array.go
@@ -48,7 +48,7 @@ var array_in = framework.Function3{
 		baseTypeOid := val2.(id.Id)
 		baseType := pgtypes.IDToBuiltInDoltgresType[id.Type(baseTypeOid)]
 		if baseType == nil {
-			if typColl, err := pgtypes.GetTypesCollectionFromContext(ctx); err == nil && typColl != nil {
+			if typColl, err := pgtypes.GetTypesCollectionFromContext(ctx, ""); err == nil && typColl != nil {
 				if t, err := typColl.GetType(ctx, id.Type(baseTypeOid)); err == nil {
 					baseType = t
 				}
@@ -181,7 +181,7 @@ func array_recv_callable(ctx *sql.Context, t [4]*pgtypes.DoltgresType, val1, val
 	if data == nil {
 		return nil, nil
 	}
-	typeColl, err := core.GetTypesCollectionFromContext(ctx)
+	typeColl, err := core.GetTypesCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/functions/dolt_procedures.go
+++ b/server/functions/dolt_procedures.go
@@ -173,7 +173,7 @@ func drainRowIter(ctx *sql.Context, rowIter sql.RowIter) (any, error) {
 	} else if err != nil {
 		return nil, err
 	}
-	castsColl, err := core.GetCastsCollectionFromContext(ctx)
+	castsColl, err := core.GetCastsCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/functions/enum.go
+++ b/server/functions/enum.go
@@ -143,7 +143,7 @@ var enum_cmp = framework.Function2{
 // getDoltgresTypeFromId takes internal ID and returns the DoltgresType associated to it. It allows retrieving a
 // user-defined type, and it requires a valid sql.Context.
 func getDoltgresTypeFromId(ctx *sql.Context, rawId id.Id) (*pgtypes.DoltgresType, error) {
-	typCol, err := core.GetTypesCollectionFromContext(ctx)
+	typCol, err := core.GetTypesCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/functions/framework/common_type.go
+++ b/server/functions/framework/common_type.go
@@ -56,7 +56,7 @@ func FindCommonType(ctx *sql.Context, types []*pgtypes.DoltgresType) (_ *pgtypes
 			return nil, false, errors.Errorf("types %s and %s cannot be matched", candidateType.String(), typ.String())
 		}
 	}
-	castsColl, err := core.GetCastsCollectionFromContext(ctx)
+	castsColl, err := core.GetCastsCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, false, err
 	}

--- a/server/functions/framework/compiled_function.go
+++ b/server/functions/framework/compiled_function.go
@@ -632,7 +632,7 @@ func (c *CompiledFunction) resolveFunction(ctx *sql.Context, argTypes []*pgtypes
 // implicitly converted to the ones provided. This is the set of all possible overloads that could be used with the
 // param types provided.
 func (c *CompiledFunction) typeCompatibleOverloads(ctx *sql.Context, fnOverloads []Overload, argTypes []*pgtypes.DoltgresType) ([]overloadMatch, error) {
-	castsColl, err := core.GetCastsCollectionFromContext(ctx)
+	castsColl, err := core.GetCastsCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}
@@ -915,7 +915,7 @@ func (c *CompiledFunction) ResolveDefaultValues(ctx *sql.Context, getDefExpr fun
 	}
 
 	if len(c.Arguments) < len(sqlFunc.ParameterTypes) {
-		castsColl, err := core.GetCastsCollectionFromContext(ctx)
+		castsColl, err := core.GetCastsCollectionFromContext(ctx, "")
 		if err != nil {
 			return err
 		}

--- a/server/functions/framework/interpreted_function.go
+++ b/server/functions/framework/interpreted_function.go
@@ -149,7 +149,7 @@ func (iFunc InterpretedFunction) QuerySingleReturn(ctx *sql.Context, stack plpgs
 				return nil, err
 			}
 		}
-		castsColl, err := core.GetCastsCollectionFromContext(ctx)
+		castsColl, err := core.GetCastsCollectionFromContext(ctx, "")
 		if err != nil {
 			return nil, err
 		}

--- a/server/functions/framework/provider.go
+++ b/server/functions/framework/provider.go
@@ -35,11 +35,11 @@ func (fp *FunctionProvider) Function(ctx *sql.Context, schema, name string) (sql
 	if !core.IsContextValid(ctx) {
 		return nil, false
 	}
-	funcCollection, err := core.GetFunctionsCollectionFromContext(ctx)
+	funcCollection, err := core.GetFunctionsCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, false
 	}
-	typesCollection, err := core.GetTypesCollectionFromContext(ctx)
+	typesCollection, err := core.GetTypesCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, false
 	}

--- a/server/functions/iterate.go
+++ b/server/functions/iterate.go
@@ -160,7 +160,7 @@ func IterateDatabase(ctx *sql.Context, database string, callbacks Callbacks) err
 
 		var typeMap map[string][]*types.DoltgresType
 		if callbacks.Type != nil {
-			coll, err := core.GetTypesCollectionFromContext(ctx)
+			coll, err := core.GetTypesCollectionFromContext(ctx, database)
 			if err != nil {
 				return err
 			}

--- a/server/functions/record.go
+++ b/server/functions/record.go
@@ -80,7 +80,7 @@ func record_recv_callable(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, va
 	if data == nil {
 		return nil, nil
 	}
-	typeColl, err := core.GetTypesCollectionFromContext(ctx)
+	typeColl, err := core.GetTypesCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/hook/delete_table.go
+++ b/server/hook/delete_table.go
@@ -119,7 +119,7 @@ OuterLoop:
 func beforeTableDeletionCheckFuncsProcs(ctx *sql.Context, doltTable *sqle.DoltTable, allDeletedTables []doltdb.TableName) error {
 	tableName := doltTable.TableName()
 	tableAsType := id.NewType(tableName.Schema, tableName.Name)
-	funcsColl, err := core.GetFunctionsCollectionFromContext(ctx)
+	funcsColl, err := core.GetFunctionsCollectionFromContext(ctx, "")
 	if err != nil {
 		return err
 	}
@@ -136,7 +136,7 @@ func beforeTableDeletionCheckFuncsProcs(ctx *sql.Context, doltTable *sqle.DoltTa
 	if err != nil {
 		return err
 	}
-	procsColl, err := core.GetProceduresCollectionFromContext(ctx)
+	procsColl, err := core.GetProceduresCollectionFromContext(ctx, "")
 	if err != nil {
 		return err
 	}

--- a/server/node/create_cast.go
+++ b/server/node/create_cast.go
@@ -78,7 +78,7 @@ func (c *CreateCast) Resolved() bool {
 
 // RowIter implements the interface sql.ExecSourceRel.
 func (c *CreateCast) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error) {
-	castCollection, err := core.GetCastsCollectionFromContext(ctx)
+	castCollection, err := core.GetCastsCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (c *CreateCast) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error) {
 			paramTypes[i] = param.Type.ID
 		}
 		funcID := id.NewFunction(schemaName, c.FuncName, paramTypes...)
-		funcCollection, err := core.GetFunctionsCollectionFromContext(ctx)
+		funcCollection, err := core.GetFunctionsCollectionFromContext(ctx, "")
 		if err != nil {
 			return nil, err
 		}

--- a/server/node/create_domain.go
+++ b/server/node/create_domain.go
@@ -68,7 +68,7 @@ func (c *CreateDomain) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error)
 	if err != nil {
 		return nil, err
 	}
-	collection, err := core.GetTypesCollectionFromContext(ctx)
+	collection, err := core.GetTypesCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (c *CreateDomain) WithResolvedChildren(ctx context.Context, children []any)
 		if !ok {
 			return nil, errors.Errorf("%T requires a SQL context for type resolution", c)
 		}
-		typeColl, err := core.GetTypesCollectionFromContext(sqlCtx)
+		typeColl, err := core.GetTypesCollectionFromContext(sqlCtx, "")
 		if err != nil {
 			return nil, err
 		}

--- a/server/node/create_function.go
+++ b/server/node/create_function.go
@@ -110,7 +110,7 @@ func (c *CreateFunction) Resolved() bool {
 
 // RowIter implements the interface sql.ExecSourceRel.
 func (c *CreateFunction) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error) {
-	funcCollection, err := core.GetFunctionsCollectionFromContext(ctx)
+	funcCollection, err := core.GetFunctionsCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/node/create_procedure.go
+++ b/server/node/create_procedure.go
@@ -89,7 +89,7 @@ func (c *CreateProcedure) Resolved() bool {
 
 // RowIter implements the interface sql.ExecSourceRel.
 func (c *CreateProcedure) RowIter(ctx *sql.Context, _ sql.Row) (sql.RowIter, error) {
-	procCollection, err := core.GetProceduresCollectionFromContext(ctx)
+	procCollection, err := core.GetProceduresCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/node/create_trigger.go
+++ b/server/node/create_trigger.go
@@ -169,7 +169,7 @@ func (c *CreateTrigger) WithResolvedChildren(ctx context.Context, children []any
 func loadFunction(ctx *sql.Context, funcCollection *functions.Collection, funcID id.Function) (functions.Function, error) {
 	var err error
 	if funcCollection == nil {
-		funcCollection, err = core.GetFunctionsCollectionFromContext(ctx)
+		funcCollection, err = core.GetFunctionsCollectionFromContext(ctx, "")
 		if err != nil {
 			return functions.Function{}, err
 		}

--- a/server/node/create_type.go
+++ b/server/node/create_type.go
@@ -98,7 +98,7 @@ func (c *CreateType) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error) {
 	if err != nil {
 		return nil, err
 	}
-	collection, err := core.GetTypesCollectionFromContext(ctx)
+	collection, err := core.GetTypesCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/node/drop_cast.go
+++ b/server/node/drop_cast.go
@@ -63,7 +63,7 @@ func (c *DropCast) Resolved() bool {
 
 // RowIter implements the interface sql.ExecSourceRel.
 func (c *DropCast) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error) {
-	castCollection, err := core.GetCastsCollectionFromContext(ctx)
+	castCollection, err := core.GetCastsCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/node/drop_domain.go
+++ b/server/node/drop_domain.go
@@ -76,7 +76,7 @@ func (c *DropDomain) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error) {
 	if err != nil {
 		return nil, err
 	}
-	collection, err := core.GetTypesCollectionFromContext(ctx)
+	collection, err := core.GetTypesCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/node/drop_function.go
+++ b/server/node/drop_function.go
@@ -85,7 +85,7 @@ func (d *DropFunction) IsReadOnly() bool {
 
 // RowIter implements the interface sql.ExecSourceRel.
 func (d *DropFunction) RowIter(ctx *sql.Context, r sql.Row) (iter sql.RowIter, err error) {
-	funcColl, err := core.GetFunctionsCollectionFromContext(ctx)
+	funcColl, err := core.GetFunctionsCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/node/drop_procedure.go
+++ b/server/node/drop_procedure.go
@@ -78,7 +78,7 @@ func (d *DropProcedure) IsReadOnly() bool {
 
 // RowIter implements the interface sql.ExecSourceRel.
 func (d *DropProcedure) RowIter(ctx *sql.Context, r sql.Row) (iter sql.RowIter, err error) {
-	procColl, err := core.GetProceduresCollectionFromContext(ctx)
+	procColl, err := core.GetProceduresCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/node/drop_type.go
+++ b/server/node/drop_type.go
@@ -86,7 +86,7 @@ func (c *DropType) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error) {
 	if err != nil {
 		return nil, err
 	}
-	collection, err := core.GetTypesCollectionFromContext(ctx)
+	collection, err := core.GetTypesCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/plpgsql/interpreter_logic.go
+++ b/server/plpgsql/interpreter_logic.go
@@ -47,7 +47,7 @@ type InterpretedFunction interface {
 
 // GetTypesCollectionFromContext is declared within the core package, but is assigned to this variable to work around
 // import cycles.
-var GetTypesCollectionFromContext func(ctx *sql.Context) (*typecollection.TypeCollection, error)
+var GetTypesCollectionFromContext func(ctx *sql.Context, database string) (*typecollection.TypeCollection, error)
 
 // Call runs the contained operations on the given runner.
 func Call(ctx *sql.Context, iFunc InterpretedFunction, runner sql.StatementRunner, paramsAndReturn []*pgtypes.DoltgresType, vals []any) (any, error) {
@@ -118,7 +118,7 @@ func call(ctx *sql.Context, iFunc InterpretedFunction, stack InterpreterStack) (
 				return nil, err
 			}
 		case OpCode_Declare:
-			typeCollection, err := GetTypesCollectionFromContext(ctx)
+			typeCollection, err := GetTypesCollectionFromContext(ctx, "")
 			if err != nil {
 				return nil, err
 			}

--- a/server/tables/pgcatalog/pg_cast.go
+++ b/server/tables/pgcatalog/pg_cast.go
@@ -45,7 +45,7 @@ func (p PgCastHandler) Name() string {
 
 // RowIter implements the interface tables.Handler.
 func (p PgCastHandler) RowIter(ctx *sql.Context, partition sql.Partition) (sql.RowIter, error) {
-	castsColl, err := core.GetCastsCollectionFromContext(ctx)
+	castsColl, err := core.GetCastsCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/tables/pgcatalog/pg_type.go
+++ b/server/tables/pgcatalog/pg_type.go
@@ -87,7 +87,7 @@ func cachePgTypes(ctx *sql.Context, pgCatalogCache *pgCatalogCache) error {
 	oidIdx := NewUniqueInMemIndexStorage[*pgType](lessTypeOid)
 
 	allTypes := pgtypes.GetAllBuitInTypes()
-	typeColl, err := core.GetTypesCollectionFromContext(ctx)
+	typeColl, err := core.GetTypesCollectionFromContext(ctx, "")
 	if err != nil {
 		return err
 	}

--- a/server/types/record.go
+++ b/server/types/record.go
@@ -98,7 +98,7 @@ func serializeTypeRecord(ctx *sql.Context, t *DoltgresType, val any) ([]byte, er
 // deserializeTypeRecord handles deserialization from the Dolt serialized format to our standard representation used by
 // expressions and nodes.
 func deserializeTypeRecord(ctx *sql.Context, t *DoltgresType, data []byte) (any, error) {
-	typeColl, err := GetTypesCollectionFromContext(ctx)
+	typeColl, err := GetTypesCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/server/types/serialization.go
+++ b/server/types/serialization.go
@@ -264,7 +264,7 @@ func recursiveDeserializeType(ctx *sql.Context, typ *DoltgresType, typeColl Type
 	var recursedType *DoltgresType
 	var err error
 	if typeColl == nil {
-		typeColl, err = GetTypesCollectionFromContext(ctx)
+		typeColl, err = GetTypesCollectionFromContext(ctx, "")
 		if err != nil {
 			return nil, nil, err
 		}

--- a/server/types/utils.go
+++ b/server/types/utils.go
@@ -77,10 +77,10 @@ type CastsCollection interface {
 }
 
 // GetTypesCollectionFromContext is a function from the core package, redeclared here to get around import cycles.
-var GetTypesCollectionFromContext func(*sql.Context) (TypeCollection, error)
+var GetTypesCollectionFromContext func(*sql.Context, string) (TypeCollection, error)
 
 // GetCastsCollectionFromContext is a function from the core package, redeclared here to get around import cycles.
-var GetCastsCollectionFromContext func(*sql.Context) (CastsCollection, error)
+var GetCastsCollectionFromContext func(*sql.Context, string) (CastsCollection, error)
 
 // FromGmsType returns a DoltgresType that is most similar to the given GMS type.
 // It returns UNKNOWN type for GMS types that are not handled.


### PR DESCRIPTION
In Dolt, we don't allow multiple databases to be modified in the same statement. Normally this isn't possible, but by accessing certain collections during database creation (such as the cast collection, even if it's not used), we would load those collections. This then caused us to try and persist those collections, even though they're empty. That empty state is still different than "no data present", so it was a valid database update, and could therefore cause multiple databases to be updated.

This change makes it such that every collection is accessed by a database string. In the database creation case, we load a collection under an empty database string (as no database exists yet). This prevents that collection from being persisted (as we don't persist something attached to an empty database name), and works around the multi-database update issue. In addition, this paves the way for proper cross-database support of collection items, which are unsupported at the current moment.