### PR TITLE
[no-release-notes] Force push to `cd-release` branch

### DIFF
--- a/.github/workflows/cd-release.yaml
+++ b/.github/workflows/cd-release.yaml
@@ -80,6 +80,7 @@ jobs:
           add: ${{ format('["{0}/server/server.go", "{0}/servercfg/config.go", "{0}/servercfg/cfgdetails/testdata/minver_validation.txt"]', github.workspace) }}
           cwd: "."
           new_branch: cd-release
+          push: 'origin cd-release --set-upstream --force'
       - name: Create Pull Request
         run: gh pr create --base main --head "cd-release" --title "[no-release-notes] Release v${{ needs.format-version.outputs.version }}" --body "Created by the Release workflow to update DoltgreSQL's version"
         env:


### PR DESCRIPTION
If the `cd-release` branch doesn't get removed after the release job, the next release run is not able to push to it, because the branch already exists on the remote and the client doesn't have a matching commit graph ([example run](https://github.com/dolthub/doltgresql/actions/runs/28200402561/job/83542349156)). 

I was able to manually work around this today by removing the `cd-release` branch. This fix changes our release job to do a force push to `cd-release` so that in the future if that branch wasn't removed, the release job will still work correctly. 