### PR TITLE
Bug fixes: JSONB serialization/deserialization

### DIFF
--- a/integration-tests/go-sql-server-driver/large_values_test.go
+++ b/integration-tests/go-sql-server-driver/large_values_test.go
@@ -280,7 +280,6 @@ func TestLargeOutOfBandValues(t *testing.T) {
 
 	t.Run("LargeJSON", func(t *testing.T) {
 		t.Parallel()
-		t.Skip("Doltgres panics (interface conversion: *val.ExtendedValueWrapper) when retrieving a large out-of-band JSON value")
 		const jsonTargetSize = 12_000
 		const numRows = 20
 
@@ -992,7 +991,6 @@ func TestTypeDiversity(t *testing.T) {
 
 	t.Run("SpecialTypes", func(t *testing.T) {
 		t.Parallel()
-		t.Skip("Doltgres panics (interface conversion: *val.ExtendedValueWrapper) when retrieving a large out-of-band JSON value")
 		server := setupTestServer(t, "special_types_test")
 		db, err := server.DB(driver.Connection{})
 		require.NoError(t, err)
@@ -1055,10 +1053,11 @@ func TestTypeDiversity(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(jsonDoc), &jsonObj))
 		require.Greater(t, len(jsonObj), 0, "large JSON value must be a non-empty object")
 
-		// Verify ENUM and SET values. FIND_IN_SET('blue', col_set) > 0 becomes a
-		// membership test against the comma-separated string.
+		// Verify ENUM and SET values. Use a comma-padded LIKE pattern to test
+		// exact element membership in the comma-separated SET string without
+		// relying on string_to_array, which is not yet implemented in Doltgres.
 		err = conn.QueryRowContext(ctx,
-			"SELECT COUNT(*) FROM special_types WHERE col_enum = 'gamma' AND ('blue' = ANY(string_to_array(col_set, ',')))").Scan(&count)
+			"SELECT COUNT(*) FROM special_types WHERE col_enum = 'gamma' AND (',' || col_set || ',') LIKE '%,blue,%'").Scan(&count)
 		require.NoError(t, err)
 		require.Equal(t, 1, count, "ENUM and SET values must round-trip correctly")
 

--- a/server/functions/json.go
+++ b/server/functions/json.go
@@ -78,6 +78,15 @@ var json_out = framework.Function1{
 }
 
 func json_out_callable(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
+	// Large values stored with the old ExtendedAdaptiveEnc encoding are returned as a
+	// *val.ExtendedValueWrapper (sql.AnyWrapper). Unwrap to get the underlying JSONDocument.
+	if wrapper, ok := val.(sql.AnyWrapper); ok {
+		unwrapped, err := wrapper.UnwrapAny(ctx)
+		if err != nil {
+			return nil, err
+		}
+		val = unwrapped
+	}
 	switch v := val.(type) {
 	case string:
 		return v, nil
@@ -89,8 +98,25 @@ func json_out_callable(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (a
 	}
 }
 
+// JsonOutCallable is exported so that tests outside this package can exercise the json output
+// function directly without going through the global function registry.
+var JsonOutCallable = json_out_callable
+
+// JsonbOutCallable is exported so that tests outside this package can exercise the jsonb output
+// function directly without going through the global function registry.
+var JsonbOutCallable = jsonb_out_callable
+
 // jsonb_out_callable formats a JSONB value for output. JSONB normalizes JSON with spaces after ':' and ','.
 func jsonb_out_callable(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
+	// Large values stored with the old ExtendedAdaptiveEnc encoding are returned as a
+	// *val.ExtendedValueWrapper (sql.AnyWrapper). Unwrap to get the underlying JSONDocument.
+	if wrapper, ok := val.(sql.AnyWrapper); ok {
+		unwrapped, err := wrapper.UnwrapAny(ctx)
+		if err != nil {
+			return nil, err
+		}
+		val = unwrapped
+	}
 	switch v := val.(type) {
 	case string:
 		// Parse and reformat the string as proper JSONB (normalized with spaces)

--- a/server/types/json_document.go
+++ b/server/types/json_document.go
@@ -319,6 +319,10 @@ func ConvertToJsonDocument(val interface{}) (JsonValue, error) {
 			return nil, err
 		}
 		return JsonValueNumber(*d), nil
+	case *apd.Decimal:
+		return JsonValueNumber(*val), nil
+	case apd.Decimal:
+		return JsonValueNumber(val), nil
 	case bool:
 		return JsonValueBoolean(val), nil
 	case nil:

--- a/testing/go/json_test.go
+++ b/testing/go/json_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _go
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	gmstypes "github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/doltgresql/server/functions"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// testAnyWrapper simulates *val.ExtendedValueWrapper — a sql.AnyWrapper that wraps a
+// sql.JSONWrapper rather than a plain string. This is what Dolt returns when reading a
+// large JSONB value that was stored out-of-band with the old ExtendedAdaptiveEnc encoding
+// (used before JsonAdaptiveEnc was enabled for json/jsonb columns). UnwrapAny() on such a
+// wrapper calls the child handler's DeserializeValue, which for JSONB returns a
+// gmstypes.JSONDocument, not a string.
+type testAnyWrapper struct {
+	inner interface{}
+}
+
+func (w *testAnyWrapper) UnwrapAny(_ context.Context) (interface{}, error) { return w.inner, nil }
+func (w *testAnyWrapper) IsExactLength() bool                              { return true }
+func (w *testAnyWrapper) MaxByteLength() int64                             { return 1000 }
+func (w *testAnyWrapper) Compare(_ context.Context, _ interface{}) (int, bool, error) {
+	return 0, false, nil
+}
+func (w *testAnyWrapper) Hash() interface{} { return nil }
+
+// TestJsonbOutCallableWithAnyWrapper verifies that jsonb_out_callable handles a
+// sql.AnyWrapper value. Large JSONB values in databases created before JsonAdaptiveEnc
+// was enabled (using ExtendedAdaptiveEnc instead) are returned from storage as a
+// *val.ExtendedValueWrapper, which implements sql.AnyWrapper. Its UnwrapAny() yields a
+// gmstypes.JSONDocument — so jsonb_out_callable must unwrap and then handle the document,
+// not panic or return an "unexpected type" error.
+func TestJsonbOutCallableWithAnyWrapper(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+
+	tests := []struct {
+		name    string
+		jsonStr string
+	}{
+		{"object", `{"key": "value", "num": 42}`},
+		{"array", `[1, 2, 3]`},
+		{"nested", `{"a": {"b": [true, null]}}`},
+		{"string_scalar", `"hello"`},
+		{"number_scalar", `99`},
+		{"bool_scalar", `false`},
+		{"null_scalar", `null`},
+		// large_object exercises the out-of-band storage path: a document large
+		// enough that the old ExtendedAdaptiveEnc encoding would store it off-page.
+		{"large_object", makeLargeJSONObject(100)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jsonDoc := gmstypes.MustJSON(tt.jsonStr)
+
+			result, err := functions.JsonbOutCallable(ctx, [2]*pgtypes.DoltgresType{}, &testAnyWrapper{inner: jsonDoc})
+			require.NoError(t, err, "jsonb_out_callable must handle sql.AnyWrapper wrapping a JSONDocument")
+			require.NotEmpty(t, result)
+		})
+	}
+}
+
+// TestJsonOutCallableWithAnyWrapper is the json_out equivalent of TestJsonbOutCallableWithAnyWrapper.
+// json_out_callable has the same AnyWrapper gap as jsonb_out_callable.
+func TestJsonOutCallableWithAnyWrapper(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+
+	tests := []struct {
+		name    string
+		jsonStr string
+	}{
+		{"object", `{"key": "value", "num": 42}`},
+		{"array", `[1, 2, 3]`},
+		{"nested", `{"a": {"b": [true, null]}}`},
+		{"string_scalar", `"hello"`},
+		{"number_scalar", `99`},
+		{"bool_scalar", `false`},
+		{"null_scalar", `null`},
+		{"large_object", makeLargeJSONObject(100)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jsonDoc := gmstypes.MustJSON(tt.jsonStr)
+
+			result, err := functions.JsonOutCallable(ctx, [2]*pgtypes.DoltgresType{}, &testAnyWrapper{inner: jsonDoc})
+			require.NoError(t, err, "json_out_callable must handle sql.AnyWrapper wrapping a JSONDocument")
+			require.NotEmpty(t, result)
+		})
+	}
+}
+
+// TestJsonbSerializeWithAnyWrapper verifies that types.JsonB.SerializeValue handles a
+// sql.AnyWrapper that wraps a JSONDocument containing *apd.Decimal values. This
+// represents the combined Bug 1 + Bug 2 production failure path:
+//
+//  1. A large legacy JSONB value is read from Dolt → *val.ExtendedValueWrapper (AnyWrapper).
+//  2. The wrapper is passed to serializeTypeJsonB (e.g. during replication or export).
+//  3. sql.UnwrapAny extracts a gmstypes.JSONDocument.
+//  4. ToInterface() returns the .Val, which after the jsonValueToInterface bugfix
+//     contains *apd.Decimal for numeric fields.
+//  5. ConvertToJsonDocument(*apd.Decimal) must handle that type — previously it did not.
+func TestJsonbSerializeWithAnyWrapper(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+
+	tests := []struct {
+		name  string
+		inner gmstypes.JSONDocument
+	}{
+		{
+			"scalar_decimal",
+			gmstypes.JSONDocument{Val: mustDecimal("3.14")},
+		},
+		{
+			"object_with_decimal",
+			gmstypes.JSONDocument{Val: map[string]any{
+				"n": mustDecimal("42"),
+				"s": "hello",
+			}},
+		},
+		{
+			"array_with_decimals",
+			gmstypes.JSONDocument{Val: []any{mustDecimal("1"), mustDecimal("2"), mustDecimal("3")}},
+		},
+		{
+			"nested_decimals",
+			gmstypes.JSONDocument{Val: map[string]any{
+				"a": map[string]any{"b": mustDecimal("-9.9")},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapper := &testAnyWrapper{inner: tt.inner}
+			_, err := pgtypes.JsonB.SerializeValue(ctx, wrapper)
+			require.NoError(t, err,
+				"SerializeValue must handle an AnyWrapper wrapping a JSONDocument with *apd.Decimal")
+		})
+	}
+}

--- a/testing/go/jsonb_test.go
+++ b/testing/go/jsonb_test.go
@@ -300,6 +300,45 @@ func requireJsonEqual(t *testing.T, expected, actual any) {
 	}
 }
 
+// TestLegacyJsonBReserialization verifies that a value deserialized from the legacy
+// ExtendedEnc format can be re-serialized without error. This exercises the path where
+// serializeTypeJsonB receives a JSONDocument whose Val contains *apd.Decimal (the type
+// that jsonValueToInterface now returns for JsonValueNumber after the bugfix), and
+// ConvertToJsonDocument must handle it.
+func TestLegacyJsonBReserialization(t *testing.T) {
+	tests := []struct {
+		name  string
+		input any
+	}{
+		{"number_integer", json.Number("42")},
+		{"number_negative", json.Number("-7")},
+		{"number_float", json.Number("3.14")},
+		{"number_large", json.Number("99999999999999999999")},
+		{"object_with_number", map[string]any{"n": json.Number("99")}},
+		{"array_with_numbers", []any{json.Number("1"), json.Number("2"), json.Number("3")}},
+		{"nested_number", map[string]any{"a": map[string]any{"b": json.Number("1.5")}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := gmstypes.JSONDocument{Val: tt.input}
+
+			// Step 1: serialize (simulates old Doltgres write using the legacy ExtendedEnc path)
+			serialized, err := types.JsonB.SerializeValue(context.Background(), doc)
+			require.NoError(t, err)
+
+			// Step 2: deserialize (jsonValueToInterface now returns *apd.Decimal for numbers)
+			deserialized, err := types.JsonB.DeserializeValue(context.Background(), serialized)
+			require.NoError(t, err)
+			require.NotNil(t, deserialized)
+
+			// Step 3: re-serialize the deserialized value.
+			_, err = types.JsonB.SerializeValue(context.Background(), deserialized)
+			require.NoError(t, err, "re-serializing a deserialized legacy JSONB value must not fail")
+		})
+	}
+}
+
 // mustDecimal parses s into an *apd.Decimal, panicking on failure.
 func mustDecimal(s string) *apd.Decimal {
 	d := new(apd.Decimal)


### PR DESCRIPTION
Fixes a customer reported issue where tables created with JSON columns before the introduction of adaptive encoding (e.g. Doltgres-0.56) use a different encoding format and don't serialize/deserialize correctly in versions of Doltgres that include the adaptive encoding feature. 