### PR TITLE
Add regression test for preparing a join query with a bindvar on an indexed column

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dolthub/dolt/go v0.40.5-0.20260630202107-2a5c6c25091b
 	github.com/dolthub/eventsapi_schema v0.0.0-20260310172945-37a9265ade69
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.20.1-0.20260626224942-f5b97c4d9179
+	github.com/dolthub/go-mysql-server v0.20.1-0.20260706181715-b6596ac1cfa4
 	github.com/dolthub/pg_query_go/v6 v6.0.0-20251215122834-fb20be4254d1
 	github.com/dolthub/sqllogictest/go v0.0.0-20260624223518-788480b24166
 	github.com/dolthub/vitess v0.0.0-20260624214226-81d034e0fde8

--- a/go.sum
+++ b/go.sum
@@ -258,6 +258,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83 h1:FEMjCGEroD
 github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260626224942-f5b97c4d9179 h1:/OVe5bHJO97HfxYTjlUIrjCo6fw2eeGJLUoR4DjwHRU=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260626224942-f5b97c4d9179/go.mod h1:mj5/QX3V8i92REbA1w6CzyknJAFdKtdE7l931405C/E=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260706181715-b6596ac1cfa4 h1:M11BBk2IXoqBQfdiBfeBExad16+LcXt7gJmEWm0Sgsw=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260706181715-b6596ac1cfa4/go.mod h1:mj5/QX3V8i92REbA1w6CzyknJAFdKtdE7l931405C/E=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20260414231531-5f031e3e9037 h1:oIW9HwuWrhxv+4HZxA+QQSKHLqWFyXZ2FmNjUYwkdiM=

--- a/testing/go/prepared_statement_test.go
+++ b/testing/go/prepared_statement_test.go
@@ -1347,6 +1347,25 @@ var preparedStatementTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "merge join planning with bindvar equality filter on indexed join column",
+		SetUpScript: []string{
+			"CREATE TABLE t1 (pk INT PRIMARY KEY, fk INT, val INT);",
+			"CREATE INDEX t1_fk_idx ON t1(fk);",
+			"CREATE TABLE t2 (pk INT PRIMARY KEY, val INT);",
+			"INSERT INTO t1 VALUES (1, 1, 100), (2, 2, 200), (3, 3, 300);",
+			"INSERT INTO t2 VALUES (1, 10), (2, 20), (3, 30);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT t1.val, t2.val FROM t1 JOIN t2 ON t1.fk = t2.pk WHERE t1.fk = $1;",
+				BindVars: []any{1},
+				Expected: []sql.Row{
+					{100, 10},
+				},
+			},
+		},
+	},
 }
 
 var pgCatalogTests = []ScriptTest{


### PR DESCRIPTION
New regression test for a customer-reported issue where preparing a join query with a bindvar comparing equality on an indexed column caused a panic. Root cause fix is in go-mysql-server, in the linked PR below. 

Depends on: https://github.com/dolthub/go-mysql-server/pull/3612