### PR TITLE
Bug fix for coalesce with mixed types

### DIFF
--- a/server/expression/coalesce.go
+++ b/server/expression/coalesce.go
@@ -129,19 +129,8 @@ func (c *PgCoalesce) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 		if ok && argType.Equals(commonType) {
 			return val, nil
 		}
-		// For Doltgres types, use an assignment cast to convert argType → commonType.
-		// This handles numeric widening (e.g. int4→int8, int4→float8) when COALESCE args have mixed types.
-		if ok && argType != nil {
-			cast, castErr := pgtypes.GetAssignmentCast(ctx, argType, commonType)
-			if castErr == nil && cast != nil {
-				converted, castErr := cast.Eval(ctx, val, argType, commonType)
-				if castErr != nil {
-					return nil, castErr
-				}
-				return converted, nil
-			}
-		}
-		converted, _, err := commonType.Convert(ctx, val)
+		// Cast the value to the common type (handles mixed-type args, e.g. int2 and int4).
+		converted, _, err := commonType.ConvertToType(ctx, argType, val)
 		if err != nil {
 			return nil, err
 		}

--- a/testing/go/expressions_test.go
+++ b/testing/go/expressions_test.go
@@ -548,5 +548,19 @@ func TestCoalesce(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "COALESCE with mixed types",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:       `SELECT COALESCE('a'::TEXT, 1::INTEGER)`,
+					ExpectedErr: `types text and integer cannot be matched`,
+				},
+				{
+					// smallint and bigint are compatible via numeric promotion; result is bigint.
+					Query:    `SELECT COALESCE(NULL, 1::SMALLINT, 2::BIGINT) AS v;`,
+					Expected: []sql.Row{{int64(1)}},
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
Added a new test for `COALESCE()` use with mixed types, and simplified implementation to use the `DoltgresType.ConvertType()` function instead of directly using the assignment cast.