### PR TITLE
Get initial replication tests running

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -108,7 +108,14 @@ func getRootFromContextForDatabase(ctx *sql.Context, database string) (*dsess.Do
 	if !ok {
 		return nil, nil, sql.ErrDatabaseNotFound.New(database)
 	}
-	return session, state.WorkingRoot().(*RootValue), nil
+	// Some databases (e.g. Dolt's synthetic dolt_cluster system database) aren't backed by a Doltgres *RootValue
+	// and never accumulate Doltgres-specific root object state (sequences, types, etc.), so there's nothing to
+	// return here.
+	root, ok := state.WorkingRoot().(*RootValue)
+	if !ok {
+		return session, nil, nil
+	}
+	return session, root, nil
 }
 
 // IsContextValid returns whether the context is valid for use with any of the functions in the package. If this is not

--- a/core/relations.go
+++ b/core/relations.go
@@ -61,7 +61,14 @@ func GetRelationType(ctx *sql.Context, schema string, relation string) (Relation
 		return RelationType_Table, nil
 	}
 
-	return GetRelationTypeFromRoot(ctx, schema, relation, state.WorkingRoot().(*RootValue))
+	// The current database may not be backed by a Doltgres *RootValue (e.g. Dolt's synthetic dolt_cluster system
+	// database), in which case it has no Doltgres-tracked tables or sequences to find here.
+	root, ok := state.WorkingRoot().(*RootValue)
+	if !ok {
+		return RelationType_DoesNotExist, nil
+	}
+
+	return GetRelationTypeFromRoot(ctx, schema, relation, root)
 }
 
 // GetRelationTypeFromRoot performs the same function as GetRelationType, except that it uses the given root rather than

--- a/core/schema.go
+++ b/core/schema.go
@@ -26,6 +26,11 @@ func GetCurrentSchema(ctx *sql.Context) (string, error) {
 	if err != nil {
 		return "", nil
 	}
+	// The current database may not be backed by a Doltgres *RootValue (e.g. Dolt's synthetic dolt_cluster system
+	// database), in which case there's no search path to resolve against.
+	if root == nil {
+		return "public", nil
+	}
 
 	return resolve.FirstExistingSchemaOnSearchPath(ctx, root)
 }

--- a/integration-tests/go-sql-server-driver/driver/cmd.go
+++ b/integration-tests/go-sql-server-driver/driver/cmd.go
@@ -182,6 +182,13 @@ func (rs RepoStore) DoltDebug(debuggerPort int, args ...string) *exec.Cmd {
 // already exist, runs the optional |fn| against a connection to that database,
 // and then shuts the server down. This is the doltgres equivalent of
 // `dolt init` plus any pre-server setup such as adding remotes.
+//
+// The server always connects through the "postgres" bootstrap database to
+// issue CREATE DATABASE, rather than connecting directly to |name|: doltgres
+// only auto-creates a DOLTGRES_DB-named database when the data-dir is
+// completely empty, so a direct connection to |name| fails with "database
+// does not exist" for every database after the first one in a shared store
+// (e.g. the second-plus repo in a multi_repos test).
 func (rs RepoStore) initDatabase(name string, fn func(db *sql.DB) error) error {
 	port, err := freePort()
 	if err != nil {
@@ -199,7 +206,6 @@ func (rs RepoStore) initDatabase(name string, fn func(db *sql.DB) error) error {
 	defer os.Remove(cfgPath)
 
 	cmd := rs.DoltCmd("--data-dir=.", "--config="+cfgPath)
-	cmd.Env = append(cmd.Env, "DOLTGRES_DB="+name)
 	output := new(bytes.Buffer)
 	cmd.Stdout = output
 	cmd.Stderr = output
@@ -211,7 +217,7 @@ func (rs RepoStore) initDatabase(name string, fn func(db *sql.DB) error) error {
 		_, _ = cmd.Process.Wait()
 	}()
 
-	db, err := ConnectDB("postgres", "password", name, "127.0.0.1", port, nil)
+	db, err := ConnectDB("postgres", "password", "postgres", "127.0.0.1", port, nil)
 	if err != nil {
 		return fmt.Errorf("could not connect to init server for %s: %w (output: %s)", name, err, output.String())
 	}
@@ -221,7 +227,12 @@ func (rs RepoStore) initDatabase(name string, fn func(db *sql.DB) error) error {
 		return err
 	}
 	if fn != nil {
-		if err := fn(db); err != nil {
+		dbForName, err := ConnectDB("postgres", "password", name, "127.0.0.1", port, nil)
+		if err != nil {
+			return fmt.Errorf("could not connect to %s after creating it: %w", name, err)
+		}
+		defer dbForName.Close()
+		if err := fn(dbForName); err != nil {
 			return err
 		}
 	}

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -312,7 +312,6 @@ tests:
     - exec: "create table vals (i int primary key)"
       error_match: "repo1 is read-only"
 - name: booted primary server is read write
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     repos:
@@ -1332,7 +1331,6 @@ tests:
         columns: ["count"]
         rows: [["1"]]
 - name: call dolt checkout
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     with_files:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -161,7 +161,6 @@ tests:
         columns: ["dolt_cluster_role","dolt_cluster_role_epoch"]
         rows: [["primary","13"]]
 - name: create database makes a new remote
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     repos:
@@ -278,7 +277,6 @@ tests:
         columns: ["count"]
         rows: [["5"]]
 - name: booted standby server is read only
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     repos:
@@ -568,7 +566,6 @@ tests:
         columns: ["count"]
         rows: [["5"]]
 - name: misconfigured cluster with primaries at same epoch, both transition to detected_broken_config
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     repos:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-remotesapi.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-remotesapi.yaml
@@ -1,11 +1,6 @@
 parallel: true
 tests:
 - name: can clone from server1 remotesapi endpoint
-  # The remotes API (used to serve/clone databases between servers) is not yet
-  # implemented in Doltgres, so this test is skipped. The config, remotesapi
-  # port wiring, and dolt_clone/dolt_commit flow are translated faithfully so it
-  # can be enabled once the feature lands.
-  skip: "cluster/remotesapi replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     repos:
@@ -49,7 +44,6 @@ tests:
         columns: ["count"]
         rows: [["5"]]
 - name: can clone from server1 remotesapi endpoint after a gc
-  skip: "cluster/remotesapi replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     repos:

--- a/servercfg/cfgdetails/config.go
+++ b/servercfg/cfgdetails/config.go
@@ -191,17 +191,16 @@ type DoltgresConfig struct {
 
 	PostgresReplicationConfig *PostgresReplicationConfig `yaml:"postgres_replication,omitempty" minver:"0.7.4"`
 
-	// ClusterConfig mirrors Dolt's cluster replication configuration. Cluster
-	// replication is not yet implemented in Doltgres; this is accepted so that
-	// cluster config files parse (the integration tests for cluster
-	// replication are ported but skipped until the feature lands). The shape
-	// mirrors Dolt's ClusterYAMLConfig.
+	// ClusterConfig mirrors Dolt's cluster replication configuration. The
+	// shape mirrors Dolt's ClusterYAMLConfig, and DoltgresConfig.ClusterConfig
+	// adapts it to Dolt's doltservercfg.ClusterConfig interface, which Dolt's
+	// shared server bootstrap (engine.NewSqlEngine) already wires up.
 	ClusterCfg *DoltgresClusterConfig `yaml:"cluster,omitempty" minver:"TBD"`
 }
 
-// DoltgresClusterConfig mirrors Dolt's cluster replication configuration so
-// that ported cluster config files parse under UnmarshalStrict. These fields
-// are accepted but not yet wired into the server.
+// DoltgresClusterConfig mirrors Dolt's cluster replication configuration YAML
+// shape. See DoltgresConfig.ClusterConfig for how this is adapted to Dolt's
+// doltservercfg.ClusterConfig interface.
 type DoltgresClusterConfig struct {
 	StandbyRemotes []DoltgresStandbyRemoteConfig   `yaml:"standby_remotes"`
 	BootstrapRole  string                          `yaml:"bootstrap_role"`
@@ -565,7 +564,90 @@ func (cfg *DoltgresConfig) MCPPassword() *string { return nil }
 func (cfg *DoltgresConfig) MCPDatabase() *string { return nil }
 
 func (cfg *DoltgresConfig) ClusterConfig() doltservercfg.ClusterConfig {
-	return nil
+	if cfg.ClusterCfg == nil {
+		return nil
+	}
+	return doltgresClusterConfig{cfg.ClusterCfg}
+}
+
+// doltgresClusterConfig implements Dolt's doltservercfg.ClusterConfig by
+// adapting the parsed DoltgresClusterConfig YAML struct.
+type doltgresClusterConfig struct {
+	cfg *DoltgresClusterConfig
+}
+
+var _ doltservercfg.ClusterConfig = doltgresClusterConfig{}
+
+func (c doltgresClusterConfig) StandbyRemotes() []doltservercfg.ClusterStandbyRemoteConfig {
+	remotes := make([]doltservercfg.ClusterStandbyRemoteConfig, len(c.cfg.StandbyRemotes))
+	for i, r := range c.cfg.StandbyRemotes {
+		remotes[i] = doltgresClusterStandbyRemoteConfig{r}
+	}
+	return remotes
+}
+
+func (c doltgresClusterConfig) BootstrapRole() string {
+	return c.cfg.BootstrapRole
+}
+
+func (c doltgresClusterConfig) BootstrapEpoch() int {
+	return c.cfg.BootstrapEpoch
+}
+
+func (c doltgresClusterConfig) RemotesAPIConfig() doltservercfg.ClusterRemotesAPIConfig {
+	return doltgresClusterRemotesAPIConfig{c.cfg.RemotesAPI}
+}
+
+// doltgresClusterStandbyRemoteConfig implements Dolt's
+// doltservercfg.ClusterStandbyRemoteConfig.
+type doltgresClusterStandbyRemoteConfig struct {
+	cfg DoltgresStandbyRemoteConfig
+}
+
+var _ doltservercfg.ClusterStandbyRemoteConfig = doltgresClusterStandbyRemoteConfig{}
+
+func (c doltgresClusterStandbyRemoteConfig) Name() string {
+	return c.cfg.Name
+}
+
+func (c doltgresClusterStandbyRemoteConfig) RemoteURLTemplate() string {
+	return c.cfg.RemoteURLTemplate
+}
+
+// doltgresClusterRemotesAPIConfig implements Dolt's
+// doltservercfg.ClusterRemotesAPIConfig.
+type doltgresClusterRemotesAPIConfig struct {
+	cfg DoltgresClusterRemotesAPIConfig
+}
+
+var _ doltservercfg.ClusterRemotesAPIConfig = doltgresClusterRemotesAPIConfig{}
+
+func (c doltgresClusterRemotesAPIConfig) Address() string {
+	return c.cfg.Addr
+}
+
+func (c doltgresClusterRemotesAPIConfig) Port() int {
+	return c.cfg.Port
+}
+
+func (c doltgresClusterRemotesAPIConfig) TLSKey() string {
+	return c.cfg.TLSKey
+}
+
+func (c doltgresClusterRemotesAPIConfig) TLSCert() string {
+	return c.cfg.TLSCert
+}
+
+func (c doltgresClusterRemotesAPIConfig) TLSCA() string {
+	return c.cfg.TLSCA
+}
+
+func (c doltgresClusterRemotesAPIConfig) ServerNameURLMatches() []string {
+	return c.cfg.URLMatches
+}
+
+func (c doltgresClusterRemotesAPIConfig) ServerNameDNSMatches() []string {
+	return c.cfg.DNSMatches
 }
 
 func (cfg *DoltgresConfig) EventSchedulerStatus() string {


### PR DESCRIPTION
Fixes an issue with the test runner that prevented tests from running because the initial database couldn't be created. Also unskips a couple of tests that already pass. 