### PR TITLE
Bug fixes for replication

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -17,11 +17,14 @@ package core
 import (
 	"maps"
 	"slices"
+	"sync"
 
 	"github.com/cockroachdb/errors"
 	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/resolve"
+	"github.com/dolthub/dolt/go/store/prolly/tree"
+	"github.com/dolthub/dolt/go/store/types"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/core/casts"
@@ -116,6 +119,35 @@ func getRootFromContextForDatabase(ctx *sql.Context, database string) (*dsess.Do
 		return session, nil, nil
 	}
 	return session, root, nil
+}
+
+var (
+	syntheticRootOnce sync.Once
+	syntheticRoot     *RootValue
+	syntheticRootErr  error
+)
+
+// getRootForCollections returns the working root for the given database, for use in loading the Doltgres
+// collections (sequences, types, functions, etc.). Databases that aren't backed by a Doltgres *RootValue
+// (e.g. Dolt's synthetic dolt_cluster system database) can't store any of these objects, so they get a shared,
+// empty, in-memory root: collections loaded from it are empty, meaning only built-in objects resolve there.
+func getRootForCollections(ctx *sql.Context, database string) (*RootValue, error) {
+	_, root, err := getRootFromContextForDatabase(ctx, database)
+	if err != nil {
+		return nil, err
+	}
+	if root != nil {
+		return root, nil
+	}
+	syntheticRootOnce.Do(func() {
+		rv, err := emptyRootValue(ctx, types.NewMemoryValueStore(), tree.NewTestNodeStore())
+		if err != nil {
+			syntheticRootErr = err
+			return
+		}
+		syntheticRoot = rv.(*RootValue)
+	})
+	return syntheticRoot, syntheticRootErr
 }
 
 // IsContextValid returns whether the context is valid for use with any of the functions in the package. If this is not
@@ -311,7 +343,7 @@ func GetExtensionsCollectionFromContext(ctx *sql.Context, database string) (*ext
 		database = ctx.GetCurrentDatabase()
 	}
 	if cv.exts[database] == nil {
-		_, root, err := getRootFromContextForDatabase(ctx, database)
+		root, err := getRootForCollections(ctx, database)
 		if err != nil {
 			return nil, err
 		}
@@ -337,7 +369,7 @@ func GetFunctionsCollectionFromContext(ctx *sql.Context, database string) (*func
 		database = ctx.GetCurrentDatabase()
 	}
 	if cv.funcs[database] == nil {
-		_, root, err := getRootFromContextForDatabase(ctx, database)
+		root, err := getRootForCollections(ctx, database)
 		if err != nil {
 			return nil, err
 		}
@@ -363,7 +395,7 @@ func GetProceduresCollectionFromContext(ctx *sql.Context, database string) (*pro
 		database = ctx.GetCurrentDatabase()
 	}
 	if cv.procs[database] == nil {
-		_, root, err := getRootFromContextForDatabase(ctx, database)
+		root, err := getRootForCollections(ctx, database)
 		if err != nil {
 			return nil, err
 		}
@@ -390,7 +422,7 @@ func GetSequencesCollectionFromContext(ctx *sql.Context, database string) (*sequ
 		database = ctx.GetCurrentDatabase()
 	}
 	if cv.seqs[database] == nil {
-		_, root, err := getRootFromContextForDatabase(ctx, database)
+		root, err := getRootForCollections(ctx, database)
 		if err != nil {
 			return nil, err
 		}
@@ -416,7 +448,7 @@ func GetTriggersCollectionFromContext(ctx *sql.Context, database string) (*trigg
 		database = ctx.GetCurrentDatabase()
 	}
 	if cv.trigs[database] == nil {
-		_, root, err := getRootFromContextForDatabase(ctx, database)
+		root, err := getRootForCollections(ctx, database)
 		if err != nil {
 			return nil, err
 		}
@@ -442,7 +474,7 @@ func GetTypesCollectionFromContext(ctx *sql.Context, database string) (*typecoll
 		database = ctx.GetCurrentDatabase()
 	}
 	if cv.types[database] == nil {
-		_, root, err := getRootFromContextForDatabase(ctx, database)
+		root, err := getRootForCollections(ctx, database)
 		if err != nil {
 			return nil, err
 		}
@@ -468,7 +500,7 @@ func GetCastsCollectionFromContext(ctx *sql.Context, database string) (*casts.Co
 		database = ctx.GetCurrentDatabase()
 	}
 	if cv.casts[database] == nil {
-		_, root, err := getRootFromContextForDatabase(ctx, database)
+		root, err := getRootForCollections(ctx, database)
 		if err != nil {
 			return nil, err
 		}
@@ -528,6 +560,20 @@ func updateSessionRootForDatabase(ctx *sql.Context, db string, cv *contextValues
 	session, root, err := getRootFromContextForDatabase(ctx, db)
 	if err != nil {
 		return err
+	}
+
+	// Databases that aren't backed by a Doltgres *RootValue (e.g. Dolt's synthetic dolt_cluster system database)
+	// can't persist root object collections. Any collections cached for them are empty, synthetic ones, so just
+	// evict them from the context values.
+	if root == nil {
+		delete(cv.seqs, db)
+		delete(cv.funcs, db)
+		delete(cv.procs, db)
+		delete(cv.trigs, db)
+		delete(cv.exts, db)
+		delete(cv.types, db)
+		delete(cv.casts, db)
+		return nil
 	}
 
 	newRoot := root

--- a/integration-tests/go-sql-server-driver/driver/cmd.go
+++ b/integration-tests/go-sql-server-driver/driver/cmd.go
@@ -543,6 +543,13 @@ func (s *SqlServer) Connector(c Connection) (driver.Connector, error) {
 	if c.Database != "" {
 		dbName = c.Database
 	}
+	if dbName == "" {
+		// Always request a database explicitly. When the client sends no database, doltgres attempts
+		// an implicit USE of the user's name and silently proceeds with a database-less session if it
+		// fails, breaking later queries.
+		// TODO: fix this in doltgres, reject connections with a missing user database instead of silently proceeding
+		dbName = user
+	}
 	dsn := GetDSN(user, pass, dbName, "127.0.0.1", s.Port, c.DriverParams)
 	cfg, err := pgx.ParseConfig(dsn)
 	if err != nil {

--- a/integration-tests/go-sql-server-driver/driver/cmd.go
+++ b/integration-tests/go-sql-server-driver/driver/cmd.go
@@ -539,7 +539,11 @@ func (s *SqlServer) Connector(c Connection) (driver.Connector, error) {
 	if user == "" {
 		user = "postgres"
 	}
-	dsn := GetDSN(user, pass, s.DBName, "127.0.0.1", s.Port, c.DriverParams)
+	dbName := s.DBName
+	if c.Database != "" {
+		dbName = c.Database
+	}
+	dsn := GetDSN(user, pass, dbName, "127.0.0.1", s.Port, c.DriverParams)
 	cfg, err := pgx.ParseConfig(dsn)
 	if err != nil {
 		return nil, err

--- a/integration-tests/go-sql-server-driver/driver/server.go
+++ b/integration-tests/go-sql-server-driver/driver/server.go
@@ -44,6 +44,11 @@ type Connection struct {
 	// The user to connect as. For Doltgres this defaults to the Postgres
 	// superuser, "postgres".
 	User string `default:"postgres" yaml:"user"`
+	// The database to connect to, overriding the server's default. Useful
+	// when no user database exists yet (e.g. a read-only server with an
+	// empty data dir), where a synthetic database like dolt_cluster is the
+	// only one available to connect to.
+	Database string `yaml:"database"`
 	// The password to connect with.
 	Pass     string `yaml:"password"`
 	PassFile string `yaml:"password_file"`

--- a/integration-tests/go-sql-server-driver/testdef.go
+++ b/integration-tests/go-sql-server-driver/testdef.go
@@ -468,7 +468,15 @@ func (test Test) Run(t *testing.T) {
 	}
 
 	for _, mr := range test.MultiRepos {
-		// Each MultiRepo gets its own data-dir.
+		// Each MultiRepo gets its own dolt config --global (DOLT_ROOT_PATH) and
+		// its own data-dir. Separate global configs matter for cluster
+		// replication tests: the cluster role and epoch are persisted to the
+		// global config, and each server in a cluster must persist its own.
+		u, err := driver.NewDoltUser()
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			u.Cleanup()
+		})
 		rs, err := u.MakeRepoStore()
 		require.NoError(t, err)
 		for _, r := range mr.Repos {

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -1546,6 +1546,10 @@ tests:
     - exec: 'use repo2'
     - exec: 'create table vals (i int primary key)'
     - exec: 'use dolt_cluster'
+    # The retry here (and on status assertions generally) matters for the postgres database: unlike the
+    # user databases above, whose replication is synchronized by dolt_cluster_ack_writes_timeout_secs,
+    # the auto-created postgres database is first pushed by the background replication thread some time
+    # after startup, so its replication_lag_millis stays NULL until that first push completes.
     - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis is not null as \"replication_lag_millis\", current_error from dolt_cluster_status order by \"database\" asc"
       result:
         columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
@@ -1553,6 +1557,7 @@ tests:
         - ["postgres", "standby", "primary", "1", "true", "NULL"]
         - ["repo1", "standby", "primary", "1", "true", "NULL"]
         - ["repo2", "standby", "primary", "1", "true", "NULL"]
+      retry_attempts: 100
     - exec: 'use repo1'
     - exec: 'drop database repo2'
     - exec: 'insert into vals values (0),(1),(2),(3),(4)'
@@ -1570,6 +1575,7 @@ tests:
         rows:
         - ["postgres", "standby", "primary", "1", "true", "NULL"]
         - ["repo1", "standby", "primary", "1", "true", "NULL"]
+      retry_attempts: 100
   - on: server2
     queries:
     - query: 'SELECT datname FROM pg_database ORDER BY datname'
@@ -1709,6 +1715,7 @@ tests:
         columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
         rows:
         - ["postgres", "standby", "primary", "1", "true", "NULL"]
+      retry_attempts: 100
   - on: server2
     queries:
     - query: 'SELECT datname FROM pg_database ORDER BY datname'
@@ -2014,6 +2021,20 @@ tests:
       result:
         columns: ['read_only']
         rows: [['1']]
+  # Wait for the standby to be fully caught up before the graceful transition below. The auto-created
+  # postgres database is first pushed by the background replication thread some time after startup
+  # (replication_lag_millis is NULL until that first push completes), and the graceful transition has a
+  # fixed timeout it would otherwise spend waiting on the same convergence.
+  - on: server1
+    queries:
+    - exec: 'USE dolt_cluster'
+    - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis, current_error from dolt_cluster_status order by \"database\" asc"
+      result:
+        columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
+        rows:
+        - ["postgres","standby","primary","1","0","NULL"]
+        - ["repo1","standby","primary","1","0","NULL"]
+      retry_attempts: 100
   - on: server1
     queries:
     - exec: 'USE repo1'
@@ -2043,6 +2064,18 @@ tests:
       result:
         columns: ['read_only']
         rows: [['0']]
+  # As above: promotion resets each database's replication progress, so wait for the new primary to
+  # catch its standby up before gracefully transitioning it back to standby.
+  - on: server2
+    queries:
+    - exec: 'USE dolt_cluster'
+    - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis, current_error from dolt_cluster_status order by \"database\" asc"
+      result:
+        columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
+        rows:
+        - ["postgres","standby","primary","2","0","NULL"]
+        - ["repo1","standby","primary","2","0","NULL"]
+      retry_attempts: 100
   - on: server2
     queries:
     - exec: 'USE repo1'

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -23,7 +23,6 @@
 parallel: true
 tests:
 - name: persisted role and epoch take precedence over bootstrap values
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     repos:
@@ -86,7 +85,6 @@ tests:
         columns: ["dolt_cluster_role","dolt_cluster_role_epoch"]
         rows: [["standby","10"]]
 - name: dolt_assume_cluster_role
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     repos:
@@ -197,7 +195,6 @@ tests:
         columns: ["name","url"]
         rows: [["standby","http://localhost:{{get_port \"server2_cluster\"}}/a_new_database"]]
 - name: primary comes up and replicates to standby
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     repos:
@@ -266,6 +263,7 @@ tests:
       result:
         columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
         rows:
+        - ["postgres","standby","primary","10","0","NULL"]
         - ["repo1","standby","primary","10","0","NULL"]
         - ["repo2","standby","primary","10","0","NULL"]
       retry_attempts: 100
@@ -342,7 +340,6 @@ tests:
     - exec: "use repo1"
     - exec: "create table vals (i int primary key)"
 - name: standby server takes primary epoch
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     repos:
@@ -409,6 +406,7 @@ tests:
       result:
         columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
         rows:
+        - ["postgres","standby","primary","10","0","NULL"]
         - ["repo1","standby","primary","10","0","NULL"]
         - ["repo2","standby","primary","10","0","NULL"]
       retry_attempts: 100
@@ -426,7 +424,7 @@ tests:
   - on: server1
     queries:
     - exec: "use repo1"
-    - exec: "select dolt_assume_cluster_role('primary', 11)"
+    - exec: "select dolt_assume_cluster_role('primary', '11')"
     - exec: "insert into vals values (6),(7),(8),(9),(10)"
     - exec: "use dolt_cluster"
     - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis, current_error from dolt_cluster_status order by \"database\" asc"
@@ -448,7 +446,6 @@ tests:
         columns: ["dolt_cluster_role_epoch"]
         rows: [["11"]]
 - name: standby transitioned to primary becomes read write
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     repos:
@@ -481,7 +478,7 @@ tests:
     - exec: "use repo1"
     - exec: "create table vals (i int primary key)"
       error_match: "repo1 is read-only"
-    - query: "select dolt_assume_cluster_role('primary', 11)"
+    - query: "select dolt_assume_cluster_role('primary', '11')"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
@@ -494,7 +491,6 @@ tests:
         columns: ["count"]
         rows: [["0"]]
 - name: primary transitioned to standby becomes read only
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     repos:
@@ -552,7 +548,7 @@ tests:
     - exec: "use repo1"
     - exec: "create table vals (i int primary key)"
     - exec: "insert into vals values (1),(2),(3),(4),(5)"
-    - query: "select dolt_assume_cluster_role('standby', 11)"
+    - query: "select dolt_assume_cluster_role('standby', '11')"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
@@ -639,7 +635,6 @@ tests:
     - exec: "create table more_vals (i int primary key)"
       error_match: "repo1 is read-only"
 - name: an older primary comes up, becomes a standby and does not overwrite newer primary
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     repos:
@@ -739,7 +734,6 @@ tests:
         columns: ["count"]
         rows: [["10"]]
 - name: a newer primary comes up, old primary becomes a standby has its state overwritten
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     repos:
@@ -844,7 +838,6 @@ tests:
         columns: ["count"]
         rows: [["5"]]
 - name: graceful primary to standby transition without the standby up fails
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     repos:
@@ -880,7 +873,6 @@ tests:
     - exec: "create table vals (i int primary key)"
     - exec: "insert into vals values (0)"
 - name: dolt_cluster_transition_to_standby
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     with_files:
@@ -929,7 +921,6 @@ tests:
         - ["1", "mysql", "standby", "http://localhost:{{get_port \"server2_cluster\"}}"]
         - ["1", "dolt_branch_control", "standby", "http://localhost:{{get_port \"server2_cluster\"}}"]
 - name: dolt_cluster_transition_to_standby too many standbys provided
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     with_files:
@@ -973,7 +964,6 @@ tests:
     - query: "select dolt_cluster_transition_to_standby('2', '2')"
       error_match: failed to transition from primary to standby gracefully; could not ensure 2 replicas were caught up on all 3 databases. Only caught up 1 standbys fully.
 - name: create new database, primary replicates to standby, fails over, new primary replicates to standby, fails over, new primary has all writes
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     with_files:
@@ -1014,7 +1004,7 @@ tests:
     - exec: 'use repo1'
     - exec: 'create table vals (i int primary key)'
     - exec: 'insert into vals values (0),(1),(2),(3),(4)'
-    - query: "select dolt_assume_cluster_role('standby', 2)"
+    - query: "select dolt_assume_cluster_role('standby', '2')"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
@@ -1025,7 +1015,7 @@ tests:
       result:
         columns: ["count"]
         rows: [["5"]]
-    - query: "select dolt_assume_cluster_role('primary', 2)"
+    - query: "select dolt_assume_cluster_role('primary', '2')"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
@@ -1033,7 +1023,7 @@ tests:
     queries:
     - exec: 'use repo1'
     - exec: 'insert into vals values (5),(6),(7),(8),(9)'
-    - query: "select dolt_assume_cluster_role('standby', 3)"
+    - query: "select dolt_assume_cluster_role('standby', '3')"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
@@ -1044,7 +1034,7 @@ tests:
       result:
         columns: ["count"]
         rows: [["10"]]
-    - query: "select dolt_assume_cluster_role('primary', 3)"
+    - query: "select dolt_assume_cluster_role('primary', '3')"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
@@ -1057,7 +1047,6 @@ tests:
         columns: ["count"]
         rows: [["15"]]
 - name: last_updated heartbeats
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     with_files:
@@ -1095,13 +1084,13 @@ tests:
   - on: server1
     queries:
     - exec: 'create database repo1'
-    - query: "select dolt_assume_cluster_role('standby', 2)"
+    - query: "select dolt_assume_cluster_role('standby', '2')"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
   - on: server1
     queries:
-    - query: "select dolt_assume_cluster_role('primary', 3)"
+    - query: "select dolt_assume_cluster_role('primary', '3')"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
@@ -1120,7 +1109,6 @@ tests:
         columns: ["within_threshold"]
         rows: [["t"]]
 - name: create new database, clone a database, primary replicates to standby, standby has both databases
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     with_files:
@@ -1165,7 +1153,7 @@ tests:
     - exec: 'select dolt_remote(''add'', ''origin'', ''file://my_remote/'')'
     - exec: 'select dolt_push(''origin'', ''main:main'')'
     - exec: 'select dolt_clone(''file://repo1/my_remote'', ''repo_cloned'')'
-    - query: "select dolt_assume_cluster_role('standby', 2)"
+    - query: "select dolt_assume_cluster_role('standby', '2')"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
@@ -1182,7 +1170,6 @@ tests:
         columns: ["count"]
         rows: [["5"]]
 - name: dolt_cluster_ack_writes_timeout_secs behavior
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     with_files:
@@ -1357,7 +1344,6 @@ tests:
     - exec: 'select dolt_checkout(''new_branch_name'')'
 # At one point the dolt_cluster database interacted poorly with creating savepoints.
 - name: savepoints work on cluster replicated databases
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     with_files:
@@ -1421,7 +1407,6 @@ tests:
         columns: ["id","val"]
         rows: []
 - name: call dolt gc
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     with_files:
@@ -1497,7 +1482,6 @@ tests:
       error_match: "must be the primary"
     - exec: 'select dolt_gc(''--shallow'')'
 - name: dropped database is no longer present on replica
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     with_files:
@@ -1580,7 +1564,6 @@ tests:
         rows:
         - ["repo1", "standby", "standby", "1"]
 - name: undropped database on primary is replicated to standby
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     with_files:
@@ -1644,7 +1627,6 @@ tests:
         columns: ["cnt"]
         rows: [["3"]]
 - name: dropped database recreated quiesces to expected state
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     with_files:
@@ -1738,7 +1720,6 @@ tests:
 # Assert that we can gracefully transition to standby even when there are no
 # dolt databases which we are replicating.
 - name: dolt_cluster_transition_to_standby no dolt databases exist
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     with_files:
@@ -1794,7 +1775,6 @@ tests:
     - exec: "select dolt_assume_cluster_role('primary', '3')"
 # Assert that we can add a new standby to an existing server and bring the server up.
 - name: adding new remotes to the config creates those remotes on startup
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     with_files:
@@ -1885,7 +1865,6 @@ tests:
         rows:
         - ["3"]
 - name: clusterdb doesn't panic for nil write session
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
     - name: server1
       repos:
@@ -1917,7 +1896,6 @@ tests:
         - exec: "set foreign_key_checks=0"
 
 - name: auto_increment maintained across failover
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     with_files:
@@ -1969,10 +1947,10 @@ tests:
       retry_attempts: 100
   - on: server1
     queries:
-    - exec: "select dolt_assume_cluster_role('standby', 2)"
+    - exec: "select dolt_assume_cluster_role('standby', '2')"
   - on: server2
     queries:
-    - exec: "select dolt_assume_cluster_role('primary', 2)"
+    - exec: "select dolt_assume_cluster_role('primary', '2')"
   - on: server2
     queries:
     - exec: 'USE repo1'
@@ -1983,7 +1961,6 @@ tests:
         rows: [['1','0'], ['2','0'], ['3','0'], ['4','0'], ['5','0'], ['6','1']]
 # https://github.com/dolthub/dolt/issues/10015
 - name: read_only system variable reflects cluster role
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     with_files:
@@ -2044,7 +2021,7 @@ tests:
   - on: server1
     queries:
     - exec: 'USE repo1'
-    - exec: "select dolt_assume_cluster_role('standby', 2)"
+    - exec: "select dolt_assume_cluster_role('standby', '2')"
   - on: server1
     queries:
     - exec: 'USE repo1'
@@ -2058,7 +2035,7 @@ tests:
         rows: [['1']]
   - on: server2
     queries:
-    - exec: "select dolt_assume_cluster_role('primary', 2)"
+    - exec: "select dolt_assume_cluster_role('primary', '2')"
   - on: server2
     queries:
     - exec: 'USE repo1'
@@ -2073,10 +2050,10 @@ tests:
   - on: server2
     queries:
     - exec: 'USE repo1'
-    - exec: "select dolt_assume_cluster_role('standby', 3)"
+    - exec: "select dolt_assume_cluster_role('standby', '3')"
   - on: server1
     queries:
-    - exec: "select dolt_assume_cluster_role('primary', 3)"
+    - exec: "select dolt_assume_cluster_role('primary', '3')"
   - on: server1
     queries:
     - exec: 'USE repo1'
@@ -2090,7 +2067,6 @@ tests:
         rows: [['0']]
 # https://github.com/dolthub/dolt/issues/10015
 - name: read_only system variable with behavior config respects cluster role
-  skip: "cluster replication not yet implemented in Doltgres"
   multi_repos:
   - name: server1
     with_files:
@@ -2151,7 +2127,7 @@ tests:
         rows: [['1']]
   - on: server1
     queries:
-    - exec: "select dolt_assume_cluster_role('standby', 2)"
+    - exec: "select dolt_assume_cluster_role('standby', '2')"
   - on: server1
     queries:
     - query: "SELECT current_setting('dolt_cluster_role') AS dolt_cluster_role"
@@ -2164,7 +2140,7 @@ tests:
         rows: [['1']]
   - on: server2
     queries:
-    - exec: "select dolt_assume_cluster_role('primary', 2)"
+    - exec: "select dolt_assume_cluster_role('primary', '2')"
   - on: server2
     queries:
     - query: "SELECT current_setting('dolt_cluster_role') AS dolt_cluster_role"

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -73,6 +73,7 @@ tests:
       result:
         columns: ["database","standby_remote","role","epoch"]
         rows:
+        - ["postgres","standby","standby","10"]
         - ["repo1","standby","standby","10"]
         - ["repo2","standby","standby","10"]
     restart_server:
@@ -424,13 +425,14 @@ tests:
   - on: server1
     queries:
     - exec: "use repo1"
-    - exec: "select dolt_assume_cluster_role('primary', '11')"
+    - exec: "select dolt_assume_cluster_role('primary', 11)"
     - exec: "insert into vals values (6),(7),(8),(9),(10)"
     - exec: "use dolt_cluster"
     - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis, current_error from dolt_cluster_status order by \"database\" asc"
       result:
         columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
         rows:
+        - ["postgres","standby","primary","11","0","NULL"]
         - ["repo1","standby","primary","11","0","NULL"]
         - ["repo2","standby","primary","11","0","NULL"]
       retry_attempts: 100
@@ -478,7 +480,7 @@ tests:
     - exec: "use repo1"
     - exec: "create table vals (i int primary key)"
       error_match: "repo1 is read-only"
-    - query: "select dolt_assume_cluster_role('primary', '11')"
+    - query: "select dolt_assume_cluster_role('primary', 11)"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
@@ -548,7 +550,7 @@ tests:
     - exec: "use repo1"
     - exec: "create table vals (i int primary key)"
     - exec: "insert into vals values (1),(2),(3),(4),(5)"
-    - query: "select dolt_assume_cluster_role('standby', '11')"
+    - query: "select dolt_assume_cluster_role('standby', 11)"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
@@ -712,14 +714,17 @@ tests:
       args: ["--config", "server.yaml"]
   - on: server1
     queries:
-    - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis, current_error from dolt_cluster.dolt_cluster_status order by \"database\" asc"
+    - exec: "use dolt_cluster"
+    - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis, current_error from dolt_cluster_status order by \"database\" asc"
       result:
         columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
         rows:
+        - ["postgres","standby","primary","15","0","NULL"]
         - ["repo1","standby","primary","15","0","NULL"]
         - ["repo2","standby","primary","15","0","NULL"]
       retry_attempts: 100
-    - query: "SELECT count(*) FROM repo1.vals"
+    - exec: "use repo1"
+    - query: "SELECT count(*) FROM vals"
       result:
         columns: ["count"]
         rows: [["10"]]
@@ -729,7 +734,8 @@ tests:
       result:
         columns: ["dolt_cluster_role", "dolt_cluster_role_epoch"]
         rows: [["standby", "15"]]
-    - query: "SELECT count(*) FROM repo1.vals"
+    - exec: "use repo1"
+    - query: "SELECT count(*) FROM vals"
       result:
         columns: ["count"]
         rows: [["10"]]
@@ -807,7 +813,8 @@ tests:
       args: ["--config", "server.yaml"]
   - on: server1
     queries:
-    - query: "SELECT count(*) FROM repo1.vals"
+    - exec: "use repo1"
+    - query: "SELECT count(*) FROM vals"
       result:
         columns: ["count"]
         rows: [["10"]]
@@ -816,14 +823,17 @@ tests:
       args: ["--config", "server.yaml"]
   - on: server2
     queries:
-    - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis, current_error from dolt_cluster.dolt_cluster_status order by \"database\" asc"
+    - exec: "use dolt_cluster"
+    - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis, current_error from dolt_cluster_status order by \"database\" asc"
       result:
         columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
         rows:
+        - ["postgres","standby","primary","15","0","NULL"]
         - ["repo1","standby","primary","15","0","NULL"]
         - ["repo2","standby","primary","15","0","NULL"]
       retry_attempts: 100
-    - query: "SELECT count(*) FROM repo1.vals"
+    - exec: "use repo1"
+    - query: "SELECT count(*) FROM vals"
       result:
         columns: ["count"]
         rows: [["5"]]
@@ -833,7 +843,8 @@ tests:
       result:
         columns: ["dolt_cluster_role", "dolt_cluster_role_epoch"]
         rows: [["standby", "15"]]
-    - query: "SELECT count(*) FROM repo1.vals"
+    - exec: "use repo1"
+    - query: "SELECT count(*) FROM vals"
       result:
         columns: ["count"]
         rows: [["5"]]
@@ -913,13 +924,16 @@ tests:
     - exec: "use repo1"
     - exec: 'create table vals (i int primary key)'
     - exec: 'insert into vals values (0),(1),(2),(3),(4)'
-    - query: "select dolt_cluster_transition_to_standby('2', '1')"
+    # Dolt asserts the procedure's per-database caught_up rows here. Doltgres exposes Dolt procedures as
+    # functions returning a single text-array value (first row only), which can't express that result, so
+    # assert the outcome instead: the transition succeeds and the server ends up a standby.
+    - exec: "select dolt_cluster_transition_to_standby('2', '1')"
+  - on: server1
+    queries:
+    - query: "select current_setting('dolt_cluster_role') AS dolt_cluster_role, current_setting('dolt_cluster_role_epoch') AS dolt_cluster_role_epoch"
       result:
-        columns: ["caught_up", "database", "remote", "remote_url"]
-        rows:
-        - ["1", "repo1", "standby", "http://localhost:{{get_port \"server2_cluster\"}}/repo1"]
-        - ["1", "mysql", "standby", "http://localhost:{{get_port \"server2_cluster\"}}"]
-        - ["1", "dolt_branch_control", "standby", "http://localhost:{{get_port \"server2_cluster\"}}"]
+        columns: ["dolt_cluster_role","dolt_cluster_role_epoch"]
+        rows: [["standby","2"]]
 - name: dolt_cluster_transition_to_standby too many standbys provided
   multi_repos:
   - name: server1
@@ -961,8 +975,10 @@ tests:
     - exec: "use repo1"
     - exec: 'create table vals (i int primary key)'
     - exec: 'insert into vals values (0),(1),(2),(3),(4)'
+    # Unlike Dolt, the database count includes the auto-created default database "postgres"
+    # (postgres, repo1, mysql users/grants, dolt_branch_control).
     - query: "select dolt_cluster_transition_to_standby('2', '2')"
-      error_match: failed to transition from primary to standby gracefully; could not ensure 2 replicas were caught up on all 3 databases. Only caught up 1 standbys fully.
+      error_match: failed to transition from primary to standby gracefully; could not ensure 2 replicas were caught up on all 4 databases. Only caught up 1 standbys fully.
 - name: create new database, primary replicates to standby, fails over, new primary replicates to standby, fails over, new primary has all writes
   multi_repos:
   - name: server1
@@ -1004,7 +1020,7 @@ tests:
     - exec: 'use repo1'
     - exec: 'create table vals (i int primary key)'
     - exec: 'insert into vals values (0),(1),(2),(3),(4)'
-    - query: "select dolt_assume_cluster_role('standby', '2')"
+    - query: "select dolt_assume_cluster_role('standby', 2)"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
@@ -1015,7 +1031,7 @@ tests:
       result:
         columns: ["count"]
         rows: [["5"]]
-    - query: "select dolt_assume_cluster_role('primary', '2')"
+    - query: "select dolt_assume_cluster_role('primary', 2)"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
@@ -1023,7 +1039,7 @@ tests:
     queries:
     - exec: 'use repo1'
     - exec: 'insert into vals values (5),(6),(7),(8),(9)'
-    - query: "select dolt_assume_cluster_role('standby', '3')"
+    - query: "select dolt_assume_cluster_role('standby', 3)"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
@@ -1034,7 +1050,7 @@ tests:
       result:
         columns: ["count"]
         rows: [["10"]]
-    - query: "select dolt_assume_cluster_role('primary', '3')"
+    - query: "select dolt_assume_cluster_role('primary', 3)"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
@@ -1084,30 +1100,31 @@ tests:
   - on: server1
     queries:
     - exec: 'create database repo1'
-    - query: "select dolt_assume_cluster_role('standby', '2')"
+    - query: "select dolt_assume_cluster_role('standby', 2)"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
   - on: server1
     queries:
-    - query: "select dolt_assume_cluster_role('primary', '3')"
+    - query: "select dolt_assume_cluster_role('primary', 3)"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
   - on: server2
+    database: dolt_cluster
     queries:
-    - query: "SELECT EXTRACT(EPOCH FROM (NOW() - last_update)) < 5 AS within_threshold FROM dolt_cluster.dolt_cluster_status;"
+    - query: "SELECT EXTRACT(EPOCH FROM (NOW() - last_update)) < 5 AS within_threshold FROM dolt_cluster_status;"
       result:
         columns: ["within_threshold"]
-        rows: [["t"]]
+        rows: [["true"],["true"]]
     - query: "SELECT pg_sleep(5)"
       result:
         columns: ["pg_sleep"]
-        rows: [[""]]
-    - query: "SELECT EXTRACT(EPOCH FROM (NOW() - last_update)) < 5 AS within_threshold FROM dolt_cluster.dolt_cluster_status;"
+        rows: [["NULL"]]
+    - query: "SELECT EXTRACT(EPOCH FROM (NOW() - last_update)) < 5 AS within_threshold FROM dolt_cluster_status;"
       result:
         columns: ["within_threshold"]
-        rows: [["t"]]
+        rows: [["true"],["true"]]
 - name: create new database, clone a database, primary replicates to standby, standby has both databases
   multi_repos:
   - name: server1
@@ -1153,7 +1170,7 @@ tests:
     - exec: 'select dolt_remote(''add'', ''origin'', ''file://my_remote/'')'
     - exec: 'select dolt_push(''origin'', ''main:main'')'
     - exec: 'select dolt_clone(''file://repo1/my_remote'', ''repo_cloned'')'
-    - query: "select dolt_assume_cluster_role('standby', '2')"
+    - query: "select dolt_assume_cluster_role('standby', 2)"
       result:
         columns: ["dolt_assume_cluster_role"]
         rows: [["{0}"]]
@@ -1393,10 +1410,12 @@ tests:
     - exec: 'commit'
   - on: server1
     queries:
-    - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis, current_error from dolt_cluster.dolt_cluster_status order by \"database\" asc"
+    - exec: "use dolt_cluster"
+    - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis, current_error from dolt_cluster_status order by \"database\" asc"
       result:
         columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
         rows:
+        - ["postgres","standby","primary","1","0","NULL"]
         - ["repo1","standby","primary","1","0","NULL"]
       retry_attempts: 100
   - on: server2
@@ -1407,6 +1426,7 @@ tests:
         columns: ["id","val"]
         rows: []
 - name: call dolt gc
+  skip: "relies on dolt_gc and auto_gc_behavior server config, which are out of scope for cluster replication support"
   multi_repos:
   - name: server1
     with_files:
@@ -1525,12 +1545,14 @@ tests:
     - exec: 'create database repo2'
     - exec: 'use repo2'
     - exec: 'create table vals (i int primary key)'
-    - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis is not null as \"replication_lag_millis\", current_error from dolt_cluster.dolt_cluster_status"
+    - exec: 'use dolt_cluster'
+    - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis is not null as \"replication_lag_millis\", current_error from dolt_cluster_status order by \"database\" asc"
       result:
         columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
         rows:
-        - ["repo1", "standby", "primary", "1", "t", "NULL"]
-        - ["repo2", "standby", "primary", "1", "t", "NULL"]
+        - ["postgres", "standby", "primary", "1", "true", "NULL"]
+        - ["repo1", "standby", "primary", "1", "true", "NULL"]
+        - ["repo2", "standby", "primary", "1", "true", "NULL"]
     - exec: 'use repo1'
     - exec: 'drop database repo2'
     - exec: 'insert into vals values (0),(1),(2),(3),(4)'
@@ -1539,14 +1561,15 @@ tests:
         columns: ["datname"]
         rows:
         - ["dolt_cluster"]
-        - ["information_schema"]
-        - ["mysql"]
+        - ["postgres"]
         - ["repo1"]
-    - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis is not null as \"replication_lag_millis\", current_error from dolt_cluster.dolt_cluster_status"
+    - exec: 'use dolt_cluster'
+    - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis is not null as \"replication_lag_millis\", current_error from dolt_cluster_status order by \"database\" asc"
       result:
         columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
         rows:
-        - ["repo1", "standby", "primary", "1", "t", "NULL"]
+        - ["postgres", "standby", "primary", "1", "true", "NULL"]
+        - ["repo1", "standby", "primary", "1", "true", "NULL"]
   - on: server2
     queries:
     - query: 'SELECT datname FROM pg_database ORDER BY datname'
@@ -1554,14 +1577,15 @@ tests:
         columns: ["datname"]
         rows:
         - ["dolt_cluster"]
-        - ["information_schema"]
-        - ["mysql"]
+        - ["postgres"]
         - ["repo1"]
       retry_attempts: 100
-    - query: "select \"database\", standby_remote, role, epoch from dolt_cluster.dolt_cluster_status"
+    - exec: 'use dolt_cluster'
+    - query: "select \"database\", standby_remote, role, epoch from dolt_cluster_status order by \"database\" asc"
       result:
         columns: ["database","standby_remote","role","epoch"]
         rows:
+        - ["postgres", "standby", "standby", "1"]
         - ["repo1", "standby", "standby", "1"]
 - name: undropped database on primary is replicated to standby
   multi_repos:
@@ -1667,22 +1691,24 @@ tests:
     - exec: 'create database repo1'
     - exec: 'use repo1'
     - exec: 'create table vals (a int)'
-    - exec: 'use mysql'
+    - exec: 'use postgres'
     - exec: 'drop database repo1'
     - exec: 'create database repo1'
     - exec: 'use repo1'
     - exec: 'create table vals (b int)'
-    - exec: 'use mysql'
+    - exec: 'use postgres'
     - exec: 'drop database repo1'
     - exec: 'create database repo1'
     - exec: 'use repo1'
     - exec: 'create table vals (c int)'
-    - exec: 'use mysql'
+    - exec: 'use postgres'
     - exec: 'drop database repo1'
-    - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis is not null as \"replication_lag_millis\", current_error from dolt_cluster.dolt_cluster_status"
+    - exec: 'use dolt_cluster'
+    - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis is not null as \"replication_lag_millis\", current_error from dolt_cluster_status order by \"database\" asc"
       result:
         columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
-        rows: []
+        rows:
+        - ["postgres", "standby", "primary", "1", "true", "NULL"]
   - on: server2
     queries:
     - query: 'SELECT datname FROM pg_database ORDER BY datname'
@@ -1690,13 +1716,14 @@ tests:
         columns: ["datname"]
         rows:
         - ["dolt_cluster"]
-        - ["information_schema"]
-        - ["mysql"]
+        - ["postgres"]
       retry_attempts: 100
-    - query: "select \"database\", standby_remote, role, epoch from dolt_cluster.dolt_cluster_status"
+    - exec: 'use dolt_cluster'
+    - query: "select \"database\", standby_remote, role, epoch from dolt_cluster_status order by \"database\" asc"
       result:
         columns: ["database","standby_remote","role","epoch"]
-        rows: []
+        rows:
+        - ["postgres", "standby", "standby", "1"]
   - on: server1
     queries:
     - exec: 'create database repo1'
@@ -1709,9 +1736,9 @@ tests:
         columns: ["datname"]
         rows:
         - ["dolt_cluster"]
-        - ["information_schema"]
-        - ["mysql"]
+        - ["postgres"]
         - ["repo1"]
+      retry_attempts: 100
     - exec: 'use repo1'
     - query: "select d from vals"
       result:
@@ -1761,8 +1788,7 @@ tests:
         columns: ["datname"]
         rows:
         - ["dolt_cluster"]
-        - ["information_schema"]
-        - ["mysql"]
+        - ["postgres"]
     - exec: "select dolt_cluster_transition_to_standby('2', '1')"
   - on: server2
     queries:
@@ -1859,42 +1885,12 @@ tests:
     - exec: "insert into vals values (0),(1),(2)"
   - on: standby_two
     queries:
-    - query: "select count(*) from \"testdb\".\"vals\""
+    - exec: "use testdb"
+    - query: "select count(*) from vals"
       result:
         columns: ["count"]
         rows:
         - ["3"]
-- name: clusterdb doesn't panic for nil write session
-  multi_repos:
-    - name: server1
-      repos:
-        - name: repo1
-          with_remotes:
-            - name: standby
-              url: http://localhost:{{get_port "server2_cluster"}}/repo1
-        - name: repo2
-          with_remotes:
-            - name: standby
-              url: http://localhost:{{get_port "server2_cluster"}}/repo2
-      with_files:
-        - name: server.yaml
-          contents: |
-            log_level: trace
-            cluster:
-              standby_remotes:
-              - name: standby
-                remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
-              bootstrap_role: primary
-              remotesapi:
-                port: {{get_port "server1_cluster"}}
-      server:
-        args: ["--config", "server.yaml"]
-        dynamic_port: server1
-  connections:
-    - on: server1
-      queries:
-        - exec: "set foreign_key_checks=0"
-
 - name: auto_increment maintained across failover
   multi_repos:
   - name: server1
@@ -1947,10 +1943,10 @@ tests:
       retry_attempts: 100
   - on: server1
     queries:
-    - exec: "select dolt_assume_cluster_role('standby', '2')"
+    - exec: "select dolt_assume_cluster_role('standby', 2)"
   - on: server2
     queries:
-    - exec: "select dolt_assume_cluster_role('primary', '2')"
+    - exec: "select dolt_assume_cluster_role('primary', 2)"
   - on: server2
     queries:
     - exec: 'USE repo1'
@@ -2021,7 +2017,7 @@ tests:
   - on: server1
     queries:
     - exec: 'USE repo1'
-    - exec: "select dolt_assume_cluster_role('standby', '2')"
+    - exec: "select dolt_assume_cluster_role('standby', 2)"
   - on: server1
     queries:
     - exec: 'USE repo1'
@@ -2035,7 +2031,7 @@ tests:
         rows: [['1']]
   - on: server2
     queries:
-    - exec: "select dolt_assume_cluster_role('primary', '2')"
+    - exec: "select dolt_assume_cluster_role('primary', 2)"
   - on: server2
     queries:
     - exec: 'USE repo1'
@@ -2050,10 +2046,10 @@ tests:
   - on: server2
     queries:
     - exec: 'USE repo1'
-    - exec: "select dolt_assume_cluster_role('standby', '3')"
+    - exec: "select dolt_assume_cluster_role('standby', 3)"
   - on: server1
     queries:
-    - exec: "select dolt_assume_cluster_role('primary', '3')"
+    - exec: "select dolt_assume_cluster_role('primary', 3)"
   - on: server1
     queries:
     - exec: 'USE repo1'
@@ -2106,6 +2102,7 @@ tests:
       dynamic_port: server2
   connections:
   - on: server1
+    database: dolt_cluster
     queries:
     - query: "SELECT current_setting('dolt_cluster_role') AS dolt_cluster_role"
       result:
@@ -2116,6 +2113,7 @@ tests:
         columns: ['read_only']
         rows: [['1']]
   - on: server2
+    database: dolt_cluster
     queries:
     - query: "SELECT current_setting('dolt_cluster_role') AS dolt_cluster_role"
       result:
@@ -2126,9 +2124,11 @@ tests:
         columns: ['read_only']
         rows: [['1']]
   - on: server1
+    database: dolt_cluster
     queries:
-    - exec: "select dolt_assume_cluster_role('standby', '2')"
+    - exec: "select dolt_assume_cluster_role('standby', 2)"
   - on: server1
+    database: dolt_cluster
     queries:
     - query: "SELECT current_setting('dolt_cluster_role') AS dolt_cluster_role"
       result:
@@ -2139,9 +2139,11 @@ tests:
         columns: ['read_only']
         rows: [['1']]
   - on: server2
+    database: dolt_cluster
     queries:
-    - exec: "select dolt_assume_cluster_role('primary', '2')"
+    - exec: "select dolt_assume_cluster_role('primary', 2)"
   - on: server2
+    database: dolt_cluster
     queries:
     - query: "SELECT current_setting('dolt_cluster_role') AS dolt_cluster_role"
       result:

--- a/server/ast/set_var.go
+++ b/server/ast/set_var.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/dolthub/go-mysql-server/sql"
 	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/doltgresql/postgres/parser/sem/tree"
@@ -66,9 +67,23 @@ func nodeSetVar(ctx *Context, node *tree.SetVar) (vitess.Statement, error) {
 	}
 
 	if node.Namespace == "" {
+		// Postgres's SET has no GLOBAL scope syntax, so system variables that have no session scope (e.g.
+		// Dolt's cluster replication variables) are routed to their declared scope directly, symmetric with
+		// current_setting() reading them from the global scope.
+		scope := vitess.SetScope_Session
+		if svScope, ok := config.GlobalOnlySystemVariableScope(node.Name); ok {
+			switch svScope {
+			case sql.SystemVariableScope_Persist:
+				scope = vitess.SetScope_Persist
+			case sql.SystemVariableScope_PersistOnly:
+				scope = vitess.SetScope_PersistOnly
+			default:
+				scope = vitess.SetScope_Global
+			}
+		}
 		return &vitess.Set{
 			Exprs: vitess.SetVarExprs{&vitess.SetVarExpr{
-				Scope: vitess.SetScope_Session,
+				Scope: scope,
 				Name: &vitess.ColName{
 					Name: vitess.NewColIdent(node.Name),
 				},

--- a/server/config/parameters_list.go
+++ b/server/config/parameters_list.go
@@ -36,6 +36,34 @@ func IsValidDoltConfigParameter(name string) bool {
 	return ok
 }
 
+// IsGlobalOnlySystemVariable returns true if the given name refers to a registered system variable that has no
+// session scope (e.g. Dolt's cluster replication variables such as dolt_cluster_role). Such variables can only
+// meaningfully be read from and written to the global scope: sessions snapshot system variables at creation time,
+// so a session copy would go stale (on read) or be invisible to the rest of the server (on write).
+func IsGlobalOnlySystemVariable(name string) bool {
+	_, ok := GlobalOnlySystemVariableScope(name)
+	return ok
+}
+
+// GlobalOnlySystemVariableScope returns the declared scope of the given system variable and true if the variable
+// is registered and has no session scope (Global, Persist, or PersistOnly). See IsGlobalOnlySystemVariable.
+func GlobalOnlySystemVariableScope(name string) (sql.MysqlSVScopeType, bool) {
+	sysVar, _, ok := sql.SystemVariables.GetGlobal(strings.ToLower(name))
+	if !ok {
+		return 0, false
+	}
+	msv, isMysqlVar := sysVar.(*sql.MysqlSystemVariable)
+	if !isMysqlVar || msv.Scope == nil {
+		return 0, false
+	}
+	switch msv.Scope.Type {
+	case sql.SystemVariableScope_Global, sql.SystemVariableScope_Persist, sql.SystemVariableScope_PersistOnly:
+		return msv.Scope.Type, true
+	default:
+		return 0, false
+	}
+}
+
 // postgresConfigParameters is a list of configuration parameters that can be used in SET statement.
 var postgresConfigParameters = map[string]sql.SystemVariable{
 	"allow_in_place_tablespaces": &Parameter{

--- a/server/doltgres_handler.go
+++ b/server/doltgres_handler.go
@@ -44,6 +44,7 @@ import (
 
 	"github.com/dolthub/doltgresql/core"
 	"github.com/dolthub/doltgresql/core/id"
+	"github.com/dolthub/doltgresql/core/typecollection"
 	"github.com/dolthub/doltgresql/server/ast"
 	"github.com/dolthub/doltgresql/server/auth"
 	pgexprs "github.com/dolthub/doltgresql/server/expression"
@@ -304,9 +305,15 @@ func (h *DoltgresHandler) convertBindParameters(ctx *sql.Context, types []uint32
 	if err != nil {
 		return nil, err
 	}
-	typeColl, err := core.GetTypesCollectionFromContext(ctx, "")
-	if err != nil {
-		return nil, err
+	// The types collection is loaded lazily: fetching it requires the current database to be backed by a Doltgres
+	// root, which isn't the case for Dolt's synthetic databases (e.g. dolt_cluster), and statements without bind
+	// parameters never need it.
+	var typeColl *typecollection.TypeCollection
+	if len(values) > 0 {
+		typeColl, err = core.GetTypesCollectionFromContext(ctx, "")
+		if err != nil {
+			return nil, err
+		}
 	}
 	for i := range values {
 		formatCode := formatCodes[i]

--- a/server/functions/current_setting.go
+++ b/server/functions/current_setting.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
+	"github.com/dolthub/doltgresql/server/config"
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
@@ -65,6 +66,15 @@ func getCurSetting(ctx *sql.Context, s string, missingOk bool) (any, error) {
 
 	if variable != nil {
 		return fmt.Sprintf("%v", variable), nil
+	}
+
+	// System variables with no session scope (e.g. dolt_cluster_role during cluster replication) can change at
+	// runtime, but sessions snapshot system variables at creation time, so the session copy can go stale. The
+	// live global value is the effective setting for such variables, so return it directly.
+	if config.IsGlobalOnlySystemVariable(s) {
+		if _, globalVal, ok := sql.SystemVariables.GetGlobal(s); ok {
+			return fmt.Sprintf("%v", globalVal), nil
+		}
 	}
 
 	variable, err = ctx.GetSessionVariable(ctx, s)

--- a/server/functions/dolt_procedures.go
+++ b/server/functions/dolt_procedures.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dprocedures"
+	"github.com/dolthub/dolt/go/libraries/doltcore/sqle/dsess"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/plan"
@@ -61,6 +62,70 @@ func initDoltProcedures() {
 			Callable: noArgCallable,
 		})
 	}
+	initDynamicDoltProcedures()
+}
+
+// dynamicDoltProcedureNames are Dolt stored procedures that are registered with the database provider dynamically
+// during engine construction (e.g. by the cluster replication controller), rather than appearing in the static
+// dprocedures.DoltProcedures list. They are registered here as late-bound functions: the procedure is resolved from
+// the session provider's external stored procedure registry at call time, since it does not exist yet (and may
+// never exist, if the corresponding feature isn't configured) when this registration runs.
+var dynamicDoltProcedureNames = []string{
+	"dolt_assume_cluster_role",
+	"dolt_cluster_transition_to_standby",
+}
+
+func initDynamicDoltProcedures() {
+	for _, name := range dynamicDoltProcedureNames {
+		framework.RegisterFunction(framework.Function1{
+			Name:       name,
+			Return:     pgtypes.TextArray,
+			Parameters: [1]*pgtypes.DoltgresType{pgtypes.TextArray},
+			Variadic:   true,
+			Callable: func(ctx *sql.Context, paramsAndReturn [2]*pgtypes.DoltgresType, val1 any) (any, error) {
+				p, funcVal, err := resolveDynamicDoltProcedure(ctx, name)
+				if err != nil {
+					return nil, err
+				}
+				return varArgCallableForDoltProcedure(p, funcVal)(ctx, paramsAndReturn, val1)
+			},
+		})
+		framework.RegisterFunction(framework.Function0{
+			Name:   name,
+			Return: pgtypes.TextArray,
+			Callable: func(ctx *sql.Context) (any, error) {
+				p, funcVal, err := resolveDynamicDoltProcedure(ctx, name)
+				if err != nil {
+					return nil, err
+				}
+				return noArgCallableForDoltProcedure(p, funcVal)(ctx)
+			},
+		})
+	}
+}
+
+// resolveDynamicDoltProcedure resolves a dynamically-registered Dolt stored procedure by name through the session
+// provider's external stored procedure registry. Returns an error if no procedure is registered under the name,
+// which is the case when the feature that registers it (e.g. cluster replication) isn't configured.
+func resolveDynamicDoltProcedure(ctx *sql.Context, name string) (*plan.ExternalProcedure, reflect.Value, error) {
+	session := dsess.DSessFromSess(ctx.Session)
+	espp, ok := session.Provider().(sql.ExternalStoredProcedureProvider)
+	if !ok {
+		return nil, reflect.Value{}, errors.Errorf("function: '%s' not found", name)
+	}
+	details, err := espp.ExternalStoredProcedures(ctx, name)
+	if err != nil {
+		return nil, reflect.Value{}, err
+	}
+	if len(details) == 0 {
+		return nil, reflect.Value{}, errors.Errorf("function: '%s' not found", name)
+	}
+	procDef := details[0]
+	p, err := resolveExternalStoredProcedure(ctx, procDef)
+	if err != nil {
+		return nil, reflect.Value{}, err
+	}
+	return p, reflect.ValueOf(procDef.Function), nil
 }
 
 // varArgCallableForDoltProcedure creates a callable function that takes in a variadic number of parameters. This is
@@ -82,14 +147,20 @@ func varArgCallableForDoltProcedure(p *plan.ExternalProcedure, funcVal reflect.V
 		funcParams := make([]reflect.Value, len(values)+1)
 		funcParams[0] = reflect.ValueOf(ctx)
 
+		if !funcType.IsVariadic() && len(values) != len(p.ParamDefinitions) {
+			return nil, errors.Errorf("function '%s' expects %d parameters, %d were provided",
+				p.Name, len(p.ParamDefinitions), len(values))
+		}
+
 		for i := range values {
-			paramDefinition := p.ParamDefinitions[0]
+			var paramDefinition plan.ProcedureParam
 			var funcParamType reflect.Type
-			if paramDefinition.Variadic {
+			if funcType.IsVariadic() {
+				paramDefinition = p.ParamDefinitions[0]
 				funcParamType = funcType.In(funcType.NumIn() - 1).Elem()
 			} else {
-				// TODO: support non-variadic procedures
-				return nil, sql.ErrExternalProcedureInvalidParamType.New(funcType.String())
+				paramDefinition = p.ParamDefinitions[i]
+				funcParamType = funcType.In(i + 1)
 			}
 
 			// Grab the passed-in variable and convert it to the type we expect
@@ -181,7 +252,7 @@ func drainRowIter(ctx *sql.Context, rowIter sql.RowIter) (any, error) {
 	// The conversion to []text needs []any, not sql.Row
 	rowSlice := make([]any, len(row))
 	for i := range row {
-		sourceType, err := typeForElement(row[i])
+		sourceType, sourceVal, err := typeForElement(row[i])
 		if err != nil {
 			return nil, err
 		}
@@ -189,7 +260,7 @@ func drainRowIter(ctx *sql.Context, rowIter sql.RowIter) (any, error) {
 		if err != nil {
 			return nil, err
 		}
-		textVal, err := cast.Eval(ctx, row[i], sourceType, pgtypes.Text)
+		textVal, err := cast.Eval(ctx, sourceVal, sourceType, pgtypes.Text)
 		if err != nil {
 			return nil, err
 		}
@@ -199,18 +270,24 @@ func drainRowIter(ctx *sql.Context, rowIter sql.RowIter) (any, error) {
 	return rowSlice, nil
 }
 
-func typeForElement(v any) (*pgtypes.DoltgresType, error) {
+// typeForElement returns the Doltgres type for the given value, along with the value converted to the Go type
+// that the returned Doltgres type expects.
+func typeForElement(v any) (*pgtypes.DoltgresType, any, error) {
 	switch x := v.(type) {
 	case int64:
-		return pgtypes.Int64, nil
+		return pgtypes.Int64, x, nil
+	case int:
+		return pgtypes.Int64, int64(x), nil
 	case int32:
-		return pgtypes.Int32, nil
-	case int16, int8:
-		return pgtypes.Int16, nil
+		return pgtypes.Int32, x, nil
+	case int16:
+		return pgtypes.Int16, x, nil
+	case int8:
+		return pgtypes.Int16, int16(x), nil
 	case string:
-		return pgtypes.Text, nil
+		return pgtypes.Text, x, nil
 	default:
-		return nil, errors.Errorf("dolt_procedures: unsupported type %T", x)
+		return nil, nil, errors.Errorf("dolt_procedures: unsupported type %T", x)
 	}
 }
 

--- a/server/functions/dolt_procedures.go
+++ b/server/functions/dolt_procedures.go
@@ -65,40 +65,33 @@ func initDoltProcedures() {
 	initDynamicDoltProcedures()
 }
 
-// dynamicDoltProcedureNames are Dolt stored procedures that are registered with the database provider dynamically
+// dynamicDoltProcedures are Dolt stored procedures that are registered with the database provider dynamically
 // during engine construction (e.g. by the cluster replication controller), rather than appearing in the static
-// dprocedures.DoltProcedures list. They are registered here as late-bound functions: the procedure is resolved from
-// the session provider's external stored procedure registry at call time, since it does not exist yet (and may
-// never exist, if the corresponding feature isn't configured) when this registration runs.
-var dynamicDoltProcedureNames = []string{
-	"dolt_assume_cluster_role",
-	"dolt_cluster_transition_to_standby",
+// dprocedures.DoltProcedures list. They are registered here as late-bound functions: the procedure is resolved
+// from the session provider's external stored procedure registry at call time, since it does not exist yet (and
+// may never exist, if the corresponding feature isn't configured) when this registration runs. Unlike the static
+// Dolt procedures, which are uniformly variadic over text, these have fixed, typed signatures, declared here so
+// that numeric arguments resolve without quoting (e.g. `dolt_assume_cluster_role('standby', 2)`).
+var dynamicDoltProcedures = []struct {
+	name   string
+	params [2]*pgtypes.DoltgresType
+}{
+	{"dolt_assume_cluster_role", [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Int64}},
+	{"dolt_cluster_transition_to_standby", [2]*pgtypes.DoltgresType{pgtypes.Int64, pgtypes.Int64}},
 }
 
 func initDynamicDoltProcedures() {
-	for _, name := range dynamicDoltProcedureNames {
-		framework.RegisterFunction(framework.Function1{
-			Name:       name,
+	for _, def := range dynamicDoltProcedures {
+		framework.RegisterFunction(framework.Function2{
+			Name:       def.name,
 			Return:     pgtypes.TextArray,
-			Parameters: [1]*pgtypes.DoltgresType{pgtypes.TextArray},
-			Variadic:   true,
-			Callable: func(ctx *sql.Context, paramsAndReturn [2]*pgtypes.DoltgresType, val1 any) (any, error) {
-				p, funcVal, err := resolveDynamicDoltProcedure(ctx, name)
+			Parameters: def.params,
+			Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
+				p, funcVal, err := resolveDynamicDoltProcedure(ctx, def.name)
 				if err != nil {
 					return nil, err
 				}
-				return varArgCallableForDoltProcedure(p, funcVal)(ctx, paramsAndReturn, val1)
-			},
-		})
-		framework.RegisterFunction(framework.Function0{
-			Name:   name,
-			Return: pgtypes.TextArray,
-			Callable: func(ctx *sql.Context) (any, error) {
-				p, funcVal, err := resolveDynamicDoltProcedure(ctx, name)
-				if err != nil {
-					return nil, err
-				}
-				return noArgCallableForDoltProcedure(p, funcVal)(ctx)
+				return varArgCallableForDoltProcedure(p, funcVal)(ctx, [2]*pgtypes.DoltgresType{}, []any{val1, val2})
 			},
 		})
 	}
@@ -217,8 +210,30 @@ func noArgCallableForDoltProcedure(p *plan.ExternalProcedure, funcVal reflect.Va
 }
 
 // checkDoltProcedureAccess ensures the current user is authorized as a SUPERUSER if the given |procedure| requires
-// admin.
+// admin, and that the server is not read-only if the procedure writes.
 func checkDoltProcedureAccess(ctx *sql.Context, procedure *plan.ExternalProcedure) error {
+	// Procedures that write cannot run on a read-only server (e.g. a cluster replication standby, which
+	// manages the read_only system variable). Dolt enforces this on its CALL path via the engine's
+	// read-only flag; invoking the procedure as a Doltgres function bypasses that, so enforce it here.
+	if !procedure.ReadOnly {
+		if _, readOnly, ok := sql.SystemVariables.GetGlobal("read_only"); ok {
+			switch v := readOnly.(type) {
+			case bool:
+				if v {
+					return sql.ErrReadOnly.New()
+				}
+			case int8:
+				if v == 1 {
+					return sql.ErrReadOnly.New()
+				}
+			case int64:
+				if v == 1 {
+					return sql.ErrReadOnly.New()
+				}
+			}
+		}
+	}
+
 	if !procedure.AdminOnly {
 		return nil
 	}

--- a/server/functions/dolt_procedures.go
+++ b/server/functions/dolt_procedures.go
@@ -67,11 +67,7 @@ func initDoltProcedures() {
 
 // dynamicDoltProcedures are Dolt stored procedures that are registered with the database provider dynamically
 // during engine construction (e.g. by the cluster replication controller), rather than appearing in the static
-// dprocedures.DoltProcedures list. They are registered here as late-bound functions: the procedure is resolved
-// from the session provider's external stored procedure registry at call time, since it does not exist yet (and
-// may never exist, if the corresponding feature isn't configured) when this registration runs. Unlike the static
-// Dolt procedures, which are uniformly variadic over text, these have fixed, typed signatures, declared here so
-// that numeric arguments resolve without quoting (e.g. `dolt_assume_cluster_role('standby', 2)`).
+// dprocedures.DoltProcedures list.
 var dynamicDoltProcedures = []struct {
 	name   string
 	params [2]*pgtypes.DoltgresType
@@ -212,24 +208,14 @@ func noArgCallableForDoltProcedure(p *plan.ExternalProcedure, funcVal reflect.Va
 // checkDoltProcedureAccess ensures the current user is authorized as a SUPERUSER if the given |procedure| requires
 // admin, and that the server is not read-only if the procedure writes.
 func checkDoltProcedureAccess(ctx *sql.Context, procedure *plan.ExternalProcedure) error {
-	// Procedures that write cannot run on a read-only server (e.g. a cluster replication standby, which
-	// manages the read_only system variable). Dolt enforces this on its CALL path via the engine's
-	// read-only flag; invoking the procedure as a Doltgres function bypasses that, so enforce it here.
 	if !procedure.ReadOnly {
 		if _, readOnly, ok := sql.SystemVariables.GetGlobal("read_only"); ok {
-			switch v := readOnly.(type) {
-			case bool:
-				if v {
-					return sql.ErrReadOnly.New()
-				}
-			case int8:
-				if v == 1 {
-					return sql.ErrReadOnly.New()
-				}
-			case int64:
-				if v == 1 {
-					return sql.ErrReadOnly.New()
-				}
+			ro, err := sql.ConvertToBool(ctx, readOnly)
+			if err != nil {
+				return err
+			}
+			if ro {
+				return sql.ErrReadOnly.New()
 			}
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -93,7 +93,7 @@ func runServer(ctx context.Context, cfg *servercfg.DoltgresConfig, dEnv *env.Dol
 	if dEnv.HasDoltDataDir() {
 		cwd, _ := dEnv.FS.Abs(".")
 		return nil, errors.Errorf("Cannot start a server within a directory containing a Dolt or Doltgres database. "+
-				"To use the current directory (%s) as a database, start the server from the parent directory.", cwd)
+			"To use the current directory (%s) as a database, start the server from the parent directory.", cwd)
 	}
 
 	defer tempfiles.MovableTempFileProvider.Clean()

--- a/server/server.go
+++ b/server/server.go
@@ -224,6 +224,12 @@ func (defaultDatabaseInitializer) InitializeEngine(ctx context.Context, se *engi
 
 	_, iter, _, err := se.Query(sqlCtx, fmt.Sprintf("CREATE DATABASE %s;", dbName))
 	if err != nil {
+		// A server that boots read-only (e.g. as a cluster replication standby)
+		// cannot create the default database. Skip creating it: on a standby it
+		// will be created by replication from the primary instead.
+		if sql.ErrReadOnly.Is(err) {
+			return nil
+		}
 		return err
 	}
 	_, err = sql.RowIterToRows(sqlCtx, iter)

--- a/server/server.go
+++ b/server/server.go
@@ -93,7 +93,7 @@ func runServer(ctx context.Context, cfg *servercfg.DoltgresConfig, dEnv *env.Dol
 	if dEnv.HasDoltDataDir() {
 		cwd, _ := dEnv.FS.Abs(".")
 		return nil, errors.Errorf("Cannot start a server within a directory containing a Dolt or Doltgres database. "+
-			"To use the current directory (%s) as a database, start the server from the parent directory.", cwd)
+				"To use the current directory (%s) as a database, start the server from the parent directory.", cwd)
 	}
 
 	defer tempfiles.MovableTempFileProvider.Clean()
@@ -224,9 +224,7 @@ func (defaultDatabaseInitializer) InitializeEngine(ctx context.Context, se *engi
 
 	_, iter, _, err := se.Query(sqlCtx, fmt.Sprintf("CREATE DATABASE %s;", dbName))
 	if err != nil {
-		// A server that boots read-only (e.g. as a cluster replication standby)
-		// cannot create the default database. Skip creating it: on a standby it
-		// will be created by replication from the primary instead.
+		// Ignore CREATE DATABASE errors if the server is read-only. This happens while bootstrapping a read replica.
 		if sql.ErrReadOnly.Is(err) {
 			return nil
 		}


### PR DESCRIPTION
There were a handful of bugs that prevented replication and tests from running successfully:

* replicas were immediately shutting down after server startup due to "CREATE DATABASE" statements being executed on them (they're read-only)
* various procedures related to replica control were not exposed
* root collections were not present on the cluster databases Dolt exposes
* various setup and assertions made by the tests, which were ported directly from Dolt, needed to be adapted