### PR TITLE
Enable automatic GC, by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/cockroachdb/apd/v3 v3.2.3
 	github.com/cockroachdb/errors v1.7.5
-	github.com/dolthub/dolt/go v0.40.5-0.20260723010422-c7bc20592ba2
+	github.com/dolthub/dolt/go v0.40.5-0.20260723211841-4d6a19a979b2
 	github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260722221430-72b291a45818

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,8 @@ github.com/dolthub/dolt-mcp v0.3.4 h1:AyG5cw+fNWXDHXujtQnqUPZrpWtPg6FN6yYtjv1pP4
 github.com/dolthub/dolt-mcp v0.3.4/go.mod h1:bCZ7KHvDYs+M0e+ySgmGiNvLhcwsN7bbf5YCyillLrk=
 github.com/dolthub/dolt/go v0.40.5-0.20260723010422-c7bc20592ba2 h1:tNHq7puTEuIOGQPc2AtGBPrkwR8T+Y06yTUehgQuFq0=
 github.com/dolthub/dolt/go v0.40.5-0.20260723010422-c7bc20592ba2/go.mod h1:o64d76hEQj3H9HVcVZAmv3M8XAhVjgPMGrdkps9F870=
+github.com/dolthub/dolt/go v0.40.5-0.20260723211841-4d6a19a979b2 h1:VAuZlaBeWUL7uXdn+8Z9cf1q4X11MJec3zk9Ll1Vmvk=
+github.com/dolthub/dolt/go v0.40.5-0.20260723211841-4d6a19a979b2/go.mod h1:o64d76hEQj3H9HVcVZAmv3M8XAhVjgPMGrdkps9F870=
 github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4 h1:0mg9QEFdkkBwJMxvz1tCjHYmfG2iIC6aShj1InDq9/M=
 github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4/go.mod h1:SSLraQS/jGLYFgff3vuZ+JbVUct6vyEeMzjLBqWqoyM=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=

--- a/integration-tests/go-sql-server-driver/auto_gc_test.go
+++ b/integration-tests/go-sql-server-driver/auto_gc_test.go
@@ -1,0 +1,247 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math/rand/v2"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	driver "github.com/dolthub/doltgresql/integration-tests/go-sql-server-driver/driver"
+)
+
+// TestAutoGC ports Dolt's driver-level automatic-GC test
+// (dolt/integration-tests/go-sql-server-driver/auto_gc_test.go) to Doltgres.
+//
+// TODO: Only the base, single-server variant is covered here: Dolt's ClusterReplication
+// and PushToRemotesAPI subtest variants are not ported yet because Doltgres does not
+// implement cluster replication or the remotes API yet (see
+// tests/sql-server-cluster.yaml, where every test is skipped for that reason).
+func TestAutoGC(t *testing.T) {
+	t.Parallel()
+	t.Run("Enable", func(t *testing.T) {
+		t.Parallel()
+		for _, sa := range []struct {
+			archive bool
+			name    string
+		}{{true, "Archive"}, {false, "NoArchive"}} {
+			t.Run(sa.name, func(t *testing.T) {
+				t.Parallel()
+				var s AutoGCTest
+				s.Enable = true
+				s.Archive = sa.archive
+				runAutoGCTestUntilGC(t, &s, 3, 16)
+			})
+		}
+	})
+	t.Run("Disabled", func(t *testing.T) {
+		t.Parallel()
+		var s AutoGCTest
+		runAutoGCTestDisabled(t, &s, 64, 16)
+	})
+}
+
+type AutoGCTest struct {
+	Enable  bool
+	Archive bool
+
+	Server *driver.SqlServer
+	DB     *sql.DB
+
+	Ports *DynamicResources
+
+	gcCount        atomic.Int32
+	sawDanglingRef atomic.Bool
+}
+
+func (s *AutoGCTest) gcVisitor() func(string) {
+	return func(line string) {
+		if strings.Contains(line, "Successfully completed auto GC") {
+			s.gcCount.Add(1)
+		}
+		if strings.Contains(line, "dangling references requested during GC") {
+			s.sawDanglingRef.Store(true)
+		}
+	}
+}
+
+func (s *AutoGCTest) Setup(ctx context.Context, t *testing.T) {
+	s.Ports = newPorts(t)
+
+	u, err := driver.NewDoltUser()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		u.Cleanup()
+	})
+
+	rs, err := u.MakeRepoStore()
+	require.NoError(t, err)
+
+	_, err = rs.MakeRepo("auto_gc_test")
+	require.NoError(t, err)
+
+	archiveFragment := ``
+	if s.Archive {
+		archiveFragment = `
+    archive_level: 1`
+	}
+
+	behaviorFragment := fmt.Sprintf(`
+behavior:
+  auto_gc_behavior:
+    enable: %v%v
+listener:
+  port: {{get_port "server_port"}}
+`, s.Enable, archiveFragment)
+
+	err = driver.WithFile{
+		Name:     "server.yaml",
+		Contents: behaviorFragment,
+		Template: s.Ports.ApplyTemplate,
+	}.WriteAtDir(rs.Dir)
+	require.NoError(t, err)
+
+	server := MakeServer(t, rs, rs.Dir, &driver.Server{
+		Name:        "primary",
+		Args:        []string{"--config", "server.yaml"},
+		DynamicPort: "server_port",
+		// Disable the auto-GC load-average throttling so GC runs immediately instead
+		// of backing off under CI load (see loadAvgGCScheduler in dolt/go's auto_gc.go).
+		Envs: []string{"DOLT_GC_SCHEDULER=NONE"},
+	}, s.Ports, driver.WithOutputVisitor(s.gcVisitor()))
+	server.DBName = "auto_gc_test"
+
+	db, err := server.DB(driver.Connection{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	s.Server = server
+	s.DB = db
+
+	s.CreateDatabase(ctx, t)
+}
+
+// CreateDatabase creates the vals table along with a battery of secondary indexes,
+// mirroring Dolt's inline `index (...)` column definitions (MySQL syntax, not valid in
+// Postgres) as separate CREATE INDEX statements. The extra indexes are load-bearing for
+// the test: each insert now writes to many prolly trees instead of one, which is what
+// lets a modest number of statements push the store past auto-GC's 128MB size threshold
+// within a reasonable test run.
+func (s *AutoGCTest) CreateDatabase(ctx context.Context, t *testing.T) {
+	conn, err := s.DB.Conn(ctx)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, `
+create table vals (
+    id bigint primary key,
+    v1 bigint,
+    v2 bigint,
+    v3 bigint,
+    v4 bigint
+)
+`)
+	require.NoError(t, err)
+	for _, cols := range [][]string{
+		{"v1"}, {"v2"}, {"v3"}, {"v4"},
+		{"v1", "v2"}, {"v1", "v3"}, {"v1", "v4"},
+		{"v2", "v3"}, {"v2", "v4"}, {"v2", "v1"},
+		{"v3", "v1"}, {"v3", "v2"}, {"v3", "v4"},
+		{"v4", "v1"}, {"v4", "v2"}, {"v4", "v3"},
+	} {
+		_, err = conn.ExecContext(ctx, fmt.Sprintf("create index vals_%s_idx on vals (%s)", strings.Join(cols, "_"), strings.Join(cols, ",")))
+		require.NoError(t, err)
+	}
+	_, err = conn.ExecContext(ctx, "select dolt_commit('-Am', 'create vals table')")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+}
+
+func autoGCInsertStatement(i int) string {
+	var vals []string
+	for j := i * 1024; j < (i+1)*1024; j++ {
+		var vs [4]string
+		vs[0] = strconv.Itoa(rand.Int())
+		vs[1] = strconv.Itoa(rand.Int())
+		vs[2] = strconv.Itoa(rand.Int())
+		vs[3] = strconv.Itoa(rand.Int())
+		val := "(" + strconv.Itoa(j) + "," + strings.Join(vs[:], ",") + ")"
+		vals = append(vals, val)
+	}
+	return "insert into vals values " + strings.Join(vals, ",")
+}
+
+// runAutoGCTestUntilGC runs insert+commit cycles until auto GC has completed
+// targetGCCount times, or fails if that doesn't happen within a reasonable number of
+// iterations. It fails immediately if the server logs a dangling references message.
+func runAutoGCTestUntilGC(t *testing.T, s *AutoGCTest, targetGCCount int, commitEvery int) {
+	const maxStatements = 1024
+	ctx := t.Context()
+	s.Setup(ctx, t)
+
+	for i := range maxStatements {
+		require.False(t, s.sawDanglingRef.Load(), "saw dangling references message during auto GC")
+		if s.gcCount.Load() >= int32(targetGCCount) {
+			t.Logf("reached %d auto GCs after %d statements", targetGCCount, i)
+			break
+		}
+
+		stmt := autoGCInsertStatement(i)
+		conn, err := s.DB.Conn(ctx)
+		require.NoError(t, err)
+		_, err = conn.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+		if (i+1)%commitEvery == 0 {
+			_, err = conn.ExecContext(ctx, "select dolt_commit('-am', 'insert from "+strconv.Itoa(i*1024)+"')")
+			require.NoError(t, err)
+		}
+		require.NoError(t, conn.Close())
+	}
+
+	require.False(t, s.sawDanglingRef.Load(), "saw dangling references message during auto GC")
+	require.GreaterOrEqual(t, s.gcCount.Load(), int32(targetGCCount),
+		"did not reach %d auto GCs within %d statements", targetGCCount, maxStatements)
+
+	t.Logf("auto GC count: %d", s.gcCount.Load())
+}
+
+// runAutoGCTestDisabled runs a fixed number of insert+commit cycles against a server
+// with auto GC disabled, verifying it never fires.
+func runAutoGCTestDisabled(t *testing.T, s *AutoGCTest, numStatements int, commitEvery int) {
+	ctx := t.Context()
+	s.Setup(ctx, t)
+
+	for i := range numStatements {
+		stmt := autoGCInsertStatement(i)
+		conn, err := s.DB.Conn(ctx)
+		require.NoError(t, err)
+		_, err = conn.ExecContext(ctx, stmt)
+		require.NoError(t, err)
+		if (i+1)%commitEvery == 0 {
+			_, err = conn.ExecContext(ctx, "select dolt_commit('-am', 'insert from "+strconv.Itoa(i*1024)+"')")
+			require.NoError(t, err)
+		}
+		require.NoError(t, conn.Close())
+	}
+
+	require.Zero(t, s.gcCount.Load(), "auto GC should not run when disabled")
+}

--- a/integration-tests/go-sql-server-driver/tests/sql-server-config.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-config.yaml
@@ -47,7 +47,6 @@ tests:
         columns: ["max_connections"]
         rows: [["999"]]
 - name: "dolt_auto_gc_enabled default"
-  skip: "default not set yet"
   repos:
   - name: repo1
     server:
@@ -63,7 +62,6 @@ tests:
     - exec: "SET dolt_auto_gc_enabled = 0"
       error_match: "Variable 'dolt_auto_gc_enabled' is a read only variable"
 - name: "@@global.dolt_auto_gc_enabled true"
-  skip: "config field not supported yet"
   repos:
   - name: repo1
     with_files:
@@ -83,7 +81,6 @@ tests:
         columns: ["dolt_auto_gc_enabled"]
         rows: [["1"]]
 - name: "@@global.dolt_auto_gc_enabled false"
-  skip: "config field not supported yet"
   repos:
     - name: repo1
       with_files:

--- a/servercfg/cfgdetails/config.go
+++ b/servercfg/cfgdetails/config.go
@@ -100,22 +100,36 @@ type DoltgresBehaviorConfig struct {
 	// DoltTransactionCommit enables the @@dolt_transaction_commit system variable, which
 	// automatically creates a Dolt commit when any SQL transaction is committed.
 	DoltTransactionCommit *bool `yaml:"dolt_transaction_commit,omitempty" minver:"0.7.4"`
+	// AutoGCBehavior configures automatic background garbage collection.
+	AutoGCBehavior *DoltgresAutoGCBehaviorYAMLConfig `yaml:"auto_gc_behavior,omitempty" minver:"TBD"`
 }
 
-// DoltgresAutoGCBehavior implements Dolt's doltservercfg.AutoGCBehavior.
-type DoltgresAutoGCBehavior struct {
+// DoltgresAutoGCBehaviorYAMLConfig implements Dolt's doltservercfg.AutoGCBehavior.
+type DoltgresAutoGCBehaviorYAMLConfig struct {
+	Enable_              *bool   `yaml:"enable,omitempty" minver:"TBD"`
+	ArchiveLevel_        *int    `yaml:"archive_level,omitempty" minver:"TBD"`
+	IncrementalFileSize_ *uint64 `yaml:"incremental_file_size,omitempty" minver:"TBD"`
 }
 
-func (DoltgresAutoGCBehavior) Enable() bool {
-	return false
+func (a *DoltgresAutoGCBehaviorYAMLConfig) Enable() bool {
+	if a.Enable_ == nil {
+		return true
+	}
+	return *a.Enable_
 }
 
-func (DoltgresAutoGCBehavior) ArchiveLevel() int {
-	return 0
+func (a *DoltgresAutoGCBehaviorYAMLConfig) ArchiveLevel() int {
+	if a.ArchiveLevel_ == nil {
+		return 1
+	}
+	return *a.ArchiveLevel_
 }
 
-func (DoltgresAutoGCBehavior) IncrementalFileSize() uint64 {
-	return 0
+func (a *DoltgresAutoGCBehaviorYAMLConfig) IncrementalFileSize() uint64 {
+	if a.IncrementalFileSize_ == nil {
+		return 0
+	}
+	return *a.IncrementalFileSize_
 }
 
 type DoltgresUserConfig struct {
@@ -655,7 +669,10 @@ func (cfg *DoltgresConfig) EventSchedulerStatus() string {
 }
 
 func (cfg *DoltgresConfig) AutoGCBehavior() doltservercfg.AutoGCBehavior {
-	return DoltgresAutoGCBehavior{}
+	if cfg.BehaviorConfig == nil || cfg.BehaviorConfig.AutoGCBehavior == nil {
+		return nil
+	}
+	return cfg.BehaviorConfig.AutoGCBehavior
 }
 
 func (cfg *DoltgresConfig) BranchActivityTracking() bool {

--- a/testing/bats/replication.bats
+++ b/testing/bats/replication.bats
@@ -11,7 +11,7 @@ teardown() {
 }
 
 @test 'replication: test postgres connection' {
-    if [[ ! -v "RUN_DOLTGRES_REPLICATION_TESTS" ]]; then
+    if [ -z "${RUN_DOLTGRES_REPLICATION_TESTS+x}" ]; then
        skip "RUN_DOLTGRES_REPLICATION_TESTS not set, skipping"
     fi
 

--- a/testing/bats/sql-auto-gc.bats
+++ b/testing/bats/sql-auto-gc.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+load $BATS_TEST_DIRNAME/setup/common.bash
+
+setup() {
+    setup_common
+    # Disable the auto-GC load-average throttling so GC runs immediately instead of
+    # backing off under CI load (see loadAvgGCScheduler in dolt/go's auto_gc.go).
+    export DOLT_GC_SCHEDULER=NONE
+}
+
+teardown() {
+    teardown_common
+}
+
+# make_gen_vals_sql writes a series of INSERT statements to $1, structured as a set of
+# separate statements (rather than one large one) so that each is its own auto-committed
+# transaction, giving the auto-GC commit hook multiple chances to fire during the import.
+make_gen_vals_sql() {
+    local out=$1
+    echo "DROP TABLE IF EXISTS vals;" > "$out"
+    echo "CREATE TABLE vals (c1 int, c2 int, c3 int, c4 int);" >> "$out"
+    for i in $(seq 1 256); do
+        echo "INSERT INTO vals SELECT (random()*65536)::int, (random()*65536)::int, (random()*65536)::int, (random()*65536)::int FROM generate_series(1, 1024);" >> "$out"
+    done
+}
+
+@test "sql-auto-gc: importing data through a running server runs auto gc" {
+    PORT=$( definePORT )
+    cat > config.yaml <<EOF
+log_level: debug
+
+behavior:
+  auto_gc_behavior:
+    enable: true
+
+listener:
+  host: localhost
+  port: $PORT
+EOF
+    start_sql_server_with_args "-config=config.yaml"
+
+    make_gen_vals_sql gen_vals.sql
+    query_server -f gen_vals.sql
+
+    # auto GC runs asynchronously against the live server (unlike Dolt's one-shot
+    # batch `dolt sql`, which blocks until GC finishes before the process exits), so
+    # poll until the store size settles instead of asserting immediately after import.
+    before=-1
+    after=$(du -sk postgres/.dolt/noms | awk '{print $1}')
+    for i in $(seq 1 30); do
+        if [ "$before" -eq "$after" ]; then
+            break
+        fi
+        before=$after
+        sleep 1
+        after=$(du -sk postgres/.dolt/noms | awk '{print $1}')
+    done
+
+    [[ "$after" -lt 524288 ]] || (echo "postgres/.dolt/noms should be less than 512MB after auto GC" && false)
+
+    tablefiles=$(ls -1 postgres/.dolt/noms/ | egrep '[0-9a-v]{32}' | egrep -v 'v{32}')
+    [[ $(echo "$tablefiles" | wc -l) -eq 1 ]] || (echo "postgres/.dolt/noms should have one table file after auto GC" && false)
+
+    stop_sql_server
+}
+
+@test "sql-auto-gc: auto gc runs by default" {
+    PORT=$( definePORT )
+    cat > config.yaml <<EOF
+log_level: debug
+
+listener:
+  host: localhost
+  port: $PORT
+EOF
+    start_sql_server_with_args "-config=config.yaml" > log.txt 2>&1
+
+    make_gen_vals_sql gen_vals.sql
+    query_server -f gen_vals.sql
+
+    # auto GC runs asynchronously against the live server, so poll until the store
+    # size settles instead of asserting immediately after import.
+    before=-1
+    after=$(du -sk postgres/.dolt/noms | awk '{print $1}')
+    for i in $(seq 1 30); do
+        if [ "$before" -eq "$after" ]; then
+            break
+        fi
+        before=$after
+        sleep 1
+        after=$(du -sk postgres/.dolt/noms | awk '{print $1}')
+    done
+
+    run grep -c "Successfully completed auto GC" log.txt
+    [[ "$output" -gt 0 ]] || (echo "auto GC should run by default when auto_gc_behavior is not configured" && false)
+
+    [[ "$after" -lt 524288 ]] || (echo "postgres/.dolt/noms should be less than 512MB after auto GC" && false)
+
+    tablefiles=$(ls -1 postgres/.dolt/noms/ | egrep '[0-9a-v]{32}' | egrep -v 'v{32}')
+    [[ $(echo "$tablefiles" | wc -l) -eq 1 ]] || (echo "postgres/.dolt/noms should have one table file after auto GC" && false)
+
+    stop_sql_server
+}
+
+@test "sql-auto-gc: auto gc can be disabled" {
+    PORT=$( definePORT )
+    cat > config.yaml <<EOF
+log_level: debug
+
+behavior:
+  auto_gc_behavior:
+    enable: false
+
+listener:
+  host: localhost
+  port: $PORT
+EOF
+    start_sql_server_with_args "-config=config.yaml" > log.txt 2>&1
+
+    make_gen_vals_sql gen_vals.sql
+    query_server -f gen_vals.sql
+    sleep 3
+
+    run grep -c "Successfully completed auto GC" log.txt
+    [[ "$output" -eq 0 ]] || (echo "auto GC should not have run when disabled" && false)
+
+    stop_sql_server
+}


### PR DESCRIPTION
Enable automatic garbage collection for Doltgres. Ports the existing auto GC tests from Dolt. 

Depends on: https://github.com/dolthub/dolt/pull/11343