### PR TITLE
Use LockSubsystem.TryLock in pg_try_advisory_lock, remove stale reentrancy TODO

### DIFF
--- a/server/functions/advisory_locks.go
+++ b/server/functions/advisory_locks.go
@@ -49,10 +49,6 @@ var pg_advisory_lock_bigint = framework.Function1{
 			return false, errors.Errorf("lock subsystem not available")
 		}
 
-		// TODO: Postgres supports reentrant locks, meaning if pg_advisory_lock(123) is called multiple times,
-		//       pg_advisory_unlock(123) must be called the same number of times to fully release a lock. This
-		//       is different from MySQL's locking behavior, so LockSubsystem should be updated to support
-		//       a reentrant mode in addition to the current mode.
 		err := lockSubsystem.Lock(ctx, lockName, time.Millisecond*-1)
 		return err == nil, err
 	},
@@ -74,16 +70,7 @@ var pg_try_advisory_lock_bigint = framework.Function1{
 			return false, errors.Errorf("lock subsystem not available")
 		}
 
-		// TODO: We currently need to specify a timeout, but it may be a better mapping to
-		//       this function if we had a lockSubsystem.TryLock function that would try
-		//       to grab the lock once and then return immediately. Until then, we set a
-		//       short timeout and translate any timeout errors into a false return value.
-		err := lockSubsystem.Lock(ctx, lockName, time.Millisecond*1)
-		if sql.ErrLockTimeout.Is(err) {
-			return false, nil
-		}
-
-		return err == nil, err
+		return lockSubsystem.TryLock(ctx, lockName)
 	},
 }
 

--- a/testing/go/lock_test.go
+++ b/testing/go/lock_test.go
@@ -65,5 +65,59 @@ func TestAdvisoryLocks(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "advisory locks are reentrant",
+			SetUpScript: []string{
+				`CREATE USER user1 PASSWORD 'password';`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT pg_advisory_lock(10)`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					// The same session may acquire a lock it already holds.
+					Query:    `SELECT pg_advisory_lock(10)`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    `SELECT pg_try_advisory_lock(10)`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Username: "user1",
+					Password: "password",
+					Query:    `SELECT pg_try_advisory_lock(10)`,
+					Expected: []sql.Row{{"f"}},
+				},
+				{
+					Query:    `SELECT pg_advisory_unlock(10)`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    `SELECT pg_advisory_unlock(10)`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					// The lock was acquired three times, so two unlocks leave it held and
+					// other sessions still cannot acquire it.
+					Username: "user1",
+					Password: "password",
+					Query:    `SELECT pg_try_advisory_lock(10)`,
+					Expected: []sql.Row{{"f"}},
+				},
+				{
+					Query:    `SELECT pg_advisory_unlock(10)`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					// After the final unlock, other sessions may acquire the lock.
+					Username: "user1",
+					Password: "password",
+					Query:    `SELECT pg_try_advisory_lock(10)`,
+					Expected: []sql.Row{{"t"}},
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
`pg_try_advisory_lock` previously emulated a try-lock by calling `LockSubsystem.Lock` with a 1ms timeout and translating `ErrLockTimeout` into a false return value. This was a workaround for the lock subsystem not having a true non-blocking acquisition API.

[dolthub/go-mysql-server#3584](https://github.com/dolthub/go-mysql-server/pull/3584) added `LockSubsystem.TryLock`, which attempts the lock acquisition exactly once and returns immediately. This change replaces the workaround with a direct call to it.

Also removes a stale `//TODO` on `pg_advisory_lock` stating that `LockSubsystem` needed to be updated to support reentrant locks. `LockSubsystem` already supports reentrant locks: re-acquiring a held lock increments a lock count, and each unlock decrements it, so a lock is only fully released after being unlocked as many times as it was acquired. A new test in `testing/go/lock_test.go` verifies the reentrant behavior.