### PR TITLE
Bug fix: infer bound var types correctly when they aren't fully specified

### DIFF
--- a/server/connection_handler.go
+++ b/server/connection_handler.go
@@ -25,7 +25,6 @@ import (
 	"net"
 	"os"
 	"runtime/debug"
-	"slices"
 	"strings"
 	"sync/atomic"
 
@@ -555,15 +554,26 @@ func (h *ConnectionHandler) handleParse(message *pgproto3.Parse) error {
 	// A valid Parse message must have ParameterObjectIDs if there are any binding variables.
 	bindVarTypes := message.ParameterOIDs
 
-	// Clients can specify an OID of zero to indicate that the type should be inferred. If we
-	// see any zero OIDs, we fall back to extracting the bind var types from the plan.
-	if len(bindVarTypes) == 0 || slices.Contains(bindVarTypes, 0) {
-		// NOTE: This is used for Prepared Statement Tests only.
-		bindVarTypes, err = extractBindVarTypes(ctx, analyzedPlan)
-		if err != nil {
-			return err
+	// Clients can specify an OID of zero for a parameter, or omit trailing parameters from
+	// ParameterOIDs entirely (the Postgres protocol allows specifying types for only a prefix
+	// of the placeholders), to indicate that a parameter's type should be inferred. We always
+	// compute the plan-inferred types (we can't know whether bindVarTypes is missing
+	// trailing entries without first inspecting the analyzed plan) but only use an inferred
+	// type to fill a position the client left unspecified. An explicit, non-zero OID from the
+	// client must never be overwritten by an inferred type, since the client will encode that
+	// parameter's Bind value using its own declared type.
+	inferredTypes, err := extractBindVarTypes(ctx, analyzedPlan)
+	if err != nil {
+		return err
+	}
+	merged := make([]uint32, len(inferredTypes))
+	copy(merged, inferredTypes)
+	for i, oid := range bindVarTypes {
+		if oid != 0 && i < len(merged) {
+			merged[i] = oid
 		}
 	}
+	bindVarTypes = merged
 
 	h.preparedStatements[message.Name] = PreparedStatementData{
 		Query:        query,

--- a/testing/go/binding_test.go
+++ b/testing/go/binding_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -59,8 +60,8 @@ func TestBindingWithOidZero(t *testing.T) {
 	var id int32
 	var name string
 	require.NoError(t, conn.QueryRow(ctx, "SELECT id, name FROM my_table").Scan(&id, &name))
-	require.Equal(t, int32(42), id)
-	require.Equal(t, "Alice", name)
+	assert.Equal(t, int32(42), id)
+	assert.Equal(t, "Alice", name)
 }
 
 // TestBindingInt4ToBigintWithUntypedNull is a regression test for
@@ -103,10 +104,10 @@ func TestBindingInt4ToBigintWithUntypedNull(t *testing.T) {
 	var b int32
 	var f *bool
 	require.NoError(t, rows.Scan(&a, &b, &f))
-	require.Equal(t, int64(1), a)
-	require.Equal(t, int32(2), b)
-	require.Nil(t, f)
-	require.False(t, rows.Next())
+	assert.Equal(t, int64(1), a)
+	assert.Equal(t, int32(2), b)
+	assert.Nil(t, f)
+	assert.False(t, rows.Next())
 }
 
 // TestBindingWhereClauseInt4ToBigintWithUntypedNull is a regression test for
@@ -142,8 +143,8 @@ func TestBindingWhereClauseInt4ToBigintWithUntypedNull(t *testing.T) {
 	result := resultReader.Read()
 	require.NoError(t, result.Err)
 	require.Len(t, result.Rows, 1)
-	require.Equal(t, "1", string(result.Rows[0][0]))
-	require.Equal(t, "t", string(result.Rows[0][1]))
+	assert.Equal(t, "1", string(result.Rows[0][0]))
+	assert.Equal(t, "t", string(result.Rows[0][1]))
 }
 
 // TestBindingUpdateInt4ToBigintWithUntypedNull is a regression test for
@@ -179,8 +180,8 @@ func TestBindingUpdateInt4ToBigintWithUntypedNull(t *testing.T) {
 	var a int64
 	var f *bool
 	require.NoError(t, conn.QueryRow(ctx, "SELECT a, f FROM t3 WHERE id = 1").Scan(&a, &f))
-	require.Equal(t, int64(42), a)
-	require.Nil(t, f)
+	assert.Equal(t, int64(42), a)
+	assert.Nil(t, f)
 }
 
 // TestBindingFloat4ToDoubleWithUntypedNull is a regression test for
@@ -215,8 +216,8 @@ func TestBindingFloat4ToDoubleWithUntypedNull(t *testing.T) {
 	var a float64
 	var f *bool
 	require.NoError(t, conn.QueryRow(ctx, "SELECT a, f FROM t4").Scan(&a, &f))
-	require.Equal(t, float64(3.5), a)
-	require.Nil(t, f)
+	assert.Equal(t, float64(3.5), a)
+	assert.Nil(t, f)
 }
 
 // TestBindingInt8ToIntColumnWithUntypedNull is a regression test for
@@ -250,8 +251,8 @@ func TestBindingInt8ToIntColumnWithUntypedNull(t *testing.T) {
 	var a int32
 	var f *bool
 	require.NoError(t, conn.QueryRow(ctx, "SELECT a, f FROM t5").Scan(&a, &f))
-	require.Equal(t, int32(7), a)
-	require.Nil(t, f)
+	assert.Equal(t, int32(7), a)
+	assert.Nil(t, f)
 }
 
 // TestBindingShortParameterOIDsArray is a regression test for a defect found from
@@ -281,8 +282,8 @@ func TestBindingShortParameterOIDsArray(t *testing.T) {
 
 	var a, b int32
 	require.NoError(t, conn.QueryRow(ctx, "SELECT a, b FROM t6").Scan(&a, &b))
-	require.Equal(t, int32(1), a)
-	require.Equal(t, int32(2), b)
+	assert.Equal(t, int32(1), a)
+	assert.Equal(t, int32(2), b)
 }
 
 func TestIssue2386(t *testing.T) {
@@ -384,8 +385,8 @@ func TestBindingOnConflictDoUpdateWithUntypedNull(t *testing.T) {
 	var a int64
 	var f *bool
 	require.NoError(t, conn.QueryRow(ctx, "SELECT a, f FROM tconf WHERE id = 1").Scan(&a, &f))
-	require.Equal(t, int64(42), a)
-	require.Nil(t, f)
+	assert.Equal(t, int64(42), a)
+	assert.Nil(t, f)
 }
 
 // TestBindingMultipleInferredAndExplicitOIDsInterleaved tests the OID-merge logic by interleaving
@@ -423,9 +424,9 @@ func TestBindingMultipleInferredAndExplicitOIDsInterleaved(t *testing.T) {
 	var d float64
 	var e *bool
 	require.NoError(t, conn.QueryRow(ctx, "SELECT a, b, c, d, e FROM t7").Scan(&a, &b, &c, &d, &e))
-	require.Equal(t, int32(11), a)
-	require.Equal(t, int64(22), b)
-	require.Equal(t, int32(33), c)
-	require.Equal(t, float64(4.5), d)
-	require.Nil(t, e)
+	assert.Equal(t, int32(11), a)
+	assert.Equal(t, int64(22), b)
+	assert.Equal(t, int32(33), c)
+	assert.Equal(t, float64(4.5), d)
+	assert.Nil(t, e)
 }

--- a/testing/go/binding_test.go
+++ b/testing/go/binding_test.go
@@ -15,6 +15,8 @@
 package _go
 
 import (
+	"encoding/binary"
+	"math"
 	"strconv"
 	"testing"
 
@@ -43,7 +45,7 @@ func TestBindingWithOidZero(t *testing.T) {
 		[]byte(strconv.Itoa(42)),
 		[]byte("Alice"),
 	}
-	paramOIDs := []uint32{0, 123}
+	paramOIDs := []uint32{0, pgtype.TextOID}
 	paramFormats := []int16{0, 0}
 	sql := "INSERT INTO my_table (id, name) VALUES ($1, $2);"
 
@@ -51,6 +53,236 @@ func TestBindingWithOidZero(t *testing.T) {
 	resultReader := conn.PgConn().ExecParams(ctx, sql, args, paramOIDs, paramFormats, nil)
 	result := resultReader.Read()
 	require.NoError(t, result.Err)
+
+	// The explicitly-typed parameter ($2) must be honored rather than discarded, and the
+	// inferred parameter ($1) must resolve correctly, so the row must round-trip intact.
+	var id int32
+	var name string
+	require.NoError(t, conn.QueryRow(ctx, "SELECT id, name FROM my_table").Scan(&id, &name))
+	require.Equal(t, int32(42), id)
+	require.Equal(t, "Alice", name)
+}
+
+// TestBindingInt4ToBigintWithUntypedNull is a regression test for
+// https://github.com/dolthub/doltgresql/issues/2973: an int4-typed parameter bound to
+// a BIGINT column was silently corrupted whenever the same statement also had an untyped
+// (OID 0) NULL parameter.
+func TestBindingInt4ToBigintWithUntypedNull(t *testing.T) {
+	ctx, connection, controller := CreateServer(t, "postgres")
+	defer func() {
+		connection.Close(ctx)
+		controller.Stop()
+		require.NoError(t, controller.WaitForStop())
+	}()
+	conn := connection.Default
+
+	_, err := connection.Exec(ctx, "CREATE TABLE t1 (a BIGINT, b INT, f BOOLEAN);")
+	require.NoError(t, err)
+
+	aBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(aBytes, 1)
+	bBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(bBytes, 2)
+
+	// $1 is explicitly int4 and 4 bytes wide even though it targets a BIGINT column;
+	// $3 is an untyped NULL (OID 0).
+	args := [][]byte{aBytes, bBytes, nil}
+	paramOIDs := []uint32{pgtype.Int4OID, pgtype.Int4OID, 0}
+	paramFormats := []int16{1, 1, 1}
+	sql := "INSERT INTO t1 (a, b, f) VALUES ($1, $2, $3);"
+
+	resultReader := conn.PgConn().ExecParams(ctx, sql, args, paramOIDs, paramFormats, nil)
+	result := resultReader.Read()
+	require.NoError(t, result.Err)
+
+	rows, err := conn.Query(ctx, "SELECT a, b, f FROM t1")
+	require.NoError(t, err)
+	defer rows.Close()
+	require.True(t, rows.Next())
+	var a int64
+	var b int32
+	var f *bool
+	require.NoError(t, rows.Scan(&a, &b, &f))
+	require.Equal(t, int64(1), a)
+	require.Equal(t, int32(2), b)
+	require.Nil(t, f)
+	require.False(t, rows.Next())
+}
+
+// TestBindingWhereClauseInt4ToBigintWithUntypedNull is a regression test for
+// https://github.com/dolthub/doltgresql/issues/2973, triggered via a WHERE-clause comparison
+// rather than an INSERT VALUES tuple. go-mysql-server's planbuilder (sql/planbuilder/scalar.go,
+// buildScalar) assigns a bindvar's inferred type from whatever column it's compared against, so
+// this is a distinct code path from the INSERT case but the same underlying corruption class.
+func TestBindingWhereClauseInt4ToBigintWithUntypedNull(t *testing.T) {
+	ctx, connection, controller := CreateServer(t, "postgres")
+	defer func() {
+		connection.Close(ctx)
+		controller.Stop()
+		require.NoError(t, controller.WaitForStop())
+	}()
+	conn := connection.Default
+
+	_, err := connection.Exec(ctx, "CREATE TABLE t2 (a BIGINT, f BOOLEAN);")
+	require.NoError(t, err)
+	_, err = connection.Exec(ctx, "INSERT INTO t2 VALUES (1, true), (2, false);")
+	require.NoError(t, err)
+
+	aBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(aBytes, 1)
+
+	// $1 is explicitly int4 and compared against a BIGINT column; $2 is an untyped NULL,
+	// referenced elsewhere in the WHERE clause so the statement actually binds it.
+	args := [][]byte{aBytes, nil}
+	paramOIDs := []uint32{pgtype.Int4OID, 0}
+	paramFormats := []int16{1, 1}
+	sql := "SELECT a, f FROM t2 WHERE a = $1 AND (f = $2 OR f IS NOT NULL);"
+
+	resultReader := conn.PgConn().ExecParams(ctx, sql, args, paramOIDs, paramFormats, nil)
+	result := resultReader.Read()
+	require.NoError(t, result.Err)
+	require.Len(t, result.Rows, 1)
+	require.Equal(t, "1", string(result.Rows[0][0]))
+	require.Equal(t, "t", string(result.Rows[0][1]))
+}
+
+// TestBindingUpdateInt4ToBigintWithUntypedNull is a regression test for
+// https://github.com/dolthub/doltgresql/issues/2973, triggered via an UPDATE ... SET assignment
+// rather than an INSERT VALUES tuple.
+func TestBindingUpdateInt4ToBigintWithUntypedNull(t *testing.T) {
+	ctx, connection, controller := CreateServer(t, "postgres")
+	defer func() {
+		connection.Close(ctx)
+		controller.Stop()
+		require.NoError(t, controller.WaitForStop())
+	}()
+	conn := connection.Default
+
+	_, err := connection.Exec(ctx, "CREATE TABLE t3 (id INT PRIMARY KEY, a BIGINT, f BOOLEAN);")
+	require.NoError(t, err)
+	_, err = connection.Exec(ctx, "INSERT INTO t3 VALUES (1, 0, true);")
+	require.NoError(t, err)
+
+	aBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(aBytes, 42)
+
+	// $1 is explicitly int4 and assigned to a BIGINT column; $2 is an untyped NULL.
+	args := [][]byte{aBytes, nil}
+	paramOIDs := []uint32{pgtype.Int4OID, 0}
+	paramFormats := []int16{1, 1}
+	sql := "UPDATE t3 SET a = $1, f = $2 WHERE id = 1;"
+
+	resultReader := conn.PgConn().ExecParams(ctx, sql, args, paramOIDs, paramFormats, nil)
+	result := resultReader.Read()
+	require.NoError(t, result.Err)
+
+	var a int64
+	var f *bool
+	require.NoError(t, conn.QueryRow(ctx, "SELECT a, f FROM t3 WHERE id = 1").Scan(&a, &f))
+	require.Equal(t, int64(42), a)
+	require.Nil(t, f)
+}
+
+// TestBindingFloat4ToDoubleWithUntypedNull is a regression test for
+// https://github.com/dolthub/doltgresql/issues/2973, for a non-integer narrowing type pair
+// (float4 -> float8/DOUBLE PRECISION).
+func TestBindingFloat4ToDoubleWithUntypedNull(t *testing.T) {
+	ctx, connection, controller := CreateServer(t, "postgres")
+	defer func() {
+		connection.Close(ctx)
+		controller.Stop()
+		require.NoError(t, controller.WaitForStop())
+	}()
+	conn := connection.Default
+
+	_, err := connection.Exec(ctx, "CREATE TABLE t4 (a DOUBLE PRECISION, f BOOLEAN);")
+	require.NoError(t, err)
+
+	aBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(aBytes, math.Float32bits(3.5))
+
+	// $1 is explicitly float4 and targets a DOUBLE PRECISION (float8) column; $2 is an
+	// untyped NULL.
+	args := [][]byte{aBytes, nil}
+	paramOIDs := []uint32{pgtype.Float4OID, 0}
+	paramFormats := []int16{1, 1}
+	sql := "INSERT INTO t4 (a, f) VALUES ($1, $2);"
+
+	resultReader := conn.PgConn().ExecParams(ctx, sql, args, paramOIDs, paramFormats, nil)
+	result := resultReader.Read()
+	require.NoError(t, result.Err)
+
+	var a float64
+	var f *bool
+	require.NoError(t, conn.QueryRow(ctx, "SELECT a, f FROM t4").Scan(&a, &f))
+	require.Equal(t, float64(3.5), a)
+	require.Nil(t, f)
+}
+
+// TestBindingInt8ToIntColumnWithUntypedNull is a regression test for
+// https://github.com/dolthub/doltgresql/issues/2973, for the mirror-image (narrowing) direction:
+// the client explicitly declares $1 as int8 (8 bytes) even though it targets an INT (int4)
+// column.
+func TestBindingInt8ToIntColumnWithUntypedNull(t *testing.T) {
+	ctx, connection, controller := CreateServer(t, "postgres")
+	defer func() {
+		connection.Close(ctx)
+		controller.Stop()
+		require.NoError(t, controller.WaitForStop())
+	}()
+	conn := connection.Default
+
+	_, err := connection.Exec(ctx, "CREATE TABLE t5 (a INT, f BOOLEAN);")
+	require.NoError(t, err)
+
+	aBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(aBytes, uint64(7))
+
+	args := [][]byte{aBytes, nil}
+	paramOIDs := []uint32{pgtype.Int8OID, 0}
+	paramFormats := []int16{1, 1}
+	sql := "INSERT INTO t5 (a, f) VALUES ($1, $2);"
+
+	resultReader := conn.PgConn().ExecParams(ctx, sql, args, paramOIDs, paramFormats, nil)
+	result := resultReader.Read()
+	require.NoError(t, result.Err)
+
+	var a int32
+	var f *bool
+	require.NoError(t, conn.QueryRow(ctx, "SELECT a, f FROM t5").Scan(&a, &f))
+	require.Equal(t, int32(7), a)
+	require.Nil(t, f)
+}
+
+// TestBindingShortParameterOIDsArray is a regression test for a defect found from
+// https://github.com/dolthub/doltgresql/issues/2973: Postgres allows a Parse message's
+// ParameterOIDs to specify types for only a prefix of the actual placeholders.
+func TestBindingShortParameterOIDsArray(t *testing.T) {
+	ctx, connection, controller := CreateServer(t, "postgres")
+	defer func() {
+		connection.Close(ctx)
+		controller.Stop()
+		require.NoError(t, controller.WaitForStop())
+	}()
+	conn := connection.Default
+
+	_, err := connection.Exec(ctx, "CREATE TABLE t6 (a INT, b INT);")
+	require.NoError(t, err)
+
+	args := [][]byte{[]byte(strconv.Itoa(1)), []byte(strconv.Itoa(2))}
+	// Only $1's OID is specified; $2 is omitted entirely rather than given an explicit 0.
+	paramOIDs := []uint32{pgtype.Int4OID}
+	paramFormats := []int16{0, 0}
+	sql := "INSERT INTO t6 (a, b) VALUES ($1, $2);"
+
+	resultReader := conn.PgConn().ExecParams(ctx, sql, args, paramOIDs, paramFormats, nil)
+	result := resultReader.Read()
+	require.NoError(t, result.Err)
+
+	var a, b int32
+	require.NoError(t, conn.QueryRow(ctx, "SELECT a, b FROM t6").Scan(&a, &b))
+	require.Equal(t, int32(1), a)
+	require.Equal(t, int32(2), b)
 }
 
 func TestIssue2386(t *testing.T) {
@@ -117,4 +349,83 @@ func TestBindingWithTextArray(t *testing.T) {
 	resultReader := conn.PgConn().ExecParams(ctx, sql, args, paramOIDs, paramFormats, nil)
 	result := resultReader.Read()
 	require.NoError(t, result.Err)
+}
+
+// TestBindingOnConflictDoUpdateWithUntypedNull tests bind var type inferrence for
+// ON CONFLICT DO UPDATE statements.
+func TestBindingOnConflictDoUpdateWithUntypedNull(t *testing.T) {
+	ctx, connection, controller := CreateServer(t, "postgres")
+	defer func() {
+		connection.Close(ctx)
+		controller.Stop()
+		require.NoError(t, controller.WaitForStop())
+	}()
+	conn := connection.Default
+
+	_, err := connection.Exec(ctx, "CREATE TABLE tconf (id INT PRIMARY KEY, a BIGINT, f BOOLEAN);")
+	require.NoError(t, err)
+	_, err = connection.Exec(ctx, "INSERT INTO tconf VALUES (1, 0, true);")
+	require.NoError(t, err)
+
+	aBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(aBytes, 42)
+
+	// $1 is explicitly int4 and assigned to a BIGINT column via ON CONFLICT DO UPDATE;
+	// $2 is an untyped NULL.
+	args := [][]byte{aBytes, nil}
+	paramOIDs := []uint32{pgtype.Int4OID, 0}
+	paramFormats := []int16{1, 1}
+	sql := "INSERT INTO tconf (id, a) VALUES (1, 0) ON CONFLICT (id) DO UPDATE SET a = $1, f = $2;"
+
+	resultReader := conn.PgConn().ExecParams(ctx, sql, args, paramOIDs, paramFormats, nil)
+	result := resultReader.Read()
+	require.NoError(t, result.Err)
+
+	var a int64
+	var f *bool
+	require.NoError(t, conn.QueryRow(ctx, "SELECT a, f FROM tconf WHERE id = 1").Scan(&a, &f))
+	require.Equal(t, int64(42), a)
+	require.Nil(t, f)
+}
+
+// TestBindingMultipleInferredAndExplicitOIDsInterleaved tests the OID-merge logic by interleaving
+// multiple unspecified (OID 0) positions with multiple explicit, narrower-than-column OIDs.
+func TestBindingMultipleInferredAndExplicitOIDsInterleaved(t *testing.T) {
+	ctx, connection, controller := CreateServer(t, "postgres")
+	defer func() {
+		connection.Close(ctx)
+		controller.Stop()
+		require.NoError(t, controller.WaitForStop())
+	}()
+	conn := connection.Default
+
+	_, err := connection.Exec(ctx, "CREATE TABLE t7 (a INT, b BIGINT, c INT, d DOUBLE PRECISION, e BOOLEAN);")
+	require.NoError(t, err)
+
+	bBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(bBytes, 22)
+	dBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(dBytes, math.Float32bits(4.5))
+
+	// $1 (-> a) and $3 (-> c) are unspecified (OID 0); $2 is explicit int4 targeting a BIGINT
+	// column, $4 is explicit float4 targeting a DOUBLE PRECISION column, $5 is an untyped NULL.
+	args := [][]byte{[]byte(strconv.Itoa(11)), bBytes, []byte(strconv.Itoa(33)), dBytes, nil}
+	paramOIDs := []uint32{0, pgtype.Int4OID, 0, pgtype.Float4OID, 0}
+	paramFormats := []int16{0, 1, 0, 1, 1}
+	sql := "INSERT INTO t7 (a, b, c, d, e) VALUES ($1, $2, $3, $4, $5);"
+
+	resultReader := conn.PgConn().ExecParams(ctx, sql, args, paramOIDs, paramFormats, nil)
+	result := resultReader.Read()
+	require.NoError(t, result.Err)
+
+	var a, c int32
+	var b int64
+	var d float64
+	var e *bool
+	require.NoError(t, conn.QueryRow(ctx, "SELECT a, b, c, d, e FROM t7").Scan(&a, &b, &c, &d, &e))
+	require.Equal(t, int32(11), a)
+	require.Equal(t, int64(22), b)
+	require.Equal(t, int32(33), c)
+	require.Equal(t, float64(4.5), d)
+	require.Nil(t, e)
 }

--- a/utils/wirerw.go
+++ b/utils/wirerw.go
@@ -17,6 +17,7 @@ package utils
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"math"
 )
 
@@ -83,21 +84,21 @@ func (rw *WireRW) ReadUint8() uint8 {
 
 // ReadUint16 reads a uint16.
 func (rw *WireRW) ReadUint16() uint16 {
-	data := rw.buf.Bytes()[rw.readIdx : rw.readIdx+2]
+	data := rw.sliceForRead(2)
 	rw.readIdx += 2
 	return binary.BigEndian.Uint16(data)
 }
 
 // ReadUint32 reads a uint32.
 func (rw *WireRW) ReadUint32() uint32 {
-	data := rw.buf.Bytes()[rw.readIdx : rw.readIdx+4]
+	data := rw.sliceForRead(4)
 	rw.readIdx += 4
 	return binary.BigEndian.Uint32(data)
 }
 
 // ReadUint64 reads a uint64.
 func (rw *WireRW) ReadUint64() uint64 {
-	data := rw.buf.Bytes()[rw.readIdx : rw.readIdx+8]
+	data := rw.sliceForRead(8)
 	rw.readIdx += 8
 	return binary.BigEndian.Uint64(data)
 }
@@ -119,9 +120,20 @@ func (rw *WireRW) ReadString(n uint32) string {
 
 // ReadBytes reads the next N bytes.
 func (rw *WireRW) ReadBytes(n uint32) []byte {
-	data := rw.buf.Bytes()[rw.readIdx : rw.readIdx+n]
+	data := rw.sliceForRead(n)
 	rw.readIdx += n
 	return data
+}
+
+// sliceForRead returns the next n unread bytes, explicitly checked against the buffer's actual
+// length rather than relying on Go's implicit slice-capacity check.
+func (rw *WireRW) sliceForRead(n uint32) []byte {
+	buf := rw.buf.Bytes()
+	if rw.readIdx+n > uint32(len(buf)) {
+		panic(fmt.Sprintf("wire reader: attempted to read %d bytes at offset %d, but only %d bytes are available",
+			n, rw.readIdx, len(buf)-int(rw.readIdx)))
+	}
+	return buf[rw.readIdx : rw.readIdx+n]
 }
 
 // WriteBool writes a 1-byte bool.

--- a/utils/wirerw.go
+++ b/utils/wirerw.go
@@ -126,12 +126,15 @@ func (rw *WireRW) ReadBytes(n uint32) []byte {
 }
 
 // sliceForRead returns the next n unread bytes, explicitly checked against the buffer's actual
-// length rather than relying on Go's implicit slice-capacity check.
+// length rather than relying on Go's implicit slice-capacity check. The check is done via
+// subtraction rather than rw.readIdx+n so that a near-maximum n can't wrap the uint32 addition
+// around and bypass the bounds check.
 func (rw *WireRW) sliceForRead(n uint32) []byte {
 	buf := rw.buf.Bytes()
-	if rw.readIdx+n > uint32(len(buf)) {
+	bufLen := uint32(len(buf))
+	if rw.readIdx > bufLen || n > bufLen-rw.readIdx {
 		panic(fmt.Sprintf("wire reader: attempted to read %d bytes at offset %d, but only %d bytes are available",
-			n, rw.readIdx, len(buf)-int(rw.readIdx)))
+			n, rw.readIdx, int(bufLen)-int(rw.readIdx)))
 	}
 	return buf[rw.readIdx : rw.readIdx+n]
 }

--- a/utils/wirerw_test.go
+++ b/utils/wirerw_test.go
@@ -17,7 +17,7 @@ package utils
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestWireRWReadPastEndPanicsWithDiagnostic asserts that reading more bytes than are available
@@ -26,19 +26,19 @@ import (
 func TestWireRWReadPastEndPanicsWithDiagnostic(t *testing.T) {
 	t.Run("ReadUint32 past end", func(t *testing.T) {
 		rw := NewWireReader([]byte{1, 2, 3})
-		require.PanicsWithValue(t,
+		assert.PanicsWithValue(t,
 			"wire reader: attempted to read 4 bytes at offset 0, but only 3 bytes are available",
 			func() { rw.ReadUint32() })
 	})
 	t.Run("ReadUint64 past end", func(t *testing.T) {
 		rw := NewWireReader([]byte{1, 2, 3, 4})
-		require.PanicsWithValue(t,
+		assert.PanicsWithValue(t,
 			"wire reader: attempted to read 8 bytes at offset 0, but only 4 bytes are available",
 			func() { rw.ReadUint64() })
 	})
 	t.Run("ReadBytes exactly at end succeeds", func(t *testing.T) {
 		rw := NewWireReader([]byte{1, 2, 3, 4})
-		require.Equal(t, []byte{1, 2, 3, 4}, rw.ReadBytes(4))
+		assert.Equal(t, []byte{1, 2, 3, 4}, rw.ReadBytes(4))
 	})
 }
 
@@ -48,9 +48,9 @@ func TestWireRWReadPastEndPanicsWithDiagnostic(t *testing.T) {
 func TestWireRWReadBytesWrappedLengthDoesNotOverflow(t *testing.T) {
 	rw := NewWireReader([]byte{1, 2, 3, 4, 5})
 	// Consume one valid prefix byte so readIdx is nonzero
-	require.Equal(t, uint8(1), rw.ReadUint8())
+	assert.Equal(t, uint8(1), rw.ReadUint8())
 
-	require.PanicsWithValue(t,
+	assert.PanicsWithValue(t,
 		"wire reader: attempted to read 4294967295 bytes at offset 1, but only 4 bytes are available",
 		func() { rw.ReadBytes(4294967295) })
 }

--- a/utils/wirerw_test.go
+++ b/utils/wirerw_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWireRWReadPastEndPanicsWithDiagnostic asserts that reading more bytes than are available
+// panics with a message naming the requested length, offset, and available bytes, rather than a
+// generic Go slice-bounds error.
+func TestWireRWReadPastEndPanicsWithDiagnostic(t *testing.T) {
+	t.Run("ReadUint32 past end", func(t *testing.T) {
+		rw := NewWireReader([]byte{1, 2, 3})
+		require.PanicsWithValue(t,
+			"wire reader: attempted to read 4 bytes at offset 0, but only 3 bytes are available",
+			func() { rw.ReadUint32() })
+	})
+	t.Run("ReadUint64 past end", func(t *testing.T) {
+		rw := NewWireReader([]byte{1, 2, 3, 4})
+		require.PanicsWithValue(t,
+			"wire reader: attempted to read 8 bytes at offset 0, but only 4 bytes are available",
+			func() { rw.ReadUint64() })
+	})
+	t.Run("ReadBytes exactly at end succeeds", func(t *testing.T) {
+		rw := NewWireReader([]byte{1, 2, 3, 4})
+		require.Equal(t, []byte{1, 2, 3, 4}, rw.ReadBytes(4))
+	})
+}
+
+// TestWireRWReadBytesWrappedLengthDoesNotOverflow is a regression test for a near-maximum
+// declared length (0xffffffff) wrapping the uint32 readIdx+n bounds check around to a small
+// value and not correctly detecting the invalid data.
+func TestWireRWReadBytesWrappedLengthDoesNotOverflow(t *testing.T) {
+	rw := NewWireReader([]byte{1, 2, 3, 4, 5})
+	// Consume one valid prefix byte so readIdx is nonzero
+	require.Equal(t, uint8(1), rw.ReadUint8())
+
+	require.PanicsWithValue(t,
+		"wire reader: attempted to read 4294967295 bytes at offset 1, but only 4 bytes are available",
+		func() { rw.ReadBytes(4294967295) })
+}


### PR DESCRIPTION
When a client indicates that a bind var's type is unspecified, the Postgres-compatible server should infer its type. Doltgres was incorrectly throwing away all provided type information if any bind var type wasn't specified, which resulted in Doltgres choosing a different type than the client was using. This further resulted in incorrect data being written to the table, since Doltgres misunderstood the type and read extra data that wasn't intended for that bind var. 

The main fix is to only infer the type for the individual bind vars that aren't specified, not for all bind vars. Additionally, the buffer reading code was changed to error out loudly if it encountered a future issue where the amount of expected bytes isn't present. 

Related to https://github.com/dolthub/doltgresql/issues/2973