### PR TITLE
Allow aliasing columns in a table function

### DIFF
--- a/server/analyzer/transform_record_filter.go
+++ b/server/analyzer/transform_record_filter.go
@@ -51,6 +51,9 @@ func TransformRecordFilter(
 		default:
 			return n, transform.SameTree, nil
 		}
+		if tblNode == nil {
+			return n, transform.SameTree, nil
+		}
 		// TODO: should only convert expressions when there's applicable index
 		if _, ok = tblNode.UnderlyingTable().(sql.IndexAddressableTable); !ok {
 			return n, transform.SameTree, nil

--- a/server/ast/select_clause.go
+++ b/server/ast/select_clause.go
@@ -127,7 +127,7 @@ PostJoinRewrite:
 			if !aliasedTableExpr.Lateral &&
 				aliasedTableExpr.Hints == nil &&
 				len(aliasedTableExpr.Partitions) == 0 &&
-				ok && len(subquery.Columns) == 0 {
+				ok {
 				// If this is true, then we can confirm that it's just a wrapper (and not an explicit AliasedTableExpr).
 				// This may seem like a lot of fragile checks, but AliasedTableExpr explicitly sets its state to this in
 				// this circumstance. We do not want to create a TableFuncExpr except under very specific circumstances.
@@ -148,9 +148,10 @@ PostJoinRewrite:
 									}
 								}
 								from[i] = &vitess.TableFuncExpr{
-									Name:  funcExpr.Name.String(),
-									Exprs: funcExpr.Exprs,
-									Alias: aliasedTableExpr.As,
+									Name:    funcExpr.Name.String(),
+									Exprs:   funcExpr.Exprs,
+									Alias:   aliasedTableExpr.As,
+									Columns: subquery.Columns,
 								}
 							}
 						}

--- a/server/functions/regproc.go
+++ b/server/functions/regproc.go
@@ -56,18 +56,27 @@ var regprocin = framework.Function1{
 		if err = regproc_IoInputValidation(ctx, input, sections); err != nil {
 			return id.Null, err
 		}
+		var funcName string
 		switch len(sections) {
 		case 1:
-			// TODO: handle procedures, aggregate functions, and window functions
-			// TODO: this only handles built-in functions
-			funcInterfaces := framework.Catalog[sections[0]]
-			if len(funcInterfaces) == 1 {
-				return funcInterfaces[0].InternalID(), nil
+			funcName = sections[0]
+		case 3:
+			// TODO: All built-in functions are cataloged under pg_catalog; there's no support yet
+			// for resolving functions in other schemas (e.g. user-defined functions)
+			if sections[0] != "pg_catalog" {
+				return id.Null, errors.Errorf(`function "%s" does not exist`, input)
 			}
-			return id.Null, errors.Errorf(`"function "%s" does not exist"`, input)
+			funcName = sections[2]
 		default:
 			return id.Null, errors.Errorf("regproc failed validation")
 		}
+		// TODO: handle procedures, aggregate functions, and window functions
+		// TODO: this only handles built-in functions
+		funcInterfaces := framework.Catalog[funcName]
+		if len(funcInterfaces) == 1 {
+			return funcInterfaces[0].InternalID(), nil
+		}
+		return id.Null, errors.Errorf(`function "%s" does not exist`, input)
 	},
 }
 
@@ -129,7 +138,7 @@ func regproc_IoInputValidation(ctx *sql.Context, input string, sections []string
 		if sections[1] != "." {
 			return errors.Errorf("invalid name syntax")
 		}
-		return errors.Errorf("functions are not yet implemented in terms of the schema")
+		return nil
 	case 5:
 		if sections[1] != "." || sections[3] != "." {
 			return errors.Errorf("invalid name syntax")

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -4219,6 +4219,68 @@ func TestSetReturningFunctions(t *testing.T) {
 				},
 			},
 			{
+				Name: "generate_series as table function with column alias",
+				Assertions: []ScriptTestAssertion{
+					{
+						Query:            `SELECT * FROM generate_series(1,3) AS s(r)`,
+						Expected:         []sql.Row{{1}, {2}, {3}},
+						ExpectedColNames: []string{"r"},
+					},
+					{
+						Query:    `SELECT r FROM generate_series(1,3) AS s(r)`,
+						Expected: []sql.Row{{1}, {2}, {3}},
+					},
+					{
+						Query:    `SELECT r + 1 FROM generate_series(1,3) AS s(r) WHERE r > 1`,
+						Expected: []sql.Row{{3}, {4}},
+					},
+					{
+						Query:            `SELECT * FROM generate_series(1, array_upper(current_schemas(false), 1)) AS s(r)`,
+						Expected:         []sql.Row{{1}},
+						ExpectedColNames: []string{"r"},
+					},
+				},
+			},
+			{
+				// Regression test for query used by DBeaver
+				Name: "generate_series as table function used in pgJDBC-style enum catalog query",
+				SetUpScript: []string{
+					"CREATE TYPE status_enum AS ENUM ('one', 'two', 'three');",
+					"CREATE TABLE test1 (id INT, status status_enum);",
+					"INSERT INTO test1 VALUES (1, 'one'), (2, 'two'), (3, 'three');",
+				},
+				Assertions: []ScriptTestAssertion{
+					{
+						Query: `SELECT
+    typinput = 'pg_catalog.array_in'::regproc AS is_array,
+    typtype,
+    typname
+FROM pg_catalog.pg_type
+LEFT JOIN (
+    SELECT ns.oid AS nspoid, ns.nspname, r.r
+    FROM pg_namespace AS ns
+    JOIN (
+        SELECT
+            s.r,
+            (current_schemas(false))[s.r] AS nspname
+        FROM generate_series(
+            1,
+            array_upper(current_schemas(false), 1)
+        ) AS s(r)
+    ) AS r USING (nspname)
+) AS sp ON sp.nspoid = typnamespace
+WHERE pg_type.oid = (
+    SELECT atttypid
+    FROM pg_attribute
+    WHERE attrelid = 'test1'::regclass
+      AND attname = 'status'
+)
+ORDER BY sp.r, pg_type.oid DESC;`,
+						Expected: []sql.Row{{"f", "e", "status_enum"}},
+					},
+				},
+			},
+			{
 				Name: "nested generate_series",
 				// Nested SRF expressions cause an infinite loop, skipped in regression tests.
 				// Challenging to fix with the current expression eval architecture and very marginal as a use case.

--- a/testing/go/types_test.go
+++ b/testing/go/types_test.go
@@ -2547,6 +2547,28 @@ var typesTests = []ScriptTest{
 				Query:       `SELECT '""acos'::regproc;`,
 				ExpectedErr: "invalid name syntax",
 			},
+			{
+				Query: `SELECT 'pg_catalog.acos'::regproc;`,
+				Expected: []sql.Row{
+					{"acos"},
+				},
+			},
+			{
+				Query: `SELECT typinput = 'pg_catalog.array_in'::regproc FROM pg_catalog.pg_type WHERE typname = 'int4';`,
+				Expected: []sql.Row{
+					{"f"},
+				},
+			},
+			{
+				Query: `SELECT typinput = 'pg_catalog.array_in'::regproc FROM pg_catalog.pg_type WHERE typname = '_int4';`,
+				Expected: []sql.Row{
+					{"t"},
+				},
+			},
+			{
+				Query:       `SELECT 'public.acos'::regproc;`,
+				ExpectedErr: "does not exist",
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Allows aliasing the column names of a table function, such as: `SELECT * FROM generate_series(1,3) AS s(r)`.

Also enables `regproc` to work with schema-qualified procedures. 

Both of these gaps were found while fixing a gap to enable DBeaver to work correctly with Doltgres. 

Depends on: 
* https://github.com/dolthub/vitess/pull/477
* https://github.com/dolthub/go-mysql-server/pull/3652