### PR TITLE
Re-enable replication tests on MacOS

### DIFF
--- a/.github/workflows/ci-go-sql-server-driver.yaml
+++ b/.github/workflows/ci-go-sql-server-driver.yaml
@@ -16,9 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04 ]
-# TODO: failing on MacOS due to races in syncig the default postgres db with no writes        
-#       os: [ ubuntu-22.04, macos-latest ]
+        os: [ ubuntu-22.04, macos-latest ]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Go
@@ -48,5 +46,13 @@ jobs:
           echo "DOLTGRES_BIN_PATH=$(pwd)/.ci_bin/doltgres" >> $GITHUB_ENV
       - name: Test Go SQL Server Driver
         working-directory: ./integration-tests/go-sql-server-driver
+        env:
+          # On macOS runners, grpc-go's DNS resolver blocks on a TXT
+          # service-config lookup (_grpc_config.localhost) that the runner's
+          # DNS drops, stalling cluster replication channels for up to 30s
+          # (grpc's ResolvingTimeout) and starving the 10s graceful-transition
+          # budget. The doltgres servers spawned by the test harness inherit
+          # this env var, which disables the TXT lookup.
+          GRPC_ENABLE_TXT_SERVICE_CONFIG: "false"
         run: |
           go test --timeout=20m ./...

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster-read-only.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster-read-only.yaml
@@ -11,7 +11,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -27,7 +27,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -53,7 +53,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -69,7 +69,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -93,7 +93,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -109,7 +109,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -140,7 +140,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -156,7 +156,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster-users-and-grants.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster-users-and-grants.yaml
@@ -11,7 +11,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -27,7 +27,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -72,7 +72,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -88,7 +88,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -190,7 +190,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -206,7 +206,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -261,7 +261,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -277,7 +277,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -330,9 +330,9 @@ tests:
         cluster:
           standby_remotes:
           - name: standby1
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           - name: standby2
-            remote_url_template: http://localhost:{{get_port "server3_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server3_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -348,9 +348,9 @@ tests:
         cluster:
           standby_remotes:
           - name: standby1
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           - name: standby2
-            remote_url_template: http://localhost:{{get_port "server3_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server3_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -366,9 +366,9 @@ tests:
         cluster:
           standby_remotes:
           - name: standby1
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           - name: standby2
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -29,11 +29,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: standby_server.yaml
       contents: |
@@ -41,7 +41,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
@@ -52,7 +52,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 15
           remotesapi:
@@ -92,11 +92,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -104,7 +104,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
@@ -166,11 +166,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -178,7 +178,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -194,7 +194,7 @@ tests:
     - query: "select name, url from dolt_remotes"
       result:
         columns: ["name","url"]
-        rows: [["standby","http://localhost:{{get_port \"server2_cluster\"}}/a_new_database"]]
+        rows: [["standby","http://127.0.0.1:{{get_port \"server2_cluster\"}}/a_new_database"]]
 - name: primary comes up and replicates to standby
   multi_repos:
   - name: server1
@@ -202,11 +202,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -214,7 +214,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -227,11 +227,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -239,7 +239,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
@@ -282,11 +282,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: standby_server.yaml
       contents: |
@@ -294,7 +294,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
@@ -315,11 +315,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -327,7 +327,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -347,11 +347,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -359,7 +359,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -372,11 +372,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -384,7 +384,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -454,11 +454,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: standby_server.yaml
       contents: |
@@ -466,7 +466,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
@@ -499,11 +499,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -511,7 +511,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -524,11 +524,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -536,7 +536,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 10
           remotesapi:
@@ -571,11 +571,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -583,7 +583,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -596,11 +596,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -608,7 +608,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -644,11 +644,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: preserver.yaml
       contents: |
@@ -659,7 +659,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 15
           remotesapi:
@@ -672,11 +672,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: preserver.yaml
       contents: |
@@ -687,7 +687,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -747,11 +747,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: preserver.yaml
       contents: |
@@ -762,7 +762,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -775,11 +775,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server1_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server1_cluster"}}/repo2
     with_files:
     - name: preserver.yaml
       contents: |
@@ -790,7 +790,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 15
           remotesapi:
@@ -856,11 +856,11 @@ tests:
     - name: repo1
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo1
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo1
     - name: repo2
       with_remotes:
       - name: standby
-        url: http://localhost:{{get_port "server2_cluster"}}/repo2
+        url: http://127.0.0.1:{{get_port "server2_cluster"}}/repo2
     with_files:
     - name: server.yaml
       contents: |
@@ -868,7 +868,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 10
           remotesapi:
@@ -894,7 +894,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -910,7 +910,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -945,7 +945,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -961,7 +961,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -990,7 +990,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1006,7 +1006,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1073,7 +1073,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1089,7 +1089,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1136,7 +1136,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1152,7 +1152,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1197,7 +1197,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1213,7 +1213,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1342,7 +1342,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1371,7 +1371,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1387,7 +1387,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1440,7 +1440,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1459,7 +1459,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1512,7 +1512,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1528,7 +1528,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1604,7 +1604,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1620,7 +1620,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1667,7 +1667,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1683,7 +1683,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1764,7 +1764,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1780,7 +1780,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1818,7 +1818,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby_one
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1829,9 +1829,9 @@ tests:
         cluster:
           standby_remotes:
           - name: standby_one
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           - name: standby_two
-            remote_url_template: http://localhost:{{get_port "server3_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server3_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1847,7 +1847,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1863,7 +1863,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1909,7 +1909,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1925,7 +1925,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -1974,7 +1974,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -1990,7 +1990,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:
@@ -2108,7 +2108,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -2126,7 +2126,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-cluster.yaml
@@ -2187,3 +2187,272 @@ tests:
       result:
         columns: ['read_only']
         rows: [['1']]
+- name: postgres default database replicates to standby
+  multi_repos:
+  - name: server1
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
+          bootstrap_role: primary
+          bootstrap_epoch: 1
+          remotesapi:
+            port: {{get_port "server1_cluster"}}
+    server:
+      args: ["--config", "server.yaml"]
+      dynamic_port: server1
+  - name: server2
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
+          bootstrap_role: standby
+          bootstrap_epoch: 1
+          remotesapi:
+            port: {{get_port "server2_cluster"}}
+    server:
+      args: ["--config", "server.yaml"]
+      dynamic_port: server2
+  connections:
+  - on: server1
+    queries:
+    - exec: 'SET dolt_cluster_ack_writes_timeout_secs = 60'
+    - exec: 'CREATE TABLE vals (i INT PRIMARY KEY)'
+    - exec: 'INSERT INTO vals VALUES (0),(1),(2),(3),(4)'
+  - on: server2
+    queries:
+    - query: 'SELECT count(*) FROM vals'
+      result:
+        columns: ["count"]
+        rows: [["5"]]
+- name: postgres default database on booted standby is read only
+  multi_repos:
+  - name: server1
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
+          bootstrap_role: primary
+          bootstrap_epoch: 1
+          remotesapi:
+            port: {{get_port "server1_cluster"}}
+    server:
+      args: ["--config", "server.yaml"]
+      dynamic_port: server1
+  - name: server2
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
+          bootstrap_role: standby
+          bootstrap_epoch: 1
+          remotesapi:
+            port: {{get_port "server2_cluster"}}
+    server:
+      args: ["--config", "server.yaml"]
+      dynamic_port: server2
+  connections:
+  - on: server1
+    queries:
+    - exec: 'SET dolt_cluster_ack_writes_timeout_secs = 60'
+    - exec: 'CREATE TABLE vals (i INT PRIMARY KEY)'
+    - exec: 'INSERT INTO vals VALUES (0),(1),(2)'
+  - on: server2
+    queries:
+    - query: 'SELECT count(*) FROM vals'
+      result:
+        columns: ["count"]
+        rows: [["3"]]
+    - exec: 'INSERT INTO vals VALUES (3)'
+      error_match: "postgres is read-only"
+- name: postgres default database survives failover
+  multi_repos:
+  - name: server1
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
+          bootstrap_role: primary
+          bootstrap_epoch: 1
+          remotesapi:
+            port: {{get_port "server1_cluster"}}
+    server:
+      args: ["--config", "server.yaml"]
+      dynamic_port: server1
+  - name: server2
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
+          bootstrap_role: standby
+          bootstrap_epoch: 1
+          remotesapi:
+            port: {{get_port "server2_cluster"}}
+    server:
+      args: ["--config", "server.yaml"]
+      dynamic_port: server2
+  connections:
+  - on: server1
+    queries:
+    - exec: 'SET dolt_cluster_ack_writes_timeout_secs = 60'
+    - exec: 'CREATE TABLE vals (i INT PRIMARY KEY)'
+    - exec: 'INSERT INTO vals VALUES (1),(2),(3)'
+  # Fail over gracefully: demote the primary first, then promote the standby.
+  - on: server1
+    queries:
+    - query: "select dolt_assume_cluster_role('standby', 2)"
+      result:
+        columns: ["dolt_assume_cluster_role"]
+        rows: [["{0}"]]
+  - on: server2
+    queries:
+    - query: "select dolt_assume_cluster_role('primary', 2)"
+      result:
+        columns: ["dolt_assume_cluster_role"]
+        rows: [["{0}"]]
+  - on: server2
+    queries:
+    - exec: 'SET dolt_cluster_ack_writes_timeout_secs = 60'
+    - query: 'SELECT count(*) FROM vals'
+      result:
+        columns: ["count"]
+        rows: [["3"]]
+    - exec: 'INSERT INTO vals VALUES (4),(5)'
+  - on: server1
+    queries:
+    - query: 'SELECT count(*) FROM vals'
+      result:
+        columns: ["count"]
+        rows: [["5"]]
+- name: postgres default database replication status
+  multi_repos:
+  - name: server1
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
+          bootstrap_role: primary
+          bootstrap_epoch: 1
+          remotesapi:
+            port: {{get_port "server1_cluster"}}
+    server:
+      args: ["--config", "server.yaml"]
+      dynamic_port: server1
+  - name: server2
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
+          bootstrap_role: standby
+          bootstrap_epoch: 1
+          remotesapi:
+            port: {{get_port "server2_cluster"}}
+    server:
+      args: ["--config", "server.yaml"]
+      dynamic_port: server2
+  connections:
+  - on: server1
+    queries:
+    - exec: 'SET dolt_cluster_ack_writes_timeout_secs = 60'
+    - exec: 'CREATE TABLE vals (i INT PRIMARY KEY)'
+    - exec: 'INSERT INTO vals VALUES (0),(1),(2)'
+  - on: server1
+    database: dolt_cluster
+    queries:
+    - query: "select \"database\", standby_remote, role, epoch, replication_lag_millis, current_error from dolt_cluster_status order by \"database\" asc"
+      result:
+        columns: ["database","standby_remote","role","epoch","replication_lag_millis","current_error"]
+        rows:
+        - ["postgres","standby","primary","1","0","NULL"]
+- name: postgres default database sequence val maintained across failover
+  multi_repos:
+  - name: server1
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
+          bootstrap_role: primary
+          bootstrap_epoch: 1
+          remotesapi:
+            port: {{get_port "server1_cluster"}}
+    server:
+      args: ["--config", "server.yaml"]
+      dynamic_port: server1
+  - name: server2
+    with_files:
+    - name: server.yaml
+      contents: |
+        log_level: trace
+        cluster:
+          standby_remotes:
+          - name: standby
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
+          bootstrap_role: standby
+          bootstrap_epoch: 1
+          remotesapi:
+            port: {{get_port "server2_cluster"}}
+    server:
+      args: ["--config", "server.yaml"]
+      dynamic_port: server2
+  connections:
+  - on: server1
+    queries:
+    - exec: 'SET dolt_cluster_ack_writes_timeout_secs = 60'
+    - exec: 'CREATE TABLE t (id SERIAL PRIMARY KEY, v INT)'
+    - exec: 'INSERT INTO t(v) VALUES (0),(0),(0),(0),(0)'
+  - on: server2
+    queries:
+    - query: 'SELECT * FROM t ORDER BY id'
+      result:
+        columns: ['id', 'v']
+        rows: [['1','0'], ['2','0'], ['3','0'], ['4','0'], ['5','0']]
+  - on: server1
+    queries:
+    - exec: "select dolt_assume_cluster_role('standby', 2)"
+  - on: server2
+    queries:
+    - exec: "select dolt_assume_cluster_role('primary', 2)"
+  - on: server2
+    queries:
+    - exec: 'SET dolt_cluster_ack_writes_timeout_secs = 60'
+    - exec: 'INSERT INTO t(v) VALUES (1)'
+    - query: 'SELECT * FROM t ORDER BY id'
+      result:
+        columns: ['id', 'v']
+        rows: [['1','0'], ['2','0'], ['3','0'], ['4','0'], ['5','0'], ['6','1']]

--- a/integration-tests/go-sql-server-driver/tests/sql-server-large-blob-replication.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-large-blob-replication.yaml
@@ -19,7 +19,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -37,7 +37,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-large-json-replication.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-large-json-replication.yaml
@@ -19,7 +19,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -37,7 +37,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-large-multi-column-replication.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-large-multi-column-replication.yaml
@@ -20,7 +20,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -38,7 +38,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-large-text-replication.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-large-text-replication.yaml
@@ -18,7 +18,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -36,7 +36,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-large-values-failover.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-large-values-failover.yaml
@@ -15,7 +15,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -34,7 +34,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-large-values-gc.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-large-values-gc.yaml
@@ -15,7 +15,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -34,7 +34,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-remotesapi.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-remotesapi.yaml
@@ -37,7 +37,7 @@ tests:
   - on: server2
     queries:
     - exec: "use repo1"
-    - exec: "select dolt_clone('http://localhost:{{get_port \"remotesapi_port\"}}/repo2')"
+    - exec: "select dolt_clone('http://127.0.0.1:{{get_port \"remotesapi_port\"}}/repo2')"
     - exec: "use repo2"
     - query: "select count(*) from vals"
       result:
@@ -86,7 +86,7 @@ tests:
   - on: server2
     queries:
     - exec: "use repo1"
-    - exec: "select dolt_clone('http://localhost:{{get_port \"remotesapi_port\"}}/repo2')"
+    - exec: "select dolt_clone('http://127.0.0.1:{{get_port \"remotesapi_port\"}}/repo2')"
     - exec: "use repo2"
     - query: "select count(*) from vals"
       result:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-type-diversity.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-type-diversity.yaml
@@ -28,7 +28,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -46,7 +46,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-wide-int-table.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-wide-int-table.yaml
@@ -15,7 +15,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -34,7 +34,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-wide-table-failover.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-wide-table-failover.yaml
@@ -15,7 +15,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -34,7 +34,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-wide-text-table.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-wide-text-table.yaml
@@ -15,7 +15,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -34,7 +34,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/integration-tests/go-sql-server-driver/tests/sql-server-wide-varchar-table.yaml
+++ b/integration-tests/go-sql-server-driver/tests/sql-server-wide-varchar-table.yaml
@@ -15,7 +15,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server2_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server2_cluster"}}/{database}
           bootstrap_role: primary
           bootstrap_epoch: 1
           remotesapi:
@@ -34,7 +34,7 @@ tests:
         cluster:
           standby_remotes:
           - name: standby
-            remote_url_template: http://localhost:{{get_port "server1_cluster"}}/{database}
+            remote_url_template: http://127.0.0.1:{{get_port "server1_cluster"}}/{database}
           bootstrap_role: standby
           bootstrap_epoch: 1
           remotesapi:

--- a/server/connection_handler.go
+++ b/server/connection_handler.go
@@ -306,10 +306,12 @@ func (h *ConnectionHandler) chooseInitialParameters(startupMessage *pgproto3.Sta
 			}
 		}
 	}
-	// set initial database
+	// Set the initial database. Postgres has no concept of a session without a current database: if the client
+	// doesn't specify one, it defaults to the username (matching libpq). Either way, if the resolved database
+	// doesn't exist we must reject the connection rather than proceed with a database-less session, which would
+	// break assumptions throughout the engine.
 	db, ok := startupMessage.Parameters["database"]
-	dbSpecified := ok && len(db) > 0
-	if !dbSpecified {
+	if !ok || len(db) == 0 {
 		db = h.mysqlConn.User
 	}
 	useStmt := fmt.Sprintf("SET database TO '%s';", db)
@@ -321,13 +323,11 @@ func (h *ConnectionHandler) chooseInitialParameters(startupMessage *pgproto3.Sta
 	err = h.doltgresHandler.ComQuery(context.Background(), h.mysqlConn, useStmt, parsed, func(_ *sql.Context, _ *Result) error {
 		return nil
 	})
-	// If a database isn't specified, then we attempt to connect to a database with the same name as the user,
-	// ignoring any error
-	if err != nil && dbSpecified {
+	if err != nil {
 		_ = h.send(&pgproto3.ErrorResponse{
 			Severity: string(ErrorResponseSeverity_Fatal),
 			Code:     "3D000",
-			Message:  fmt.Sprintf(`"database "%s" does not exist"`, db),
+			Message:  fmt.Sprintf(`database "%s" does not exist`, db),
 			Routine:  "InitPostgres",
 		})
 		return err


### PR DESCRIPTION
GitHub MacOS runners can take a long time to do DNS lookups, even for localhost, which was the root cause of the races on that platform. All are now changed to the loopback IP.

Also fixes an unrelated bug: connections that default to a DB with the same name as a user are now rejected if that DB doesn't exist.