### PR TITLE
pointer comparison for `DoltgresType.Equals()`

### DIFF
--- a/server/types/type.go
+++ b/server/types/type.go
@@ -607,10 +607,14 @@ func (t *DoltgresType) DomainUnderlyingBaseType() *DoltgresType {
 
 // Equals implements the types.ExtendedType interface.
 func (t *DoltgresType) Equals(otherType sql.Type) bool {
-	if otherExtendedType, ok := otherType.(*DoltgresType); ok {
-		return bytes.Equal(t.Serialize(), otherExtendedType.Serialize())
+	otherExtendedType, ok := otherType.(*DoltgresType)
+	if !ok {
+		return false
 	}
-	return false
+	if t == otherExtendedType {
+		return true
+	}
+	return bytes.Equal(t.Serialize(), otherExtendedType.Serialize())
 }
 
 // FormatValue implements the types.ExtendedType interface. Callers with


### PR DESCRIPTION
Compare the pointers to the `DoltgresType`s before comparing their Serialized bytes, because they are the same most of the time.