### PR TITLE
Add regression tests for bindvar type inference with `#>>` operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dolthub/dolt/go v0.40.5-0.20260803164215-b8d454fa4bd6
 	github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.20.1-0.20260731205841-0addd7496c93
+	github.com/dolthub/go-mysql-server v0.20.1-0.20260803203407-e49664d6062c
 	github.com/dolthub/pg_query_go/v6 v6.0.0-20251215122834-fb20be4254d1
 	github.com/dolthub/sqllogictest/go v0.0.0-20260624223518-788480b24166
 	github.com/dolthub/vitess v0.0.0-20260728212736-0542037326d7

--- a/go.sum
+++ b/go.sum
@@ -258,6 +258,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83 h1:FEMjCGEroD
 github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260731205841-0addd7496c93 h1:FieO3CB9RC6sPlAinYSKPJuLidccy1x5mNmknnmoCD8=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260731205841-0addd7496c93/go.mod h1:9GLxpglhedopzqBGpW0PGrw7UlwG5kBIOepE2QfTQ1s=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260803203407-e49664d6062c h1:LBB80tYm5hGinPy0uI0szGgeknqpJ0HEBDT95Sgp8GY=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260803203407-e49664d6062c/go.mod h1:9GLxpglhedopzqBGpW0PGrw7UlwG5kBIOepE2QfTQ1s=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20260414231531-5f031e3e9037 h1:oIW9HwuWrhxv+4HZxA+QQSKHLqWFyXZ2FmNjUYwkdiM=

--- a/testing/go/binding_test.go
+++ b/testing/go/binding_test.go
@@ -430,3 +430,34 @@ func TestBindingMultipleInferredAndExplicitOIDsInterleaved(t *testing.T) {
 	assert.Equal(t, float64(4.5), d)
 	assert.Nil(t, e)
 }
+
+// TestBindingJSONBExtractPathTextWithUntypedParam tests that an untyped parameter
+// compared against the result of `jsonb #>> text[]` is correctly inferred as JSONB (not TEXT).
+// https://github.com/dolthub/doltgresql/issues/3012.
+func TestBindingJSONBExtractPathTextWithUntypedParam(t *testing.T) {
+	ctx, connection, controller := CreateServer(t, "postgres")
+	defer func() {
+		connection.Close(ctx)
+		controller.Stop()
+		require.NoError(t, controller.WaitForStop())
+	}()
+	conn := connection.Default
+
+	_, err := connection.Exec(ctx, "CREATE TABLE t8 (id TEXT PRIMARY KEY, props JSONB);")
+	require.NoError(t, err)
+	_, err = connection.Exec(ctx, `INSERT INTO t8 VALUES ('a', '{"name":"Alice"}');`)
+	require.NoError(t, err)
+
+	// $1 is untyped (OID 0) and must be inferred as text, since `#>>` returns text even
+	// though its left operand (props) is jsonb.
+	args := [][]byte{[]byte("Alice")}
+	paramOIDs := []uint32{0}
+	paramFormats := []int16{0}
+	sql := "SELECT count(*) FROM t8 WHERE props #>> array['name']::text[] = $1"
+
+	resultReader := conn.PgConn().ExecParams(ctx, sql, args, paramOIDs, paramFormats, nil)
+	result := resultReader.Read()
+	require.NoError(t, result.Err)
+	require.Len(t, result.Rows, 1)
+	assert.Equal(t, "1", string(result.Rows[0][0]))
+}


### PR DESCRIPTION
Fixes: https://github.com/dolthub/doltgresql/issues/3012

Depends on: https://github.com/dolthub/go-mysql-server/pull/3663