### PR TITLE
Add native `ntile()`, `nth_value()`, and `cume_dist()` window functions

### DIFF
--- a/server/analyzer/init.go
+++ b/server/analyzer/init.go
@@ -144,6 +144,13 @@ var postgresOnlyAggregateFuncNames = map[string]bool{
 	"bool_or":   true,
 }
 
+// postgresOnlyWindowFuncNames holds Postgres functions that may only be used as window functions (i.e.
+// within an OVER(...) clause) with no MySQL equivalent and no GROUP BY aggregate form.
+var postgresOnlyWindowFuncNames = map[string]bool{
+	"cume_dist": true,
+	"nth_value": true,
+}
+
 // IsAggregateFunc checks if the given function name is an aggregate function. This is the entire set supported by
 // MySQL plus some postgres specific ones.
 func IsAggregateFunc(name string) bool {
@@ -153,7 +160,7 @@ func IsAggregateFunc(name string) bool {
 // IsWindowFunc checks if the given function name is a window function. This is the entire set supported by
 // MySQL plus some postgres specific ones.
 func IsWindowFunc(name string) bool {
-	return planbuilder.IsMySQLWindowFuncName(name) || postgresOnlyAggregateFuncNames[name]
+	return planbuilder.IsMySQLWindowFuncName(name) || postgresOnlyAggregateFuncNames[name] || postgresOnlyWindowFuncNames[name]
 }
 
 // insertAnalyzerRules inserts the given rule(s) before or after the given analyzer.RuleId, returning an updated slice.

--- a/server/functions/framework/catalog.go
+++ b/server/functions/framework/catalog.go
@@ -106,9 +106,9 @@ func RegisterWindowFunction(f WindowFunctionInterface) {
 	if initializedFunctions {
 		panic("attempted to register a function after the init() phase")
 	}
-	switch f := f.(type) {
-	case Func0Window:
-		name := strings.ToLower(f.Name)
+	switch f.(type) {
+	case Func0Window, Func1Window, Func2Window:
+		name := strings.ToLower(f.GetName())
 		WindowCatalog[name] = append(WindowCatalog[name], f)
 	default:
 		panic(fmt.Sprintf("unhandled function type %T", f))

--- a/server/functions/framework/compiled_window_function.go
+++ b/server/functions/framework/compiled_window_function.go
@@ -149,6 +149,13 @@ func (c *CompiledWindowFunction) WithId(id sql.ColumnId) sql.IdExpression {
 
 // NewWindowFunction implements the interface sql.WindowAdaptableExpression.
 func (c *CompiledWindowFunction) NewWindowFunction(ctx *sql.Context) (sql.WindowFunction, error) {
+	// c.window is only ever nil when WithWindow was called with a nil *sql.WindowDefinition, which the
+	// planbuilder does exactly when the call has no OVER clause at all (an empty `OVER ()` still produces a
+	// non-nil, zero-value definition). Window-only functions like cume_dist() have no scalar evaluation path,
+	// so without this check a bare call reaches GMS's windowToIter with a nil window and panics.
+	if c.window == nil {
+		return nil, cerrors.Errorf("window function %s() requires an OVER clause", c.Name)
+	}
 	fn, err := c.windowOverload()
 	if err != nil {
 		return nil, err

--- a/server/functions/framework/functions.go
+++ b/server/functions/framework/functions.go
@@ -704,3 +704,29 @@ func (f Func0Window) NewWindowFunc() NewWindowFunctionFn {
 		return f.NewWinFunc(window)
 	}
 }
+
+// Func1Window is a PostgreSQL function that takes one parameter and may only be used as a window function
+// (within an OVER(...) clause), such as ntile().
+type Func1Window struct {
+	Function1
+	NewWinFunc NewWindowFunctionFn
+}
+
+var _ WindowFunctionInterface = Func1Window{}
+
+func (f Func1Window) NewWindowFunc() NewWindowFunctionFn {
+	return f.NewWinFunc
+}
+
+// Func2Window is a PostgreSQL function that takes two parameters and may only be used as a window function
+// (within an OVER(...) clause), such as nth_value().
+type Func2Window struct {
+	Function2
+	NewWinFunc NewWindowFunctionFn
+}
+
+var _ WindowFunctionInterface = Func2Window{}
+
+func (f Func2Window) NewWindowFunc() NewWindowFunctionFn {
+	return f.NewWinFunc
+}

--- a/server/functions/window/cume_dist.go
+++ b/server/functions/window/cume_dist.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package window
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// cumeDist represents the PostgreSQL cume_dist() window function.
+var cumeDist = framework.Func0Window{
+	Function0: framework.Function0{
+		Name:   "cume_dist",
+		Return: pgtypes.Float64,
+	},
+	NewWinFunc: newCumeDistWindowFunction,
+}
+
+// cumeDistWindowFunction is the sql.WindowFunction used for cume_dist() within an OVER(...) clause. It
+// reuses rankWindowFunction's partition tracking and peer-group framing the same way percentRank does:
+// per the SQL standard, cume_dist ignores any explicit frame clause and groups rows into peers by the
+// window's ORDER BY expressions. The result is (number of rows preceding or peer with the current row) /
+// (partition size).
+type cumeDistWindowFunction struct {
+	*rankWindowFunction
+}
+
+var _ sql.WindowFunction = (*cumeDistWindowFunction)(nil)
+
+// newCumeDistWindowFunction creates the sql.WindowFunction for cume_dist().
+func newCumeDistWindowFunction(window *sql.WindowDefinition) (sql.WindowFunction, error) {
+	r, err := newRankWindowFunction(window)
+	if err != nil {
+		return nil, err
+	}
+	return &cumeDistWindowFunction{rankWindowFunction: r.(*rankWindowFunction)}, nil
+}
+
+// Compute implements the sql.WindowFunction interface.
+func (w *cumeDistWindowFunction) Compute(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) (interface{}, error) {
+	partitionSize := w.partitionEnd - w.partitionStart
+	if partitionSize <= 0 {
+		return nil, nil
+	}
+	return float64(interval.End-w.partitionStart) / float64(partitionSize), nil
+}

--- a/server/functions/window/framer_state.go
+++ b/server/functions/window/framer_state.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package window
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression/function/aggregation"
+)
+
+// windowFramerState holds the sql.WindowFramer setup for a window function that respects an explicit
+// frame clause rather than always operating over the whole partition or peer group - e.g. nth_value().
+type windowFramerState struct {
+	framer sql.WindowFramer
+}
+
+// bindFramer builds and stores this window's framer, if it declared an explicit frame clause; with no
+// explicit frame, DefaultFramer's fallback applies instead.
+func (s *windowFramerState) bindFramer(window *sql.WindowDefinition) error {
+	if window == nil || window.Frame == nil {
+		return nil
+	}
+	framer, err := window.Frame.NewFramer(window)
+	if err != nil {
+		return err
+	}
+	s.framer = framer
+	return nil
+}
+
+// StartPartition implements the sql.WindowFunction interface.
+func (s *windowFramerState) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
+	return nil
+}
+
+// DefaultFramer implements the sql.WindowFunction interface; with no explicit frame, this supplies
+// Postgres's default (unbounded preceding to current row).
+func (s *windowFramerState) DefaultFramer() sql.WindowFramer {
+	if s.framer != nil {
+		return s.framer
+	}
+	return aggregation.NewUnboundedPrecedingToCurrentRowFramer()
+}
+
+// Dispose implements the sql.WindowFunction interface.
+func (s *windowFramerState) Dispose(ctx *sql.Context) {}

--- a/server/functions/window/nth_value.go
+++ b/server/functions/window/nth_value.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package window
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// nthValue represents the PostgreSQL nth_value(value, n) window function. Its return type is
+// AnyElement, which CompiledFunction.Type resolves back to value's actual argument type.
+var nthValue = framework.Func2Window{
+	Function2: framework.Function2{
+		Name:   "nth_value",
+		Return: pgtypes.AnyElement,
+		Parameters: [2]*pgtypes.DoltgresType{
+			pgtypes.AnyElement,
+			pgtypes.Int32,
+		},
+		Callable: func(ctx *sql.Context, paramsAndReturn [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
+			return nil, nil
+		},
+	},
+	NewWinFunc: newNthValueWindowFunction,
+}
+
+// nthValueWindowFunction is the sql.WindowFunction used for nth_value() within an OVER(...) clause.
+// Unlike the ranking functions, nth_value respects the window's explicit frame clause (default RANGE
+// UNBOUNDED PRECEDING to CURRENT ROW), so it embeds windowFramerState the same way the native sum/avg
+// window functions do.
+type nthValueWindowFunction struct {
+	windowFramerState
+	valueExpr sql.Expression
+	nExpr     sql.Expression
+}
+
+var _ sql.WindowFunction = (*nthValueWindowFunction)(nil)
+
+// newNthValueWindowFunction creates the sql.WindowFunction for nth_value().
+func newNthValueWindowFunction(exprs []sql.Expression, window *sql.WindowDefinition) (sql.WindowFunction, error) {
+	wf := &nthValueWindowFunction{valueExpr: exprs[0], nExpr: exprs[1]}
+	if err := wf.bindFramer(window); err != nil {
+		return nil, err
+	}
+	return wf, nil
+}
+
+// Compute implements the sql.WindowFunction interface.
+func (w *nthValueWindowFunction) Compute(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) (interface{}, error) {
+	if interval.End <= interval.Start {
+		return nil, nil
+	}
+	nVal, err := w.nExpr.Eval(ctx, buf[interval.Start])
+	if err != nil {
+		return nil, err
+	}
+	if nVal == nil {
+		return nil, nil
+	}
+	n, ok := nVal.(int32)
+	if !ok {
+		return nil, errors.Errorf("nth_value: expected int32 offset, got %T", nVal)
+	}
+	if n <= 0 {
+		return nil, sql.ErrInvalidArgument.New("NTH_VALUE")
+	}
+
+	idx := interval.Start + int(n) - 1
+	if idx >= interval.End {
+		return nil, nil
+	}
+	return w.valueExpr.Eval(ctx, buf[idx])
+}

--- a/server/functions/window/ntile.go
+++ b/server/functions/window/ntile.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package window
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression/function/aggregation"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// ntile represents the PostgreSQL ntile(num_buckets) window function.
+var ntile = framework.Func1Window{
+	Function1: framework.Function1{
+		Name:   "ntile",
+		Return: pgtypes.Int32,
+		Parameters: [1]*pgtypes.DoltgresType{
+			pgtypes.Int32,
+		},
+		Callable: func(ctx *sql.Context, paramsAndReturn [2]*pgtypes.DoltgresType, val1 any) (any, error) {
+			return nil, nil
+		},
+	},
+	NewWinFunc: newNtileWindowFunction,
+}
+
+// ntileWindowFunction is the sql.WindowFunction used for ntile() within an OVER(...) clause. Per the SQL
+// standard, ntile() ignores any explicit frame clause and always divides the whole partition into
+// num_buckets buckets as evenly as possible, assigning any remainder one-per-bucket starting from the
+// first bucket.
+type ntileWindowFunction struct {
+	numBucketsExpr sql.Expression
+
+	pos        int64
+	bucketSize int64
+	bigBuckets int64
+	bucket     int64
+}
+
+var _ sql.WindowFunction = (*ntileWindowFunction)(nil)
+
+// newNtileWindowFunction creates the sql.WindowFunction for ntile().
+func newNtileWindowFunction(exprs []sql.Expression, _ *sql.WindowDefinition) (sql.WindowFunction, error) {
+	return &ntileWindowFunction{numBucketsExpr: exprs[0]}, nil
+}
+
+// DefaultFramer implements the sql.WindowFunction interface.
+func (w *ntileWindowFunction) DefaultFramer() sql.WindowFramer {
+	return aggregation.NewPartitionFramer()
+}
+
+// StartPartition implements the sql.WindowFunction interface.
+func (w *ntileWindowFunction) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
+	numBucketsVal, err := w.numBucketsExpr.Eval(ctx, nil)
+	if err != nil {
+		return err
+	}
+	numBuckets, ok := numBucketsVal.(int32)
+	if !ok || numBuckets <= 0 {
+		return sql.ErrInvalidArgument.New("NTILE")
+	}
+
+	count := int64(interval.End - interval.Start)
+	n := int64(numBuckets)
+	if n > count {
+		w.bucketSize = 1
+		w.bigBuckets = 0
+	} else {
+		w.bucketSize = count / n
+		w.bigBuckets = count % n
+	}
+	w.pos = 0
+	w.bucket = 1
+	return nil
+}
+
+// Compute implements the sql.WindowFunction interface.
+func (w *ntileWindowFunction) Compute(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) (interface{}, error) {
+	defer func() { w.pos++ }()
+	if w.pos == 0 {
+		return int32(w.bucket), nil
+	}
+
+	// The first w.bigBuckets buckets are of size w.bucketSize+1; the remaining buckets are of size
+	// w.bucketSize.
+	if w.bigBuckets > 0 && w.pos%(w.bucketSize+1) == 0 {
+		w.bucket++
+		w.bigBuckets--
+		if w.bigBuckets == 0 {
+			w.pos = 0
+		}
+	} else if w.bigBuckets == 0 && w.pos%w.bucketSize == 0 {
+		w.bucket++
+	}
+
+	return int32(w.bucket), nil
+}
+
+// Dispose implements the sql.WindowFunction interface.
+func (w *ntileWindowFunction) Dispose(ctx *sql.Context) {}

--- a/server/functions/window/row_number.go
+++ b/server/functions/window/row_number.go
@@ -28,6 +28,9 @@ func initRanking() {
 	framework.RegisterWindowFunction(rank)
 	framework.RegisterWindowFunction(denseRank)
 	framework.RegisterWindowFunction(percentRank)
+	framework.RegisterWindowFunction(cumeDist)
+	framework.RegisterWindowFunction(ntile)
+	framework.RegisterWindowFunction(nthValue)
 }
 
 // rowNumber represents the PostgreSQL row_number() window function, returning a bigint directly rather than

--- a/testing/go/window_test.go
+++ b/testing/go/window_test.go
@@ -275,5 +275,64 @@ func TestWindowFunctions(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "ntile and cume_dist ignore ties/frame and operate over the whole partition",
+			SetUpScript: []string{
+				"CREATE TABLE rank_ext (id INT PRIMARY KEY, grp INT, val INT);",
+				// grp 1 has a tied peer group (val=10 for id 1 and 2); grp 2 has no ties.
+				"INSERT INTO rank_ext VALUES (1,1,10),(2,1,10),(3,1,20),(4,1,30),(5,2,5),(6,2,15);",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT id, ntile(2) OVER (PARTITION BY grp ORDER BY val) FROM rank_ext ORDER BY id",
+					Expected: []sql.Row{
+						{1, 1},
+						{2, 1},
+						{3, 2},
+						{4, 2},
+						{5, 1},
+						{6, 2},
+					},
+				},
+				{
+					Query: "SELECT id, cume_dist() OVER (PARTITION BY grp ORDER BY val) FROM rank_ext ORDER BY id",
+					Expected: []sql.Row{
+						{1, float64(0.5)},
+						{2, float64(0.5)},
+						{3, float64(0.75)},
+						{4, float64(1)},
+						{5, float64(0.5)},
+						{6, float64(1)},
+					},
+				},
+			},
+		},
+		{
+			Name: "nth_value respects the window's frame and returns the polymorphic argument type",
+			SetUpScript: []string{
+				"CREATE TABLE nv (id INT PRIMARY KEY, grp INT, val INT);",
+				"INSERT INTO nv VALUES (1,1,100),(2,1,200),(3,1,300),(4,2,999);",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT id, nth_value(val, 2) OVER (PARTITION BY grp ORDER BY id) FROM nv ORDER BY id",
+					Expected: []sql.Row{
+						{1, nil},
+						{2, 200},
+						{3, 200},
+						{4, nil},
+					},
+				},
+				{
+					Query: "SELECT id, nth_value(val, 2) OVER (PARTITION BY grp ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM nv ORDER BY id",
+					Expected: []sql.Row{
+						{1, 200},
+						{2, 200},
+						{3, 200},
+						{4, nil},
+					},
+				},
+			},
+		},
 	})
 }

--- a/testing/go/window_test.go
+++ b/testing/go/window_test.go
@@ -305,6 +305,20 @@ func TestWindowFunctions(t *testing.T) {
 						{6, float64(1)},
 					},
 				},
+				{
+					// cume_dist (and the other window-only functions with no required arguments) must reject a
+					// bare call with a clean error rather than reaching execution with a nil window.
+					Query:       "SELECT cume_dist() FROM rank_ext",
+					ExpectedErr: "requires an OVER clause",
+				},
+				{
+					Query:       "SELECT row_number() FROM rank_ext",
+					ExpectedErr: "requires an OVER clause",
+				},
+				{
+					Query:       "SELECT rank() FROM rank_ext",
+					ExpectedErr: "requires an OVER clause",
+				},
 			},
 		},
 		{


### PR DESCRIPTION
New window functions for `ntile()`, `nth_value()`, and `cume_dist()` implemented in the Doltgres layer, matching Postgres's exact return types and semantics.