### PR TITLE
Native support for stddev and variance related window functions

### DIFF
--- a/server/cast/float64.go
+++ b/server/cast/float64.go
@@ -38,7 +38,12 @@ func float64Assignment(builtInCasts map[id.Cast]casts.Cast) {
 		FromType: pgtypes.Float64,
 		ToType:   pgtypes.Float32,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return float32(val.(float64)), nil
+			f := val.(float64)
+			f32 := float32(f)
+			if math.IsInf(float64(f32), 0) && !math.IsInf(f, 0) {
+				return nil, errors.Wrap(pgtypes.ErrCastOutOfRange, "real out of range")
+			}
+			return f32, nil
 		},
 	})
 	framework.MustAddAssignmentTypeCast(builtInCasts, framework.TypeCast{

--- a/server/cast/numeric.go
+++ b/server/cast/numeric.go
@@ -15,6 +15,8 @@
 package cast
 
 import (
+	"math"
+
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
@@ -78,8 +80,15 @@ func numericImplicit(builtInCasts map[id.Cast]casts.Cast) {
 		ToType:   pgtypes.Float32,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
 			d := val.(*apd.Decimal)
-			f, _ := d.Float64()
-			return float32(f), nil
+			f, err := d.Float64()
+			if err != nil {
+				return nil, errors.Wrap(pgtypes.ErrCastOutOfRange, "real out of range")
+			}
+			f32 := float32(f)
+			if math.IsInf(float64(f32), 0) && !math.IsInf(f, 0) {
+				return nil, errors.Wrap(pgtypes.ErrCastOutOfRange, "real out of range")
+			}
+			return f32, nil
 		},
 	})
 	framework.MustAddImplicitTypeCast(builtInCasts, framework.TypeCast{
@@ -87,7 +96,10 @@ func numericImplicit(builtInCasts map[id.Cast]casts.Cast) {
 		ToType:   pgtypes.Float64,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
 			d := val.(*apd.Decimal)
-			f, _ := d.Float64()
+			f, err := d.Float64()
+			if err != nil {
+				return nil, errors.Wrap(pgtypes.ErrCastOutOfRange, "double precision out of range")
+			}
 			return f, nil
 		},
 	})

--- a/server/functions/aggregate/init.go
+++ b/server/functions/aggregate/init.go
@@ -18,4 +18,5 @@ func Init() {
 	initBoolAggs()
 	initNumericAggs()
 	initAvgAggs()
+	initVarianceAggs()
 }

--- a/server/functions/aggregate/variance_aggregates.go
+++ b/server/functions/aggregate/variance_aggregates.go
@@ -15,7 +15,10 @@
 package aggregate
 
 import (
+	"fmt"
 	"math"
+	"strconv"
+	"strings"
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/errors"
@@ -75,40 +78,155 @@ func varianceOverload(name string, paramType, returnType *pgtypes.DoltgresType, 
 	}
 }
 
-// decimalVariance computes the population (sample=false) or sample (sample=true) variance of n values given
-// their running sum and sum of squares, using the sum-of-squares formula (n*sumX2 - sumX^2) / divisor, where
-// divisor is n^2 for population variance and n*(n-1) for sample variance. The caller must ensure n is large
-// enough for the requested variant (n>=1 for population, n>=2 for sample) to avoid a division by zero.
-func decimalVariance(n int64, sumX, sumX2 *apd.Decimal, sample bool) (*apd.Decimal, error) {
+// decimalVarianceNumeratorDenominator computes the numerator (n*sumX2 - sumX^2) and denominator (n^2 for
+// population variance, n*(n-1) for sample variance) of the sum-of-squares variance formula. Both apd.Decimal
+// operations here run under sql.DecimalCtx, whose Precision of 0 disables rounding, so this arithmetic is
+// exact (no floating-point-style cancellation risk) regardless of how large sumX/sumX2 get. The caller must
+// ensure n is large enough for the requested variant (n>=1 for population, n>=2 for sample) to avoid a
+// division by zero.
+func decimalVarianceNumeratorDenominator(n int64, sumX, sumX2 *apd.Decimal, sample bool) (numerator, denominator *apd.Decimal, err error) {
 	nDec := apd.New(n, 0)
 	sumXSquared := new(apd.Decimal)
 	if _, err := sql.DecimalCtx.Mul(sumXSquared, sumX, sumX); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	nTimesSumX2 := new(apd.Decimal)
 	if _, err := sql.DecimalCtx.Mul(nTimesSumX2, nDec, sumX2); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	dividend := new(apd.Decimal)
-	if _, err := sql.DecimalCtx.Sub(dividend, nTimesSumX2, sumXSquared); err != nil {
-		return nil, err
+	numerator = new(apd.Decimal)
+	if _, err := sql.DecimalCtx.Sub(numerator, nTimesSumX2, sumXSquared); err != nil {
+		return nil, nil, err
 	}
-	divisor := new(apd.Decimal)
+	denominator = new(apd.Decimal)
 	if sample {
-		if _, err := sql.DecimalCtx.Mul(divisor, nDec, apd.New(n-1, 0)); err != nil {
-			return nil, err
+		if _, err := sql.DecimalCtx.Mul(denominator, nDec, apd.New(n-1, 0)); err != nil {
+			return nil, nil, err
 		}
 	} else {
-		if _, err := sql.DecimalCtx.Mul(divisor, nDec, nDec); err != nil {
-			return nil, err
+		if _, err := sql.DecimalCtx.Mul(denominator, nDec, nDec); err != nil {
+			return nil, nil, err
 		}
 	}
-	return quoAvg(dividend, divisor)
+	return numerator, denominator, nil
 }
 
-// decimalStdDev takes the square root of a variance already computed by decimalVariance, sized to
-// variance's own digit count plus a fixed set of guard digits.
-func decimalStdDev(variance *apd.Decimal) (*apd.Decimal, error) {
+// numericWeightAndFirstDigit mirrors the weight/firstdigit extraction at the top of Postgres's
+// select_div_scale (numeric.c): Postgres numerics internally store their digits in base-10000 "NBASE
+// digit" groups aligned to the decimal point, weight is the power-of-10000 position of the most
+// significant such group, and firstDigit is that leading group's own value (1-9999).
+func numericWeightAndFirstDigit(d *apd.Decimal) (weight, firstDigit int64) {
+	if d.IsZero() {
+		return 0, 0
+	}
+	digits := fmt.Sprintf("%d", &d.Coeff)
+	numDigits := int64(len(digits))
+	e := numDigits - 1 + int64(d.Exponent) // decimal exponent of the leading digit
+	w := floorDiv(e, 4)
+	k := int64(d.Exponent) - 4*w // digits to pad (k>=0) or trim (k<0) to land on d's own group boundary
+	var group string
+	if k >= 0 {
+		group = digits + strings.Repeat("0", int(k))
+	} else if cut := numDigits + k; cut > 0 {
+		group = digits[:cut]
+	} else {
+		group = "0"
+	}
+	if len(group) > 4 {
+		group = group[len(group)-4:]
+	}
+	fd, _ := strconv.ParseInt(group, 10, 64)
+	return w, fd
+}
+
+// floorDiv is integer division rounding towards negative infinity (unlike Go's /, which truncates towards
+// zero), needed so weights below the decimal point (negative e) group correctly in numericWeightAndFirstDigit.
+func floorDiv(a, b int64) int64 {
+	q := a / b
+	if a%b != 0 && (a < 0) != (b < 0) {
+		q--
+	}
+	return q
+}
+
+// decimalScale returns the number of digits after the decimal point in d's exact representation, Postgres's
+// "dscale" for a NumericVar.
+func decimalScale(d *apd.Decimal) int64 {
+	if d.Exponent < 0 {
+		return int64(-d.Exponent)
+	}
+	return 0
+}
+
+// selectDivScale mirrors Postgres's select_div_scale (numeric.c) exactly: it picks the number of fractional
+// digits (rscale) a dividend/divisor division should be rounded to, aiming for at least 16 significant
+// digits in the quotient (so numeric division is no less accurate than float8) while never dropping below
+// either operand's own number of fractional digits.
+func selectDivScale(dividend, divisor *apd.Decimal) int64 {
+	w1, fd1 := numericWeightAndFirstDigit(dividend)
+	w2, fd2 := numericWeightAndFirstDigit(divisor)
+	qweight := w1 - w2
+	if fd1 <= fd2 {
+		qweight--
+	}
+	const numericMinSigDigits = 16
+	rscale := numericMinSigDigits - qweight*4
+	if s := decimalScale(dividend); rscale < s {
+		rscale = s
+	}
+	if s := decimalScale(divisor); rscale < s {
+		rscale = s
+	}
+	if rscale < 0 {
+		rscale = 0
+	}
+	const numericMaxDisplayScale = 1000
+	if rscale > numericMaxDisplayScale {
+		rscale = numericMaxDisplayScale
+	}
+	return rscale
+}
+
+// quoScale divides dividend/divisor and rounds the result to exactly rscale digits after the decimal point,
+// matching Postgres's div_var(..., rscale, round=true) semantics used throughout numeric.c.
+func quoScale(dividend, divisor *apd.Decimal, rscale int64) (*apd.Decimal, error) {
+	p := dividend.NumDigits() - divisor.NumDigits() + int64(dividend.Exponent) - int64(divisor.Exponent) + 1
+	if p < 1 {
+		p = 1
+	}
+	p += rscale + avgGuardDigits
+	result := new(apd.Decimal)
+	if _, err := sql.DecimalCtx.WithPrecision(uint32(p)).Quo(result, dividend, divisor); err != nil {
+		return nil, err
+	}
+	if _, err := sql.DecimalCtx.WithPrecision(uint32(p)).Quantize(result, result, int32(-rscale)); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// decimalVariance computes the population (sample=false) or sample (sample=true) variance of n values given
+// their running sum and sum of squares, using the sum-of-squares formula (n*sumX2 - sumX^2) / divisor, where
+// divisor is n^2 for population variance and n*(n-1) for sample variance.
+func decimalVariance(n int64, sumX, sumX2 *apd.Decimal, sample bool) (*apd.Decimal, int64, error) {
+	numerator, denominator, err := decimalVarianceNumeratorDenominator(n, sumX, sumX2, sample)
+	if err != nil {
+		return nil, 0, err
+	}
+	if numerator.Sign() <= 0 {
+		return new(apd.Decimal), 0, nil
+	}
+	rscale := selectDivScale(numerator, denominator)
+	variance, err := quoScale(numerator, denominator, rscale)
+	if err != nil {
+		return nil, 0, err
+	}
+	return variance, rscale, nil
+}
+
+// decimalStdDev takes the square root of a variance already computed by decimalVariance, rounding to the
+// same rscale decimalVariance's own division used.
+func decimalStdDev(variance *apd.Decimal, rscale int64) (*apd.Decimal, error) {
 	if variance.Sign() <= 0 {
 		return new(apd.Decimal), nil
 	}
@@ -116,12 +234,14 @@ func decimalStdDev(variance *apd.Decimal) (*apd.Decimal, error) {
 	if variance.Exponent > 0 {
 		p += int64(variance.Exponent)
 	}
-	p += avgGuardDigits
+	p = p/2 + 1 + rscale + avgGuardDigits
 	res := new(apd.Decimal)
 	if _, err := sql.DecimalCtx.WithPrecision(uint32(p)).Sqrt(res, variance); err != nil {
 		return nil, err
 	}
-	res.Reduce(res)
+	if _, err := sql.DecimalCtx.WithPrecision(uint32(p)).Quantize(res, res, int32(-rscale)); err != nil {
+		return nil, err
+	}
 	return res, nil
 }
 
@@ -155,12 +275,12 @@ func (b *decimalVarianceBuffer[T]) Eval(ctx *sql.Context) (interface{}, error) {
 	if b.count < minCount {
 		return nil, nil
 	}
-	variance, err := decimalVariance(b.count, &b.sumX, &b.sumX2, b.sample)
+	variance, rscale, err := decimalVariance(b.count, &b.sumX, &b.sumX2, b.sample)
 	if err != nil {
 		return nil, err
 	}
 	if b.sqrtResult {
-		return decimalStdDev(variance)
+		return decimalStdDev(variance, rscale)
 	}
 	return variance, nil
 }
@@ -227,18 +347,15 @@ func (w *decimalVarianceWindowFunction[T]) Compute(ctx *sql.Context, interval sq
 	return b.Eval(ctx)
 }
 
-// floatVariance computes the population (sample=false) or sample (sample=true) variance of n float64 values
-// given their running sum and sum of squares, using the same sum-of-squares formula as decimalVariance. A
-// variance that comes out marginally negative due to floating-point rounding is clamped to 0.
-func floatVariance(n int64, sumX, sumX2 float64, sample bool) float64 {
-	nf := float64(n)
-	var divisor float64
+// floatVariance computes the population (sample=false) or sample (sample=true) variance from a running count n
+// and a running sum of squared deviations from the mean (sxx), the latter accumulated incrementally via the
+// Youngs-Cramer algorithm in floatVarianceBuffer.Update.
+func floatVariance(n, sxx float64, sample bool) float64 {
+	divisor := n
 	if sample {
-		divisor = nf * (nf - 1)
-	} else {
-		divisor = nf * nf
+		divisor = n - 1
 	}
-	variance := (nf*sumX2 - sumX*sumX) / divisor
+	variance := sxx / divisor
 	if variance < 0 {
 		return 0
 	}
@@ -249,9 +366,9 @@ func floatVariance(n int64, sumX, sumX2 float64, sample bool) float64 {
 // real/double precision input, both of which promote to double precision.
 type floatVarianceBuffer[T float32 | float64] struct {
 	expr       sql.Expression
-	sumX       float64
-	sumX2      float64
-	count      int64
+	n          float64
+	sx         float64
+	sxx        float64
 	sample     bool
 	sqrtResult bool
 }
@@ -267,20 +384,22 @@ func newFloatVarianceBuffer[T float32 | float64](sample, sqrtResult bool) framew
 func (b *floatVarianceBuffer[T]) Dispose(ctx *sql.Context) {}
 
 func (b *floatVarianceBuffer[T]) Eval(ctx *sql.Context) (interface{}, error) {
-	minCount := int64(1)
+	minCount := float64(1)
 	if b.sample {
 		minCount = 2
 	}
-	if b.count < minCount {
+	if b.n < minCount {
 		return nil, nil
 	}
-	variance := floatVariance(b.count, b.sumX, b.sumX2, b.sample)
+	variance := floatVariance(b.n, b.sxx, b.sample)
 	if b.sqrtResult {
 		return math.Sqrt(variance), nil
 	}
 	return variance, nil
 }
 
+// Update folds the next value into the running count/sum/sum-of-squared-deviations using the Youngs-Cramer
+// algorithm.
 func (b *floatVarianceBuffer[T]) Update(ctx *sql.Context, row sql.Row) error {
 	v, err := b.expr.Eval(ctx, row)
 	if err != nil {
@@ -294,9 +413,14 @@ func (b *floatVarianceBuffer[T]) Update(ctx *sql.Context, row sql.Row) error {
 		return errors.Errorf("variance: expected %T, got %T", f, v)
 	}
 	fv := float64(f)
-	b.sumX += fv
-	b.sumX2 += fv * fv
-	b.count++
+	b.n++
+	b.sx += fv
+	if b.n > 1 {
+		tmp := fv*b.n - b.sx
+		b.sxx += tmp * tmp / (b.n * (b.n - 1))
+	} else if math.IsNaN(fv) || math.IsInf(fv, 0) {
+		b.sxx = math.NaN()
+	}
 	return nil
 }
 

--- a/server/functions/aggregate/variance_aggregates.go
+++ b/server/functions/aggregate/variance_aggregates.go
@@ -1,0 +1,335 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregate
+
+import (
+	"math"
+
+	"github.com/cockroachdb/apd/v3"
+	"github.com/cockroachdb/errors"
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// initVarianceAggs registers the variance and standard deviation functions to the catalog.
+func initVarianceAggs() {
+	for _, o := range []struct {
+		name       string
+		sample     bool
+		sqrtResult bool
+	}{
+		{"var_pop", false, false},
+		{"var_samp", true, false},
+		{"variance", true, false},
+		{"stddev_pop", false, true},
+		{"stddev_samp", true, true},
+		{"stddev", true, true},
+	} {
+		framework.RegisterAggregateFunction(varianceOverload(o.name, pgtypes.Int16, pgtypes.Numeric, newDecimalVarianceBuffer(int16ToDecimal, o.sample, o.sqrtResult), newDecimalVarianceWindowFunction(int16ToDecimal, o.sample, o.sqrtResult)))
+		framework.RegisterAggregateFunction(varianceOverload(o.name, pgtypes.Int32, pgtypes.Numeric, newDecimalVarianceBuffer(int32ToDecimal, o.sample, o.sqrtResult), newDecimalVarianceWindowFunction(int32ToDecimal, o.sample, o.sqrtResult)))
+		framework.RegisterAggregateFunction(varianceOverload(o.name, pgtypes.Int64, pgtypes.Numeric, newDecimalVarianceBuffer(int64ToDecimal, o.sample, o.sqrtResult), newDecimalVarianceWindowFunction(int64ToDecimal, o.sample, o.sqrtResult)))
+		framework.RegisterAggregateFunction(varianceOverload(o.name, pgtypes.Numeric, pgtypes.Numeric, newDecimalVarianceBuffer(decimalIdentity, o.sample, o.sqrtResult), newDecimalVarianceWindowFunction(decimalIdentity, o.sample, o.sqrtResult)))
+		framework.RegisterAggregateFunction(varianceOverload(o.name, pgtypes.Float32, pgtypes.Float64, newFloatVarianceBuffer[float32](o.sample, o.sqrtResult), newFloatVarianceWindowFunction[float32](o.sample, o.sqrtResult)))
+		framework.RegisterAggregateFunction(varianceOverload(o.name, pgtypes.Float64, pgtypes.Float64, newFloatVarianceBuffer[float64](o.sample, o.sqrtResult), newFloatVarianceWindowFunction[float64](o.sample, o.sqrtResult)))
+	}
+}
+
+// int16ToDecimal converts an int16 value to *apd.Decimal, for use as the decimalConvert of a
+// decimalVarianceBuffer instantiated over int16 (i.e. var_pop(int2)/var_samp(int2)/etc.).
+func int16ToDecimal(v int16) *apd.Decimal { return apd.New(int64(v), 0) }
+
+// int32ToDecimal converts an int32 value to *apd.Decimal, for use as the decimalConvert of a
+// decimalVarianceBuffer instantiated over int32 (i.e. var_pop(int4)/var_samp(int4)/etc.).
+func int32ToDecimal(v int32) *apd.Decimal { return apd.New(int64(v), 0) }
+
+// varianceOverload builds a single var_pop(...)/var_samp(...)/stddev_pop(...)/etc. overload; see sumOverload,
+// which this mirrors.
+func varianceOverload(name string, paramType, returnType *pgtypes.DoltgresType, newBuffer framework.NewBufferFn, newWindowFunc framework.NewWindowFunctionFn) framework.Func1Aggregate {
+	return framework.Func1Aggregate{
+		Function1: framework.Function1{
+			Name:   name,
+			Return: returnType,
+			Parameters: [1]*pgtypes.DoltgresType{
+				paramType,
+			},
+			Callable: func(ctx *sql.Context, paramsAndReturn [2]*pgtypes.DoltgresType, val1 any) (any, error) {
+				return nil, nil
+			},
+		},
+		NewAggBuffer:     newBuffer,
+		NewAggWindowFunc: newWindowFunc,
+	}
+}
+
+// decimalVariance computes the population (sample=false) or sample (sample=true) variance of n values given
+// their running sum and sum of squares, using the sum-of-squares formula (n*sumX2 - sumX^2) / divisor, where
+// divisor is n^2 for population variance and n*(n-1) for sample variance. The caller must ensure n is large
+// enough for the requested variant (n>=1 for population, n>=2 for sample) to avoid a division by zero.
+func decimalVariance(n int64, sumX, sumX2 *apd.Decimal, sample bool) (*apd.Decimal, error) {
+	nDec := apd.New(n, 0)
+	sumXSquared := new(apd.Decimal)
+	if _, err := sql.DecimalCtx.Mul(sumXSquared, sumX, sumX); err != nil {
+		return nil, err
+	}
+	nTimesSumX2 := new(apd.Decimal)
+	if _, err := sql.DecimalCtx.Mul(nTimesSumX2, nDec, sumX2); err != nil {
+		return nil, err
+	}
+	dividend := new(apd.Decimal)
+	if _, err := sql.DecimalCtx.Sub(dividend, nTimesSumX2, sumXSquared); err != nil {
+		return nil, err
+	}
+	divisor := new(apd.Decimal)
+	if sample {
+		if _, err := sql.DecimalCtx.Mul(divisor, nDec, apd.New(n-1, 0)); err != nil {
+			return nil, err
+		}
+	} else {
+		if _, err := sql.DecimalCtx.Mul(divisor, nDec, nDec); err != nil {
+			return nil, err
+		}
+	}
+	return quoAvg(dividend, divisor)
+}
+
+// decimalStdDev takes the square root of a variance already computed by decimalVariance, sized to
+// variance's own digit count plus a fixed set of guard digits.
+func decimalStdDev(variance *apd.Decimal) (*apd.Decimal, error) {
+	if variance.Sign() <= 0 {
+		return new(apd.Decimal), nil
+	}
+	p := variance.NumDigits()
+	if variance.Exponent > 0 {
+		p += int64(variance.Exponent)
+	}
+	p += avgGuardDigits
+	res := new(apd.Decimal)
+	if _, err := sql.DecimalCtx.WithPrecision(uint32(p)).Sqrt(res, variance); err != nil {
+		return nil, err
+	}
+	res.Reduce(res)
+	return res, nil
+}
+
+// decimalVarianceBuffer is the GROUP BY buffer for var_pop/var_samp/stddev_pop/stddev_samp/variance/stddev over
+// smallint/integer/bigint/numeric input, all of which promote to numeric.
+type decimalVarianceBuffer[T int16 | int32 | int64 | *apd.Decimal] struct {
+	expr       sql.Expression
+	sumX       apd.Decimal
+	sumX2      apd.Decimal
+	count      int64
+	convert    func(T) *apd.Decimal
+	sample     bool
+	sqrtResult bool
+}
+
+var _ sql.AggregationBuffer = (*decimalVarianceBuffer[int64])(nil)
+
+func newDecimalVarianceBuffer[T int16 | int32 | int64 | *apd.Decimal](convert func(T) *apd.Decimal, sample, sqrtResult bool) framework.NewBufferFn {
+	return func(exprs []sql.Expression) (sql.AggregationBuffer, error) {
+		return &decimalVarianceBuffer[T]{expr: exprs[0], convert: convert, sample: sample, sqrtResult: sqrtResult}, nil
+	}
+}
+
+func (b *decimalVarianceBuffer[T]) Dispose(ctx *sql.Context) {}
+
+func (b *decimalVarianceBuffer[T]) Eval(ctx *sql.Context) (interface{}, error) {
+	minCount := int64(1)
+	if b.sample {
+		minCount = 2
+	}
+	if b.count < minCount {
+		return nil, nil
+	}
+	variance, err := decimalVariance(b.count, &b.sumX, &b.sumX2, b.sample)
+	if err != nil {
+		return nil, err
+	}
+	if b.sqrtResult {
+		return decimalStdDev(variance)
+	}
+	return variance, nil
+}
+
+func (b *decimalVarianceBuffer[T]) Update(ctx *sql.Context, row sql.Row) error {
+	v, err := b.expr.Eval(ctx, row)
+	if err != nil {
+		return err
+	}
+	if v == nil {
+		return nil
+	}
+	typedV, ok := v.(T)
+	if !ok {
+		return errors.Errorf("variance: expected %T, got %T", typedV, v)
+	}
+	d := b.convert(typedV)
+	if _, err = sql.DecimalCtx.Add(&b.sumX, &b.sumX, d); err != nil {
+		return err
+	}
+	dSquared := new(apd.Decimal)
+	if _, err = sql.DecimalCtx.Mul(dSquared, d, d); err != nil {
+		return err
+	}
+	if _, err = sql.DecimalCtx.Add(&b.sumX2, &b.sumX2, dSquared); err != nil {
+		return err
+	}
+	b.count++
+	return nil
+}
+
+// decimalVarianceWindowFunction is the sql.WindowFunction used for var_pop/var_samp/stddev_pop/stddev_samp/
+// variance/stddev over smallint/integer/bigint/numeric input within an OVER(...) clause.
+type decimalVarianceWindowFunction[T int16 | int32 | int64 | *apd.Decimal] struct {
+	framework.WindowFramerState
+	expr       sql.Expression
+	convert    func(T) *apd.Decimal
+	sample     bool
+	sqrtResult bool
+}
+
+var _ sql.WindowFunction = (*decimalVarianceWindowFunction[int64])(nil)
+
+func newDecimalVarianceWindowFunction[T int16 | int32 | int64 | *apd.Decimal](convert func(T) *apd.Decimal, sample, sqrtResult bool) framework.NewWindowFunctionFn {
+	return func(exprs []sql.Expression, window *sql.WindowDefinition) (sql.WindowFunction, error) {
+		wf := &decimalVarianceWindowFunction[T]{expr: exprs[0], convert: convert, sample: sample, sqrtResult: sqrtResult}
+		if err := wf.BindFramer(window); err != nil {
+			return nil, err
+		}
+		return wf, nil
+	}
+}
+
+func (w *decimalVarianceWindowFunction[T]) Compute(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) (interface{}, error) {
+	if interval.End <= interval.Start {
+		return nil, nil
+	}
+	b := &decimalVarianceBuffer[T]{expr: w.expr, convert: w.convert, sample: w.sample, sqrtResult: w.sqrtResult}
+	for i := interval.Start; i < interval.End; i++ {
+		if err := b.Update(ctx, buf[i]); err != nil {
+			return nil, err
+		}
+	}
+	return b.Eval(ctx)
+}
+
+// floatVariance computes the population (sample=false) or sample (sample=true) variance of n float64 values
+// given their running sum and sum of squares, using the same sum-of-squares formula as decimalVariance. A
+// variance that comes out marginally negative due to floating-point rounding is clamped to 0.
+func floatVariance(n int64, sumX, sumX2 float64, sample bool) float64 {
+	nf := float64(n)
+	var divisor float64
+	if sample {
+		divisor = nf * (nf - 1)
+	} else {
+		divisor = nf * nf
+	}
+	variance := (nf*sumX2 - sumX*sumX) / divisor
+	if variance < 0 {
+		return 0
+	}
+	return variance
+}
+
+// floatVarianceBuffer is the GROUP BY buffer for var_pop/var_samp/stddev_pop/stddev_samp/variance/stddev over
+// real/double precision input, both of which promote to double precision.
+type floatVarianceBuffer[T float32 | float64] struct {
+	expr       sql.Expression
+	sumX       float64
+	sumX2      float64
+	count      int64
+	sample     bool
+	sqrtResult bool
+}
+
+var _ sql.AggregationBuffer = (*floatVarianceBuffer[float64])(nil)
+
+func newFloatVarianceBuffer[T float32 | float64](sample, sqrtResult bool) framework.NewBufferFn {
+	return func(exprs []sql.Expression) (sql.AggregationBuffer, error) {
+		return &floatVarianceBuffer[T]{expr: exprs[0], sample: sample, sqrtResult: sqrtResult}, nil
+	}
+}
+
+func (b *floatVarianceBuffer[T]) Dispose(ctx *sql.Context) {}
+
+func (b *floatVarianceBuffer[T]) Eval(ctx *sql.Context) (interface{}, error) {
+	minCount := int64(1)
+	if b.sample {
+		minCount = 2
+	}
+	if b.count < minCount {
+		return nil, nil
+	}
+	variance := floatVariance(b.count, b.sumX, b.sumX2, b.sample)
+	if b.sqrtResult {
+		return math.Sqrt(variance), nil
+	}
+	return variance, nil
+}
+
+func (b *floatVarianceBuffer[T]) Update(ctx *sql.Context, row sql.Row) error {
+	v, err := b.expr.Eval(ctx, row)
+	if err != nil {
+		return err
+	}
+	if v == nil {
+		return nil
+	}
+	f, ok := v.(T)
+	if !ok {
+		return errors.Errorf("variance: expected %T, got %T", f, v)
+	}
+	fv := float64(f)
+	b.sumX += fv
+	b.sumX2 += fv * fv
+	b.count++
+	return nil
+}
+
+// floatVarianceWindowFunction is the sql.WindowFunction used for var_pop/var_samp/stddev_pop/stddev_samp/
+// variance/stddev over real/double precision input within an OVER(...) clause.
+type floatVarianceWindowFunction[T float32 | float64] struct {
+	framework.WindowFramerState
+	expr       sql.Expression
+	sample     bool
+	sqrtResult bool
+}
+
+var _ sql.WindowFunction = (*floatVarianceWindowFunction[float64])(nil)
+
+func newFloatVarianceWindowFunction[T float32 | float64](sample, sqrtResult bool) framework.NewWindowFunctionFn {
+	return func(exprs []sql.Expression, window *sql.WindowDefinition) (sql.WindowFunction, error) {
+		wf := &floatVarianceWindowFunction[T]{expr: exprs[0], sample: sample, sqrtResult: sqrtResult}
+		if err := wf.BindFramer(window); err != nil {
+			return nil, err
+		}
+		return wf, nil
+	}
+}
+
+func (w *floatVarianceWindowFunction[T]) Compute(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) (interface{}, error) {
+	if interval.End <= interval.Start {
+		return nil, nil
+	}
+	b := &floatVarianceBuffer[T]{expr: w.expr, sample: w.sample, sqrtResult: w.sqrtResult}
+	for i := interval.Start; i < interval.End; i++ {
+		if err := b.Update(ctx, buf[i]); err != nil {
+			return nil, err
+		}
+	}
+	return b.Eval(ctx)
+}

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -15,6 +15,7 @@
 package _go
 
 import (
+	"math"
 	"testing"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -482,6 +483,47 @@ func TestAggregateFunctions(t *testing.T) {
 			`,
 					Expected: []sql.Row{
 						{"{1}"},
+					},
+				},
+			},
+		},
+		{
+			Name: "var_pop/var_samp/stddev_pop/stddev_samp with infinite and NaN float8 input",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `SELECT sum(x::float8), avg(x::float8), var_pop(x::float8)::text FROM (VALUES ('infinity'), ('1')) v(x);`,
+					Expected: []sql.Row{
+						{math.Inf(1), math.Inf(1), "NaN"},
+					},
+				},
+				{
+					Query: `SELECT sum(x::float8), avg(x::float8), var_pop(x::float8)::text FROM (VALUES ('1'), ('infinity')) v(x);`,
+					Expected: []sql.Row{
+						{math.Inf(1), math.Inf(1), "NaN"},
+					},
+				},
+				{
+					Query: `SELECT var_pop(x::float8)::text FROM (VALUES ('infinity'), ('infinity')) v(x);`,
+					Expected: []sql.Row{
+						{"NaN"},
+					},
+				},
+				{
+					Query: `SELECT var_pop(x::float8)::text, var_samp(x::float8)::text, stddev_pop(x::float8)::text, stddev_samp(x::float8)::text FROM (VALUES ('infinity')) v(x);`,
+					Expected: []sql.Row{
+						{"NaN", nil, "NaN", nil},
+					},
+				},
+				{
+					Query: `SELECT var_pop(x::float8)::text, var_samp(x::float8)::text, stddev_pop(x::float8)::text, stddev_samp(x::float8)::text FROM (VALUES ('nan')) v(x);`,
+					Expected: []sql.Row{
+						{"NaN", nil, "NaN", nil},
+					},
+				},
+				{
+					Query: `SELECT var_pop(x::float8), var_samp(x::float8), stddev_pop(x::float8), stddev_samp(x::float8) FROM (VALUES (1::float8), (2::float8), (3::float8), (4::float8)) v(x);`,
+					Expected: []sql.Row{
+						{1.25, 1.6666666666666667, 1.118033988749895, 1.2909944487358056},
 					},
 				},
 			},

--- a/testing/go/types_test.go
+++ b/testing/go/types_test.go
@@ -16,6 +16,7 @@ package _go
 
 import (
 	"bytes"
+	"math"
 	"strings"
 	"testing"
 
@@ -2361,6 +2362,33 @@ var typesTests = []ScriptTest{
 					{1, 123.875},
 					{2, 67.125},
 				},
+			},
+			{
+				// Values that overflow float4 must be rejected, not wrapped to +/-Inf
+				Query:       "INSERT INTO t_real VALUES (3, 1.0e100);",
+				ExpectedErr: "real out of range",
+			},
+			{
+				Query:       "INSERT INTO t_real VALUES (3, 1.0e100::numeric);",
+				ExpectedErr: "real out of range",
+			},
+			{
+				// Largest finite float4 magnitude must still be accepted.
+				Query: "SELECT 3.4e38::float8::real, (-3.4e38)::float8::real;",
+				Expected: []sql.Row{
+					{float32(3.4e38), float32(-3.4e38)},
+				},
+			},
+			{
+				// An infinite numeric must pass through as float Infinity
+				Query: "SELECT 'Infinity'::numeric::real, '-Infinity'::numeric::real, 'Infinity'::numeric::float8;",
+				Expected: []sql.Row{
+					{float32(math.Inf(1)), float32(math.Inf(-1)), math.Inf(1)},
+				},
+			},
+			{
+				Query:       "SELECT ('1' || repeat('0', 320))::numeric::float8;",
+				ExpectedErr: "double precision out of range",
 			},
 		},
 	},

--- a/testing/go/window_test.go
+++ b/testing/go/window_test.go
@@ -407,45 +407,45 @@ func TestWindowFunctions(t *testing.T) {
 				{
 					Query: "SELECT id, STDDEV_POP(val) OVER (ORDER BY grp) FROM t3038 ORDER BY id;",
 					Expected: []sql.Row{
-						{1, Numeric("5")},
-						{2, Numeric("5")},
-						{3, Numeric("9.601432184835760219712")},
-						{4, Numeric("9.601432184835760219712")},
-						{5, Numeric("8.53912563829966531937038356855984732")},
-						{6, Numeric("8.53912563829966531937038356855984732")},
+						{1, Numeric("5.0000000000000000")},
+						{2, Numeric("5.0000000000000000")},
+						{3, Numeric("9.6014321848357602")},
+						{4, Numeric("9.6014321848357602")},
+						{5, Numeric("8.5391256382996653")},
+						{6, Numeric("8.5391256382996653")},
 					},
 				},
 				{
 					Query: "SELECT id, STDDEV_SAMP(val) OVER (ORDER BY grp) FROM t3038 ORDER BY id;",
 					Expected: []sql.Row{
-						{1, Numeric("7.07106781186547524")},
-						{2, Numeric("7.07106781186547524")},
-						{3, Numeric("11.0867789130417256043553548840367852")},
-						{4, Numeric("11.0867789130417256043553548840367852")},
-						{5, Numeric("9.354143466934853464")},
-						{6, Numeric("9.354143466934853464")},
+						{1, Numeric("7.0710678118654752")},
+						{2, Numeric("7.0710678118654752")},
+						{3, Numeric("11.0867789130417256")},
+						{4, Numeric("11.0867789130417256")},
+						{5, Numeric("9.3541434669348535")},
+						{6, Numeric("9.3541434669348535")},
 					},
 				},
 				{
 					Query: "SELECT id, VAR_POP(val) OVER (ORDER BY grp) FROM t3038 ORDER BY id;",
 					Expected: []sql.Row{
-						{1, Numeric("25")},
-						{2, Numeric("25")},
-						{3, Numeric("92.1875")},
-						{4, Numeric("92.1875")},
-						{5, Numeric("72.916666666666666667")},
-						{6, Numeric("72.916666666666666667")},
+						{1, Numeric("25.0000000000000000")},
+						{2, Numeric("25.0000000000000000")},
+						{3, Numeric("92.1875000000000000")},
+						{4, Numeric("92.1875000000000000")},
+						{5, Numeric("72.9166666666666667")},
+						{6, Numeric("72.9166666666666667")},
 					},
 				},
 				{
 					Query: "SELECT id, VAR_SAMP(val) OVER (ORDER BY grp) FROM t3038 ORDER BY id;",
 					Expected: []sql.Row{
-						{1, Numeric("50")},
-						{2, Numeric("50")},
-						{3, Numeric("122.91666666666666667")},
-						{4, Numeric("122.91666666666666667")},
-						{5, Numeric("87.5")},
-						{6, Numeric("87.5")},
+						{1, Numeric("50.0000000000000000")},
+						{2, Numeric("50.0000000000000000")},
+						{3, Numeric("122.9166666666666667")},
+						{4, Numeric("122.9166666666666667")},
+						{5, Numeric("87.5000000000000000")},
+						{6, Numeric("87.5000000000000000")},
 					},
 				},
 			},
@@ -464,9 +464,9 @@ func TestWindowFunctions(t *testing.T) {
 				{
 					Query: "SELECT grp, VAR_POP(val), VAR_SAMP(val), STDDEV_POP(val), STDDEV_SAMP(val) FROM t3038b GROUP BY grp ORDER BY grp;",
 					Expected: []sql.Row{
-						{"a", Numeric("25"), Numeric("50"), Numeric("5"), Numeric("7.07106781186547524")},
-						{"b", Numeric("156.25"), Numeric("312.5"), Numeric("12.5"), Numeric("17.67766952966368811")},
-						{"c", Numeric("25"), Numeric("50"), Numeric("5"), Numeric("7.07106781186547524")},
+						{"a", Numeric("25.0000000000000000"), Numeric("50.0000000000000000"), Numeric("5.0000000000000000"), Numeric("7.0710678118654752")},
+						{"b", Numeric("156.2500000000000000"), Numeric("312.5000000000000000"), Numeric("12.5000000000000000"), Numeric("17.6776695296636881")},
+						{"c", Numeric("25.0000000000000000"), Numeric("50.0000000000000000"), Numeric("5.0000000000000000"), Numeric("7.0710678118654752")},
 					},
 				},
 				{
@@ -487,7 +487,24 @@ func TestWindowFunctions(t *testing.T) {
 					// variance/stddev must match var_samp/stddev_samp (Postgres semantics)
 					Query: "SELECT VARIANCE(val), STDDEV(val) FROM t3038b WHERE grp = 'a';",
 					Expected: []sql.Row{
-						{Numeric("50"), Numeric("7.07106781186547524")},
+						{Numeric("50.0000000000000000"), Numeric("7.0710678118654752")},
+					},
+				},
+			},
+		},
+		{
+			Name: "variance/stddev over float8 avoid cancellation for large nearly-equal values",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT avg(x::float8), var_pop(x::float8), var_samp(x::float8), stddev_pop(x::float8), stddev_samp(x::float8) FROM (VALUES (100000003), (100000004), (100000006), (100000007)) v(x);",
+					Expected: []sql.Row{
+						{float64(100000005), float64(2.5), float64(3.3333333333333335), float64(1.5811388300841898), float64(1.8257418583505538)},
+					},
+				},
+				{
+					Query: "SELECT avg(x::float8), var_pop(x::float8), var_samp(x::float8), stddev_pop(x::float8), stddev_samp(x::float8) FROM (VALUES (7000000000005), (7000000000007)) v(x);",
+					Expected: []sql.Row{
+						{float64(7000000000006), float64(1), float64(2), float64(1), float64(1.4142135623730951)},
 					},
 				},
 			},

--- a/testing/go/window_test.go
+++ b/testing/go/window_test.go
@@ -397,5 +397,100 @@ func TestWindowFunctions(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "variance/stddev window functions over an int column",
+			SetUpScript: []string{
+				"CREATE TABLE t3038 (id BIGINT PRIMARY KEY, grp VARCHAR(10), val INT);",
+				"INSERT INTO t3038 VALUES (1,'a',10), (2,'a',20), (3,'b',30), (4,'b',5), (5,'c',15), (6,'c',25);",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT id, STDDEV_POP(val) OVER (ORDER BY grp) FROM t3038 ORDER BY id;",
+					Expected: []sql.Row{
+						{1, Numeric("5")},
+						{2, Numeric("5")},
+						{3, Numeric("9.601432184835760219712")},
+						{4, Numeric("9.601432184835760219712")},
+						{5, Numeric("8.53912563829966531937038356855984732")},
+						{6, Numeric("8.53912563829966531937038356855984732")},
+					},
+				},
+				{
+					Query: "SELECT id, STDDEV_SAMP(val) OVER (ORDER BY grp) FROM t3038 ORDER BY id;",
+					Expected: []sql.Row{
+						{1, Numeric("7.07106781186547524")},
+						{2, Numeric("7.07106781186547524")},
+						{3, Numeric("11.0867789130417256043553548840367852")},
+						{4, Numeric("11.0867789130417256043553548840367852")},
+						{5, Numeric("9.354143466934853464")},
+						{6, Numeric("9.354143466934853464")},
+					},
+				},
+				{
+					Query: "SELECT id, VAR_POP(val) OVER (ORDER BY grp) FROM t3038 ORDER BY id;",
+					Expected: []sql.Row{
+						{1, Numeric("25")},
+						{2, Numeric("25")},
+						{3, Numeric("92.1875")},
+						{4, Numeric("92.1875")},
+						{5, Numeric("72.916666666666666667")},
+						{6, Numeric("72.916666666666666667")},
+					},
+				},
+				{
+					Query: "SELECT id, VAR_SAMP(val) OVER (ORDER BY grp) FROM t3038 ORDER BY id;",
+					Expected: []sql.Row{
+						{1, Numeric("50")},
+						{2, Numeric("50")},
+						{3, Numeric("122.91666666666666667")},
+						{4, Numeric("122.91666666666666667")},
+						{5, Numeric("87.5")},
+						{6, Numeric("87.5")},
+					},
+				},
+			},
+		},
+		{
+			Name: "variance/stddev as GROUP BY aggregates, single-row, float8, and aliases",
+			SetUpScript: []string{
+				"CREATE TABLE t3038b (grp VARCHAR(10), val INT);",
+				"INSERT INTO t3038b VALUES ('a',10), ('a',20), ('b',30), ('b',5), ('c',15), ('c',25);",
+				"CREATE TABLE t3038_one (val INT);",
+				"INSERT INTO t3038_one VALUES (42);",
+				"CREATE TABLE t3038_f (val DOUBLE PRECISION);",
+				"INSERT INTO t3038_f VALUES (10.0), (20.0);",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT grp, VAR_POP(val), VAR_SAMP(val), STDDEV_POP(val), STDDEV_SAMP(val) FROM t3038b GROUP BY grp ORDER BY grp;",
+					Expected: []sql.Row{
+						{"a", Numeric("25"), Numeric("50"), Numeric("5"), Numeric("7.07106781186547524")},
+						{"b", Numeric("156.25"), Numeric("312.5"), Numeric("12.5"), Numeric("17.67766952966368811")},
+						{"c", Numeric("25"), Numeric("50"), Numeric("5"), Numeric("7.07106781186547524")},
+					},
+				},
+				{
+					// A single row has a well-defined population variance/stddev (0, since there's no
+					// spread) but an undefined sample variance/stddev (NULL, not a divide-by-zero panic).
+					Query: "SELECT VAR_POP(val), VAR_SAMP(val), STDDEV_POP(val), STDDEV_SAMP(val) FROM t3038_one;",
+					Expected: []sql.Row{
+						{Numeric("0"), nil, Numeric("0"), nil},
+					},
+				},
+				{
+					Query: "SELECT VAR_POP(val), VAR_SAMP(val), STDDEV_POP(val), STDDEV_SAMP(val) FROM t3038_f;",
+					Expected: []sql.Row{
+						{float64(25), float64(50), float64(5), float64(7.0710678118654755)},
+					},
+				},
+				{
+					// variance/stddev must match var_samp/stddev_samp (Postgres semantics)
+					Query: "SELECT VARIANCE(val), STDDEV(val) FROM t3038b WHERE grp = 'a';",
+					Expected: []sql.Row{
+						{Numeric("50"), Numeric("7.07106781186547524")},
+					},
+				},
+			},
+		},
 	})
 }

--- a/testing/go/window_test.go
+++ b/testing/go/window_test.go
@@ -492,5 +492,33 @@ func TestWindowFunctions(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "variance/stddev over a real column, as GROUP BY aggregates and window functions",
+			SetUpScript: []string{
+				"CREATE TABLE t3038r (id INT PRIMARY KEY, grp VARCHAR(10), val REAL);",
+				"INSERT INTO t3038r VALUES (1,'a',10), (2,'a',20), (3,'b',30), (4,'b',5), (5,'c',15), (6,'c',25);",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "SELECT grp, VAR_POP(val), VAR_SAMP(val), STDDEV_POP(val), STDDEV_SAMP(val) FROM t3038r GROUP BY grp ORDER BY grp;",
+					Expected: []sql.Row{
+						{"a", float64(25), float64(50), float64(5), float64(7.0710678118654755)},
+						{"b", float64(156.25), float64(312.5), float64(12.5), float64(17.67766952966369)},
+						{"c", float64(25), float64(50), float64(5), float64(7.0710678118654755)},
+					},
+				},
+				{
+					Query: "SELECT id, VAR_POP(val) OVER (ORDER BY grp) FROM t3038r ORDER BY id;",
+					Expected: []sql.Row{
+						{1, float64(25)},
+						{2, float64(25)},
+						{3, float64(92.1875)},
+						{4, float64(92.1875)},
+						{5, float64(72.91666666666667)},
+						{6, float64(72.91666666666667)},
+					},
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
Fixed a bug where `STDDEV_POP`, `STDDEV_SAMP`, `VAR_POP`, `VAR_SAMP`, and their `variance` and `stddev` aliases would crash the server when used as window functions over integer columns. They now return correct, Postgres-compatible numeric/double precision results instead of panicking.                                   

Fixes: https://github.com/dolthub/doltgresql/issues/3038