### PR TITLE
Fix goroutine deadlock from unlocked mutex during panic

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -84,6 +84,14 @@ jobs:
           fi
           exit "$test_status"
 
+      - name: Fail if PR regression process deadlocked
+        run: |
+          LOG=testing/go/regression/out/pr-go-test.log
+          if [ -f "$LOG" ] && grep -q "panic: test timed out" "$LOG"; then
+            echo "::error::The PR regression test process hung and was killed by the 90m go test timeout. This is NOT a normal per-query test failure -- something deadlocked. See the goroutine dump in pr-go-test.log (uploaded as an artifact) to find what was stuck."
+            exit 1
+          fi
+
       - name: Upload PR regression artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -136,6 +144,14 @@ jobs:
             cp ../out/results.trackers ../out/results1.trackers
           fi
           exit "$test_status"
+
+      - name: Fail if main regression process deadlocked
+        run: |
+          LOG=testing/go/regression/out/main-go-test.log
+          if [ -f "$LOG" ] && grep -q "panic: test timed out" "$LOG"; then
+            echo "::error::The main regression test process hung and was killed by the 90m go test timeout. This is NOT a normal per-query test failure -- something deadlocked. See the goroutine dump in main-go-test.log (uploaded as an artifact) to find what was stuck."
+            exit 1
+          fi
 
       - name: Upload main regression artifacts
         if: always()

--- a/server/types/type.go
+++ b/server/types/type.go
@@ -596,26 +596,10 @@ func (t *DoltgresType) ConvertToType(ctx *sql.Context, typ sql.ExtendedType, val
 		return nil, sql.InRange, errors.Errorf("expected DoltgresType, got %T", typ)
 	}
 
-	t.mutex.Lock()
-	if t.castCache == nil {
-		t.castCache = make(map[*DoltgresType]Cast)
+	cast, err := t.getOrBuildCast(ctx, dt, convTyp)
+	if err != nil {
+		return nil, sql.InRange, err
 	}
-	var cast Cast
-	if cast, ok = t.castCache[dt]; !ok {
-		var err error
-		getCastFunc, err := GetCastFunc(ctx, convTyp)
-		if err != nil {
-			t.mutex.Unlock()
-			return nil, sql.InRange, err
-		}
-		cast, _, err = getCastFunc(dt, t)
-		if err != nil {
-			t.mutex.Unlock()
-			return nil, sql.InRange, err
-		}
-		t.castCache[dt] = cast
-	}
-	t.mutex.Unlock()
 
 	if cast == nil {
 		// In the case that we have an unknown type string literal, we attempt to parse it with the target type's
@@ -648,6 +632,28 @@ func (t *DoltgresType) ConvertToType(ctx *sql.Context, typ sql.ExtendedType, val
 	}
 
 	return castResult, sql.InRange, nil
+}
+
+// getOrBuildCast returns the cached Cast for converting to |dt|, building and caching it first if necessary.
+func (t *DoltgresType) getOrBuildCast(ctx *sql.Context, dt *DoltgresType, convTyp byte) (Cast, error) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	if t.castCache == nil {
+		t.castCache = make(map[*DoltgresType]Cast)
+	}
+	if cast, ok := t.castCache[dt]; ok {
+		return cast, nil
+	}
+	getCastFunc, err := GetCastFunc(ctx, convTyp)
+	if err != nil {
+		return nil, err
+	}
+	cast, _, err := getCastFunc(dt, t)
+	if err != nil {
+		return nil, err
+	}
+	t.castCache[dt] = cast
+	return cast, nil
 }
 
 // DomainUnderlyingBaseType returns an underlying base type of this domain type.
@@ -722,24 +728,9 @@ func (t *DoltgresType) IoInput(ctx *sql.Context, input string) (any, error) {
 
 // IoOutput converts given type value to output string.
 func (t *DoltgresType) IoOutput(ctx *sql.Context, val any) (string, error) {
-	var o any
-	var err error
+	outFunc := t.getOrResolveOutFunc(ctx)
 
-	var outFunc QuickFunction
-	t.mutex.Lock()
-	if t.outFunc == nil || t.outFuncID != t.OutputFunc {
-		t.outFuncID = t.OutputFunc
-		t.outFunc = globalFunctionRegistry.GetFunction(ctx, t.OutputFunc)
-		if t.ModInFunc != 0 || t.IsArrayType() || t.IsCompositeType() {
-			resTypes := t.outFunc.ResolvedTypes()
-			resTypes[0] = t
-			t.outFunc = t.outFunc.WithResolvedTypes(resTypes).(QuickFunction)
-		}
-	}
-	outFunc = t.outFunc
-	t.mutex.Unlock()
-
-	o, err = outFunc.CallVariadic(ctx, val)
+	o, err := outFunc.CallVariadic(ctx, val)
 	if err != nil {
 		return "", err
 	}
@@ -749,6 +740,23 @@ func (t *DoltgresType) IoOutput(ctx *sql.Context, val any) (string, error) {
 		return "", errors.Errorf("unexpected type for io output, expected string, got %T", val)
 	}
 	return os, err
+}
+
+// getOrResolveOutFunc returns the cached output QuickFunction for this type, resolving and caching it first if
+// necessary.
+func (t *DoltgresType) getOrResolveOutFunc(ctx *sql.Context) QuickFunction {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	if t.outFunc == nil || t.outFuncID != t.OutputFunc {
+		t.outFuncID = t.OutputFunc
+		t.outFunc = globalFunctionRegistry.GetFunction(ctx, t.OutputFunc)
+		if t.ModInFunc != 0 || t.IsArrayType() || t.IsCompositeType() {
+			resTypes := t.outFunc.ResolvedTypes()
+			resTypes[0] = t
+			t.outFunc = t.outFunc.WithResolvedTypes(resTypes).(QuickFunction)
+		}
+	}
+	return t.outFunc
 }
 
 // IsArrayType returns true if the type is of 'array' type.


### PR DESCRIPTION
Fixes a deadlock in DoltgresType.IoOutput/ConvertToType where a panic while resolving a type's cast or output function (e.g. an index-out-of-range on an unexpected empty ResolvedTypes()) left the type's mutex locked        
  forever, hanging every later query that touched the same type.

Also adds a step in the CI workflow to check for signs of a timeout in the logs, and if so, errors with a message about a deadlock timeout. 