### PR TITLE
audited error codes

### DIFF
--- a/core/typecollection/typecollection.go
+++ b/core/typecollection/typecollection.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/dolthub/doltgresql/core/id"
 	"github.com/dolthub/doltgresql/core/rootobject/objinterface"
+	"github.com/dolthub/doltgresql/postgres/parser/pgcode"
+	"github.com/dolthub/doltgresql/postgres/parser/pgerror"
 	parsertypes "github.com/dolthub/doltgresql/postgres/parser/types"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
@@ -240,7 +242,7 @@ func (pgs *TypeCollection) ResolveType(ctx context.Context, name id.Type) (*pgty
 		return nil, err
 	}
 	if !t.IsResolvedType() {
-		return nil, errors.Errorf("unable to resolve type `%s`", name.TypeName())
+		return nil, pgerror.WithCandidateCode(errors.Errorf("unable to resolve type `%s`", name.TypeName()), pgcode.UndefinedObject)
 	}
 	return t, nil
 }

--- a/server/cast/utils.go
+++ b/server/cast/utils.go
@@ -20,13 +20,12 @@ import (
 	"unicode/utf8"
 
 	cerrors "github.com/cockroachdb/errors"
-	"gopkg.in/src-d/go-errors.v1"
 
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
 // errOutOfRange is returned when a value is out of range for a given type.
-var errOutOfRange = errors.NewKind("%s out of range")
+var errOutOfRange = pgtypes.ErrOutOfRange
 
 // handleStringCast handles casts to the string types that may have length restrictions. Returns an error if other types
 // are passed in. Will always return the correct string, even on error, as some contexts may ignore the error.

--- a/server/connection_handler.go
+++ b/server/connection_handler.go
@@ -1430,7 +1430,6 @@ func (h *ConnectionHandler) endOfMessages(err error) {
 // sendError sends the given error to the client. This should generally never be called directly.
 func (h *ConnectionHandler) sendError(err error) {
 	pgErr := castSQLError(err)
-	fmt.Println(pgErr.Message)
 	if sendErr := h.send(&pgproto3.ErrorResponse{
 		Severity: pgErr.Severity,
 		Code:     pgErr.Code,

--- a/server/connection_handler.go
+++ b/server/connection_handler.go
@@ -48,9 +48,12 @@ import (
 	"github.com/dolthub/doltgresql/postgres/parser/parser"
 	psql "github.com/dolthub/doltgresql/postgres/parser/parser/sql"
 	"github.com/dolthub/doltgresql/postgres/parser/pgcode"
+	"github.com/dolthub/doltgresql/postgres/parser/pgerror"
 	"github.com/dolthub/doltgresql/postgres/parser/sem/tree"
 	"github.com/dolthub/doltgresql/server/ast"
+	"github.com/dolthub/doltgresql/server/functions/framework"
 	"github.com/dolthub/doltgresql/server/node"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
 // ConnectionHandler is responsible for the entire lifecycle of a user connection: receiving messages they send,
@@ -1426,21 +1429,12 @@ func (h *ConnectionHandler) endOfMessages(err error) {
 
 // sendError sends the given error to the client. This should generally never be called directly.
 func (h *ConnectionHandler) sendError(err error) {
-	var severity, code, errMsg string
-	if pgErr, ok := err.(*pgconn.PgError); ok {
-		severity = pgErr.Severity
-		code = pgErr.Code
-		errMsg = pgErr.Message
-	} else {
-		severity = string(ErrorResponseSeverity_Error)
-		code = pgcode.Internal.String() // internal_error for now
-		errMsg = err.Error()
-	}
-	fmt.Println(errMsg)
+	pgErr := castSQLError(err)
+	fmt.Println(pgErr.Message)
 	if sendErr := h.send(&pgproto3.ErrorResponse{
-		Severity: severity,
-		Code:     code,
-		Message:  errMsg,
+		Severity: pgErr.Severity,
+		Code:     pgErr.Code,
+		Message:  pgErr.Message,
 	}); sendErr != nil {
 		// If we're unable to send anything to the connection, then there's something wrong with the connection and
 		// we should terminate it. This will be caught in HandleConnection's defer block.
@@ -1584,12 +1578,68 @@ func castSQLError(err error) *pgconn.PgError {
 		return castSQLError(wm.Err)
 	}
 
-	// TODO: map more errors case
+	// Errors originating in our Postgres-derived parser already carry a candidate SQLSTATE (e.g. 42601
+	// for syntax errors, 0A000 for unimplemented syntax); report that code directly when present.
+	if pgerror.HasCandidateCode(err) {
+		if code := pgerror.GetPGCode(err); code != pgcode.Uncategorized {
+			return &pgconn.PgError{
+				Severity: string(ErrorResponseSeverity_Error),
+				Code:     code.String(),
+				Message:  err.Error(),
+			}
+		}
+	}
+
+	// Errors that reach a client with an XX-class (internal error) code are more than cosmetic: some
+	// clients (e.g. Npgsql) treat XX-class errors as critical failures and close the connection, so any
+	// error a client can provoke should be mapped to its proper SQLSTATE here.
 	// TODO: should update the error message to match Postgres
 	var code pgcode.Code
 	switch {
-	case sql.ErrCheckConstraintViolated.Is(err):
+	// Class 0A — Feature Not Supported
+	case sql.ErrUnsupportedFeature.Is(err), sql.ErrUnsupportedSyntax.Is(err):
+		code = pgcode.FeatureNotSupported
+	// Class 21 — Cardinality Violation
+	case sql.ErrExpectedSingleRow.Is(err), sql.ErrMoreThanOneRow.Is(err):
+		code = pgcode.CardinalityViolation
+	// Class 22 — Data Exception
+	case pgtypes.ErrDivisionByZero.Is(err):
+		code = pgcode.DivisionByZero
+	case sql.ErrValueOutOfRange.Is(err), pgtypes.ErrValueIsOutOfRangeForType.Is(err),
+		pgtypes.ErrOutOfRange.Is(err), pgtypes.ErrInputOutOfRange.Is(err),
+		errors.Is(err, pgtypes.ErrCastOutOfRange):
+		code = pgcode.NumericValueOutOfRange
+	case pgtypes.ErrInvalidSyntaxForType.Is(err), sql.ErrInvalidValue.Is(err):
+		code = pgcode.InvalidTextRepresentation
+	case pgtypes.ErrWrongLengthBit.Is(err), pgtypes.ErrVarBitLengthExceeded.Is(err):
+		code = pgcode.StringDataLengthMismatch
+	case sql.ErrInvalidTimeZone.Is(err), sql.ErrInvalidArgument.Is(err), sql.ErrInvalidArgumentDetails.Is(err):
+		code = pgcode.InvalidParameterValue
+	// Class 23 — Integrity Constraint Violation
+	case sql.ErrPrimaryKeyViolation.Is(err), sql.ErrUniqueKeyViolation.Is(err),
+		sql.ErrDuplicateEntry.Is(err), sql.ErrDuplicateEntrySet.Is(err):
+		code = pgcode.UniqueViolation
+	case sql.ErrForeignKeyChildViolation.Is(err), sql.ErrForeignKeyParentViolation.Is(err),
+		sql.ErrForeignKeyNotResolved.Is(err):
+		code = pgcode.ForeignKeyViolation
+	case sql.ErrCheckConstraintViolated.Is(err), pgtypes.ErrDomainValueViolatesCheckConstraint.Is(err):
 		code = pgcode.CheckViolation
+	case sql.ErrInsertIntoNonNullableProvidedNull.Is(err), sql.ErrInsertIntoNonNullableDefaultNullColumn.Is(err),
+		sql.ErrColumnDefaultReturnedNull.Is(err), pgtypes.ErrDomainDoesNotAllowNullValues.Is(err):
+		code = pgcode.NotNullViolation
+	// Class 25 — Invalid Transaction State
+	case sql.ErrReadOnly.Is(err), sql.ErrReadOnlyTransaction.Is(err):
+		code = pgcode.ReadOnlySQLTransaction
+	// Classes 26, 34, 3B — statement, cursor, and savepoint names
+	case sql.ErrUnknownPreparedStatement.Is(err):
+		code = pgcode.InvalidSQLStatementName
+	case sql.ErrCursorNotFound.Is(err):
+		code = pgcode.InvalidCursorName
+	case sql.ErrCursorAlreadyOpen.Is(err):
+		code = pgcode.DuplicateCursor
+	case sql.ErrSavepointDoesNotExist.Is(err):
+		code = pgcode.InvalidSavepointSpecification
+	// Classes 3D, 3F — catalog and schema names
 	case sql.ErrDatabaseExists.Is(err):
 		code = pgcode.DuplicateDatabase
 	case sql.ErrDatabaseNotFound.Is(err):
@@ -1598,14 +1648,37 @@ func castSQLError(err error) *pgconn.PgError {
 		code = pgcode.DuplicateSchema
 	case sql.ErrDatabaseSchemaNotFound.Is(err):
 		code = pgcode.UndefinedSchema
-	case sql.ErrForeignKeyChildViolation.Is(err):
-		code = pgcode.ForeignKeyViolation
-	case sql.ErrForeignKeyDuplicateName.Is(err):
-		code = pgcode.DuplicateObject
-	case sql.ErrTableNotFound.Is(err):
+	// Class 40 — Transaction Rollback. Dolt reports commit-time transaction conflicts as ErrLockDeadlock.
+	case sql.ErrLockDeadlock.Is(err):
+		code = pgcode.SerializationFailure
+	// Class 42 — Syntax or Access Rule Violation
+	case sql.ErrSyntaxError.Is(err), sql.ErrInvalidSyntax.Is(err), sql.ErrColValCountMismatch.Is(err),
+		sql.ErrInsertIntoMismatchValueCount.Is(err), sql.ErrColumnNumberDoesNotMatch.Is(err):
+		code = pgcode.Syntax
+	case sql.ErrPrivilegeCheckFailed.Is(err), sql.ErrDatabaseAccessDeniedForUser.Is(err),
+		sql.ErrTableAccessDeniedForUser.Is(err):
+		code = pgcode.InsufficientPrivilege
+	case sql.ErrNonAggregatedColumnWithoutGroupBy.Is(err):
+		code = pgcode.Grouping
+	case sql.ErrTableNotFound.Is(err), sql.ErrUnknownTable.Is(err), sql.ErrViewDoesNotExist.Is(err):
 		code = pgcode.UndefinedTable
-	case sql.ErrUniqueKeyViolation.Is(err):
-		code = pgcode.UniqueViolation
+	case sql.ErrTableAlreadyExists.Is(err), sql.ErrExistingView.Is(err):
+		code = pgcode.DuplicateRelation
+	case sql.ErrColumnNotFound.Is(err), sql.ErrTableColumnNotFound.Is(err), sql.ErrUnknownColumn.Is(err),
+		sql.ErrKeyColumnDoesNotExist.Is(err):
+		code = pgcode.UndefinedColumn
+	case sql.ErrColumnExists.Is(err), sql.ErrDuplicateColumn.Is(err), sql.ErrColumnSpecifiedTwice.Is(err):
+		code = pgcode.DuplicateColumn
+	case sql.ErrAmbiguousColumnName.Is(err), sql.ErrAmbiguousColumnOrAliasName.Is(err),
+		sql.ErrAmbiguousColumnInOrderBy.Is(err):
+		code = pgcode.AmbiguousColumn
+	case sql.ErrFunctionNotFound.Is(err), sql.ErrTableFunctionNotFound.Is(err),
+		sql.ErrInvalidArgumentNumber.Is(err), framework.ErrFunctionDoesNotExist.Is(err):
+		code = pgcode.UndefinedFunction
+	case sql.ErrForeignKeyDuplicateName.Is(err), pgtypes.ErrTypeAlreadyExists.Is(err):
+		code = pgcode.DuplicateObject
+	case sql.ErrUnknownSystemVariable.Is(err), sql.ErrUnknownConstraint.Is(err), pgtypes.ErrTypeDoesNotExist.Is(err):
+		code = pgcode.UndefinedObject
 	default:
 		code = pgcode.Internal
 	}

--- a/server/functions/acos.go
+++ b/server/functions/acos.go
@@ -17,7 +17,6 @@ package functions
 import (
 	"math"
 
-	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -38,7 +37,7 @@ var acos_float64 = framework.Function1{
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Acos(val1.(float64))
 		if math.IsNaN(r) {
-			return nil, errors.Errorf("input is out of range")
+			return nil, pgtypes.ErrInputOutOfRange.New()
 		}
 		return r, nil
 	},

--- a/server/functions/acosd.go
+++ b/server/functions/acosd.go
@@ -17,7 +17,6 @@ package functions
 import (
 	"math"
 
-	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -38,7 +37,7 @@ var acosd_float64 = framework.Function1{
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Acos(val1.(float64))
 		if math.IsNaN(r) {
-			return nil, errors.Errorf("input is out of range")
+			return nil, pgtypes.ErrInputOutOfRange.New()
 		}
 		return toDegrees(r), nil
 	},

--- a/server/functions/acosh.go
+++ b/server/functions/acosh.go
@@ -17,7 +17,6 @@ package functions
 import (
 	"math"
 
-	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -38,7 +37,7 @@ var acosh_float64 = framework.Function1{
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Acosh(val1.(float64))
 		if math.IsNaN(r) {
-			return nil, errors.Errorf("input is out of range")
+			return nil, pgtypes.ErrInputOutOfRange.New()
 		}
 		return r, nil
 	},

--- a/server/functions/asin.go
+++ b/server/functions/asin.go
@@ -17,7 +17,6 @@ package functions
 import (
 	"math"
 
-	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -38,7 +37,7 @@ var asin_float64 = framework.Function1{
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Asin(val1.(float64))
 		if math.IsNaN(r) {
-			return nil, errors.Errorf("input is out of range")
+			return nil, pgtypes.ErrInputOutOfRange.New()
 		}
 		return r, nil
 	},

--- a/server/functions/asind.go
+++ b/server/functions/asind.go
@@ -17,7 +17,6 @@ package functions
 import (
 	"math"
 
-	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -38,7 +37,7 @@ var asind_float64 = framework.Function1{
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Asin(val1.(float64))
 		if math.IsNaN(r) {
-			return nil, errors.Errorf("input is out of range")
+			return nil, pgtypes.ErrInputOutOfRange.New()
 		}
 		return toDegrees(r), nil
 	},

--- a/server/functions/asinh.go
+++ b/server/functions/asinh.go
@@ -17,7 +17,6 @@ package functions
 import (
 	"math"
 
-	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -38,7 +37,7 @@ var asinh_float64 = framework.Function1{
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Asinh(val1.(float64))
 		if math.IsNaN(r) {
-			return nil, errors.Errorf("input is out of range")
+			return nil, pgtypes.ErrInputOutOfRange.New()
 		}
 		return r, nil
 	},

--- a/server/functions/atan.go
+++ b/server/functions/atan.go
@@ -17,7 +17,6 @@ package functions
 import (
 	"math"
 
-	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -38,7 +37,7 @@ var atan_float64 = framework.Function1{
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Atan(val1.(float64))
 		if math.IsNaN(r) {
-			return nil, errors.Errorf("input is out of range")
+			return nil, pgtypes.ErrInputOutOfRange.New()
 		}
 		return r, nil
 	},

--- a/server/functions/atan2.go
+++ b/server/functions/atan2.go
@@ -17,7 +17,6 @@ package functions
 import (
 	"math"
 
-	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -38,7 +37,7 @@ var atan2_float64 = framework.Function2{
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, y any, x any) (any, error) {
 		r := math.Atan2(y.(float64), x.(float64))
 		if math.IsNaN(r) {
-			return nil, errors.Errorf("input is out of range")
+			return nil, pgtypes.ErrInputOutOfRange.New()
 		}
 		return r, nil
 	},

--- a/server/functions/atan2d.go
+++ b/server/functions/atan2d.go
@@ -17,7 +17,6 @@ package functions
 import (
 	"math"
 
-	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -38,7 +37,7 @@ var atan2d_float64 = framework.Function2{
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, y any, x any) (any, error) {
 		r := math.Atan2(y.(float64), x.(float64))
 		if math.IsNaN(r) {
-			return nil, errors.Errorf("input is out of range")
+			return nil, pgtypes.ErrInputOutOfRange.New()
 		}
 		return toDegrees(r), nil
 	},

--- a/server/functions/atand.go
+++ b/server/functions/atand.go
@@ -17,7 +17,6 @@ package functions
 import (
 	"math"
 
-	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -38,7 +37,7 @@ var atand_float64 = framework.Function1{
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Atan(val1.(float64))
 		if math.IsNaN(r) {
-			return nil, errors.Errorf("input is out of range")
+			return nil, pgtypes.ErrInputOutOfRange.New()
 		}
 		return toDegrees(r), nil
 	},

--- a/server/functions/atanh.go
+++ b/server/functions/atanh.go
@@ -17,7 +17,6 @@ package functions
 import (
 	"math"
 
-	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -38,7 +37,7 @@ var atanh_float64 = framework.Function1{
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
 		r := math.Atanh(val1.(float64))
 		if math.IsNaN(r) {
-			return nil, errors.Errorf("input is out of range")
+			return nil, pgtypes.ErrInputOutOfRange.New()
 		}
 		return r, nil
 	},

--- a/server/functions/binary/divide.go
+++ b/server/functions/binary/divide.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/apd/v3"
-	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/postgres/parser/duration"
@@ -52,7 +51,7 @@ func initBinaryDivide() {
 // float4div_callable is the callable logic for the float4div function.
 func float4div_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	if val2.(float32) == 0 {
-		return nil, errors.Errorf("division by zero")
+		return nil, pgtypes.ErrDivisionByZero.New()
 	}
 	return val1.(float32) / val2.(float32), nil
 }
@@ -69,7 +68,7 @@ var float4div = framework.Function2{
 // float48div_callable is the callable logic for the float48div function.
 func float48div_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	if val2.(float64) == 0 {
-		return nil, errors.Errorf("division by zero")
+		return nil, pgtypes.ErrDivisionByZero.New()
 	}
 	return float64(val1.(float32)) / val2.(float64), nil
 }
@@ -86,7 +85,7 @@ var float48div = framework.Function2{
 // float8div_callable is the callable logic for the float8div function.
 func float8div_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	if val2.(float64) == 0 {
-		return nil, errors.Errorf("division by zero")
+		return nil, pgtypes.ErrDivisionByZero.New()
 	}
 	return val1.(float64) / val2.(float64), nil
 }
@@ -103,7 +102,7 @@ var float8div = framework.Function2{
 // float84div_callable is the callable logic for the float84div function.
 func float84div_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	if val2.(float32) == 0 {
-		return nil, errors.Errorf("division by zero")
+		return nil, pgtypes.ErrDivisionByZero.New()
 	}
 	return val1.(float64) / float64(val2.(float32)), nil
 }
@@ -120,7 +119,7 @@ var float84div = framework.Function2{
 // int2div_callable is the callable logic for the int2div function.
 func int2div_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	if val2.(int16) == 0 {
-		return nil, errors.Errorf("division by zero")
+		return nil, pgtypes.ErrDivisionByZero.New()
 	}
 	return val1.(int16) / val2.(int16), nil
 }
@@ -137,7 +136,7 @@ var int2div = framework.Function2{
 // int24div_callable is the callable logic for the int24div function.
 func int24div_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	if val2.(int32) == 0 {
-		return nil, errors.Errorf("division by zero")
+		return nil, pgtypes.ErrDivisionByZero.New()
 	}
 	return int32(val1.(int16)) / val2.(int32), nil
 }
@@ -154,7 +153,7 @@ var int24div = framework.Function2{
 // int28div_callable is the callable logic for the int28div function.
 func int28div_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	if val2.(int64) == 0 {
-		return nil, errors.Errorf("division by zero")
+		return nil, pgtypes.ErrDivisionByZero.New()
 	}
 	return int64(val1.(int16)) / val2.(int64), nil
 }
@@ -171,7 +170,7 @@ var int28div = framework.Function2{
 // int4div_callable is the callable logic for the int4div function.
 func int4div_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	if val2.(int32) == 0 {
-		return nil, errors.Errorf("division by zero")
+		return nil, pgtypes.ErrDivisionByZero.New()
 	}
 	return val1.(int32) / val2.(int32), nil
 }
@@ -188,7 +187,7 @@ var int4div = framework.Function2{
 // int42div_callable is the callable logic for the int42div function.
 func int42div_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	if val2.(int16) == 0 {
-		return nil, errors.Errorf("division by zero")
+		return nil, pgtypes.ErrDivisionByZero.New()
 	}
 	return val1.(int32) / int32(val2.(int16)), nil
 }
@@ -205,7 +204,7 @@ var int42div = framework.Function2{
 // int48div_callable is the callable logic for the int48div function.
 func int48div_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	if val2.(int64) == 0 {
-		return nil, errors.Errorf("division by zero")
+		return nil, pgtypes.ErrDivisionByZero.New()
 	}
 	return int64(val1.(int32)) / val2.(int64), nil
 }
@@ -222,7 +221,7 @@ var int48div = framework.Function2{
 // int8div_callable is the callable logic for the int8div function.
 func int8div_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	if val2.(int64) == 0 {
-		return nil, errors.Errorf("division by zero")
+		return nil, pgtypes.ErrDivisionByZero.New()
 	}
 	return val1.(int64) / val2.(int64), nil
 }
@@ -239,7 +238,7 @@ var int8div = framework.Function2{
 // int82div_callable is the callable logic for the int82div function.
 func int82div_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	if val2.(int16) == 0 {
-		return nil, errors.Errorf("division by zero")
+		return nil, pgtypes.ErrDivisionByZero.New()
 	}
 	return val1.(int64) / int64(val2.(int16)), nil
 }
@@ -256,7 +255,7 @@ var int82div = framework.Function2{
 // int84div_callable is the callable logic for the int84div function.
 func int84div_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	if val2.(int32) == 0 {
-		return nil, errors.Errorf("division by zero")
+		return nil, pgtypes.ErrDivisionByZero.New()
 	}
 	return val1.(int64) / int64(val2.(int32)), nil
 }
@@ -273,7 +272,7 @@ var int84div = framework.Function2{
 // interval_div_callable is the callable logic for the interval_div function.
 func interval_div_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	if val2.(float64) == 0 {
-		return nil, errors.Errorf("division by zero")
+		return nil, pgtypes.ErrDivisionByZero.New()
 	}
 	return val1.(duration.Duration).DivFloat(val2.(float64)), nil
 }
@@ -296,7 +295,7 @@ func numeric_div_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any
 		return pgtypes.NumericNaN, nil
 	}
 	if num2.IsZero() {
-		return nil, errors.Errorf("division by zero")
+		return nil, pgtypes.ErrDivisionByZero.New()
 	}
 	if num1.Form == apd.Infinite {
 		return num1, nil

--- a/server/functions/binary/minus.go
+++ b/server/functions/binary/minus.go
@@ -114,7 +114,7 @@ var int2mi = framework.Function2{
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int16)) - int64(val2.(int16))
 		if result > math.MaxInt16 || result < math.MinInt16 {
-			return nil, errors.Errorf("smallint out of range")
+			return nil, pgtypes.ErrOutOfRange.New("smallint")
 		}
 		return int16(result), nil
 	},
@@ -129,7 +129,7 @@ var int24mi = framework.Function2{
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int16)) - int64(val2.(int32))
 		if result > math.MaxInt16 || result < math.MinInt16 {
-			return nil, errors.Errorf("integer out of range")
+			return nil, pgtypes.ErrOutOfRange.New("integer")
 		}
 		return int32(result), nil
 	},
@@ -155,7 +155,7 @@ var int4mi = framework.Function2{
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int32)) - int64(val2.(int32))
 		if result > math.MaxInt32 || result < math.MinInt32 {
-			return nil, errors.Errorf("integer out of range")
+			return nil, pgtypes.ErrOutOfRange.New("integer")
 		}
 		return int32(result), nil
 	},
@@ -170,7 +170,7 @@ var int42mi = framework.Function2{
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int32)) - int64(val2.(int16))
 		if result > math.MaxInt32 || result < math.MinInt32 {
-			return nil, errors.Errorf("integer out of range")
+			return nil, pgtypes.ErrOutOfRange.New("integer")
 		}
 		return int32(result), nil
 	},
@@ -418,11 +418,11 @@ var timetz_mi_interval = framework.Function2{
 func minusOverflow(val1 int64, val2 int64) (any, error) {
 	if val2 > 0 {
 		if val1 < math.MinInt64+val2 {
-			return nil, errors.Errorf("bigint out of range")
+			return nil, pgtypes.ErrOutOfRange.New("bigint")
 		}
 	} else {
 		if val1 > math.MaxInt64+val2 {
-			return nil, errors.Errorf("bigint out of range")
+			return nil, pgtypes.ErrOutOfRange.New("bigint")
 		}
 	}
 	return val1 - val2, nil

--- a/server/functions/binary/mod.go
+++ b/server/functions/binary/mod.go
@@ -16,7 +16,6 @@ package binary
 
 import (
 	"github.com/cockroachdb/apd/v3"
-	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 
@@ -43,7 +42,7 @@ var int2mod = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int16) == 0 {
-			return nil, errors.Errorf("division by zero")
+			return nil, pgtypes.ErrDivisionByZero.New()
 		}
 		return val1.(int16) % val2.(int16), nil
 	},
@@ -57,7 +56,7 @@ var int4mod = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int32) == 0 {
-			return nil, errors.Errorf("division by zero")
+			return nil, pgtypes.ErrDivisionByZero.New()
 		}
 		return val1.(int32) % val2.(int32), nil
 	},
@@ -71,7 +70,7 @@ var int8mod = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int64) == 0 {
-			return nil, errors.Errorf("division by zero")
+			return nil, pgtypes.ErrDivisionByZero.New()
 		}
 		return val1.(int64) % val2.(int64), nil
 	},
@@ -91,7 +90,7 @@ var numeric_mod = framework.Function2{
 			return pgtypes.NumericNaN, nil
 		}
 		if num2.IsZero() {
-			return nil, errors.Errorf("division by zero")
+			return nil, pgtypes.ErrDivisionByZero.New()
 		}
 		if num1.Form == apd.Infinite {
 			return num1, nil

--- a/server/functions/binary/multiply.go
+++ b/server/functions/binary/multiply.go
@@ -18,7 +18,6 @@ import (
 	"math"
 
 	"github.com/cockroachdb/apd/v3"
-	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/postgres/parser/duration"
@@ -101,7 +100,7 @@ var int2mul = framework.Function2{
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int16)) * int64(val2.(int16))
 		if result > math.MaxInt16 || result < math.MinInt16 {
-			return nil, errors.Errorf("smallint out of range")
+			return nil, pgtypes.ErrOutOfRange.New("smallint")
 		}
 		return int16(result), nil
 	},
@@ -116,7 +115,7 @@ var int24mul = framework.Function2{
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int16)) * int64(val2.(int32))
 		if result > math.MaxInt16 || result < math.MinInt16 {
-			return nil, errors.Errorf("integer out of range")
+			return nil, pgtypes.ErrOutOfRange.New("integer")
 		}
 		return int32(result), nil
 	},
@@ -142,7 +141,7 @@ var int4mul = framework.Function2{
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int32)) * int64(val2.(int32))
 		if result > math.MaxInt32 || result < math.MinInt32 {
-			return nil, errors.Errorf("integer out of range")
+			return nil, pgtypes.ErrOutOfRange.New("integer")
 		}
 		return int32(result), nil
 	},
@@ -157,7 +156,7 @@ var int42mul = framework.Function2{
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		result := int64(val1.(int32)) * int64(val2.(int16))
 		if result > math.MaxInt32 || result < math.MinInt32 {
-			return nil, errors.Errorf("integer out of range")
+			return nil, pgtypes.ErrOutOfRange.New("integer")
 		}
 		return int32(result), nil
 	},
@@ -244,7 +243,7 @@ var numeric_mul = framework.Function2{
 func multiplyOverflow(val1 int64, val2 int64) (any, error) {
 	result := val1 * val2
 	if val2 != 0 && result/val2 != val1 {
-		return nil, errors.Errorf("bigint out of range")
+		return nil, pgtypes.ErrOutOfRange.New("bigint")
 	}
 	return result, nil
 }

--- a/server/functions/binary/plus.go
+++ b/server/functions/binary/plus.go
@@ -128,7 +128,7 @@ var float84pl = framework.Function2{
 func int2pl_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	result := int64(val1.(int16)) + int64(val2.(int16))
 	if result > math.MaxInt16 || result < math.MinInt16 {
-		return nil, errors.Errorf("smallint out of range")
+		return nil, pgtypes.ErrOutOfRange.New("smallint")
 	}
 	return int16(result), nil
 }
@@ -146,7 +146,7 @@ var int2pl = framework.Function2{
 func int24pl_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	result := int64(val1.(int16)) + int64(val2.(int32))
 	if result > math.MaxInt16 || result < math.MinInt16 {
-		return nil, errors.Errorf("integer out of range")
+		return nil, pgtypes.ErrOutOfRange.New("integer")
 	}
 	return int32(result), nil
 }
@@ -178,7 +178,7 @@ var int28pl = framework.Function2{
 func int4pl_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	result := int64(val1.(int32)) + int64(val2.(int32))
 	if result > math.MaxInt32 || result < math.MinInt32 {
-		return nil, errors.Errorf("integer out of range")
+		return nil, pgtypes.ErrOutOfRange.New("integer")
 	}
 	return int32(result), nil
 }
@@ -196,7 +196,7 @@ var int4pl = framework.Function2{
 func int42pl_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 	result := int64(val1.(int32)) + int64(val2.(int16))
 	if result > math.MaxInt32 || result < math.MinInt32 {
-		return nil, errors.Errorf("integer out of range")
+		return nil, pgtypes.ErrOutOfRange.New("integer")
 	}
 	return int32(result), nil
 }
@@ -413,11 +413,11 @@ var numeric_add = framework.Function2{
 func plusOverflow(val1 int64, val2 int64) (any, error) {
 	if val2 > 0 {
 		if val1 > math.MaxInt64-val2 {
-			return nil, errors.Errorf("bigint out of range")
+			return nil, pgtypes.ErrOutOfRange.New("bigint")
 		}
 	} else {
 		if val1 < math.MinInt64-val2 {
-			return nil, errors.Errorf("bigint out of range")
+			return nil, pgtypes.ErrOutOfRange.New("bigint")
 		}
 	}
 	return val1 + val2, nil

--- a/server/functions/div.go
+++ b/server/functions/div.go
@@ -16,7 +16,6 @@ package functions
 
 import (
 	"github.com/cockroachdb/apd/v3"
-	errors "github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -42,7 +41,7 @@ var div_numeric = framework.Function2{
 			return pgtypes.NumericNaN, nil
 		}
 		if num2.IsZero() {
-			return nil, errors.Errorf("division by zero")
+			return nil, pgtypes.ErrDivisionByZero.New()
 		}
 		if num1.Form == apd.Infinite {
 			return num1, nil

--- a/server/functions/lcm.go
+++ b/server/functions/lcm.go
@@ -15,7 +15,6 @@
 package functions
 
 import (
-	"github.com/cockroachdb/errors"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
@@ -52,7 +51,7 @@ var lcm_int64_int64 = framework.Function2{
 		// Check for overflow
 		result := val1 * val2
 		if val2 != 0 && result/val2 != val1 {
-			return nil, errors.Errorf("bigint out of range")
+			return nil, pgtypes.ErrOutOfRange.New("bigint")
 		}
 		return utils.Abs(result / gcdResult), nil
 	},

--- a/server/functions/lcm.go
+++ b/server/functions/lcm.go
@@ -15,7 +15,6 @@
 package functions
 
 import (
-
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"

--- a/server/functions/log.go
+++ b/server/functions/log.go
@@ -112,7 +112,7 @@ var log_numeric_numeric = framework.Function2{
 			return nil, err
 		}
 		if lnBase.IsZero() {
-			return nil, errors.Errorf("division by zero")
+			return nil, pgtypes.ErrDivisionByZero.New()
 		}
 
 		lnNum := new(apd.Decimal)

--- a/server/functions/mod.go
+++ b/server/functions/mod.go
@@ -16,7 +16,6 @@ package functions
 
 import (
 	"github.com/cockroachdb/apd/v3"
-	"github.com/cockroachdb/errors"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
@@ -41,7 +40,7 @@ var mod_int16_int16 = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int16) == 0 {
-			return nil, errors.Errorf("division by zero")
+			return nil, pgtypes.ErrDivisionByZero.New()
 		}
 		return val1.(int16) % val2.(int16), nil
 	},
@@ -55,7 +54,7 @@ var mod_int32_int32 = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int32) == 0 {
-			return nil, errors.Errorf("division by zero")
+			return nil, pgtypes.ErrDivisionByZero.New()
 		}
 		return val1.(int32) % val2.(int32), nil
 	},
@@ -69,7 +68,7 @@ var mod_int64_int64 = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
 		if val2.(int64) == 0 {
-			return nil, errors.Errorf("division by zero")
+			return nil, pgtypes.ErrDivisionByZero.New()
 		}
 		return val1.(int64) % val2.(int64), nil
 	},
@@ -89,7 +88,7 @@ var mod_numeric_numeric = framework.Function2{
 			return pgtypes.NumericNaN, nil
 		}
 		if num2.IsZero() {
-			return nil, errors.Errorf("division by zero")
+			return nil, pgtypes.ErrDivisionByZero.New()
 		}
 		if num1.Form == apd.Infinite {
 			return num1, nil

--- a/server/functions/to_timestamp.go
+++ b/server/functions/to_timestamp.go
@@ -65,7 +65,7 @@ var to_timestamp_float8 = framework.Function1{
 
 		// Check for valid timestamp range (PostgreSQL limits)
 		if timestamp < -210866803200 || timestamp > 9223372036.854775 {
-			return nil, errors.Errorf("timestamp out of range")
+			return nil, pgtypes.ErrOutOfRange.New("timestamp")
 		}
 
 		return time.Unix(sec, nsec).UTC(), nil

--- a/server/tables/pg_database.go
+++ b/server/tables/pg_database.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/dolthub/doltgresql/core"
 	"github.com/dolthub/doltgresql/core/id"
+	"github.com/dolthub/doltgresql/postgres/parser/pgcode"
+	"github.com/dolthub/doltgresql/postgres/parser/pgerror"
 )
 
 // PgDatabase wraps a sqle.Database to add PostgreSQL-specific behavior.
@@ -198,7 +200,7 @@ func (d *PgDatabase) ValidateNewIndexName(ctx *sql.Context, newIndexName string,
 		return true, nil
 	}
 
-	return nameAlreadyUsed, fmt.Errorf(`relation "%s" already exists`, newIndexName)
+	return nameAlreadyUsed, pgerror.WithCandidateCode(fmt.Errorf(`relation "%s" already exists`, newIndexName), pgcode.DuplicateRelation)
 }
 
 // ValidateNewSequenceName implements the sql.SchemaObjectNameValidator interface
@@ -216,7 +218,7 @@ func (d *PgDatabase) ValidateNewSequenceName(ctx *sql.Context, newSequenceName s
 		return true, nil
 	}
 
-	return nameAlreadyUsed, fmt.Errorf(`relation "%s" already exists`, newSequenceName)
+	return nameAlreadyUsed, pgerror.WithCandidateCode(fmt.Errorf(`relation "%s" already exists`, newSequenceName), pgcode.DuplicateRelation)
 }
 
 // ValidateNewViewName implements the sql.SchemaObjectNameValidator interface
@@ -239,7 +241,7 @@ func (d *PgDatabase) ValidateNewViewName(ctx *sql.Context, newViewName string, r
 		}
 	}
 
-	return fmt.Errorf(`relation "%s" already exists`, newViewName)
+	return pgerror.WithCandidateCode(fmt.Errorf(`relation "%s" already exists`, newViewName), pgcode.DuplicateRelation)
 }
 
 // ValidateNewTableName implements the sql.SchemaObjectNameValidator interface
@@ -257,7 +259,7 @@ func (d *PgDatabase) ValidateNewTableName(ctx *sql.Context, newTableName string,
 		return true, nil
 	}
 
-	return true, fmt.Errorf(`relation "%s" already exists`, newTableName)
+	return true, pgerror.WithCandidateCode(fmt.Errorf(`relation "%s" already exists`, newTableName), pgcode.DuplicateRelation)
 }
 
 // GenerateIndexName implements the sql.IndexNameGenerator interface with PostgreSQL-compatible naming conventions:

--- a/server/types/utils.go
+++ b/server/types/utils.go
@@ -30,6 +30,18 @@ import (
 	"github.com/dolthub/doltgresql/utils"
 )
 
+// ErrDivisionByZero is returned when dividing by zero. It is defined as an error kind (rather than each
+// division site creating its own error) so that the server can report it with SQLSTATE 22012.
+var ErrDivisionByZero = errors.NewKind(`division by zero`)
+
+// ErrOutOfRange is returned when a value overflows the given type (e.g. "integer out of range").
+// It is defined as an error kind so that the server can report it with SQLSTATE 22003.
+var ErrOutOfRange = errors.NewKind(`%s out of range`)
+
+// ErrInputOutOfRange is returned by math functions whose input is outside the function's valid domain.
+// It is defined as an error kind so that the server can report it with SQLSTATE 22003.
+var ErrInputOutOfRange = errors.NewKind(`input is out of range`)
+
 // ErrTypeAlreadyExists is returned when creating given type when it already exists.
 var ErrTypeAlreadyExists = errors.NewKind(`type "%s" already exists`)
 

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -1078,7 +1078,7 @@ func TestSystemInformationFunctions(t *testing.T) {
 				},
 				{
 					Query:       `SELECT current_catalog();`,
-					ExpectedErr: `ERROR: at or near "(": syntax error (SQLSTATE XX000)`,
+					ExpectedErr: `ERROR: at or near "(": syntax error (SQLSTATE 42601)`,
 				},
 				// // TODO: Implement table function for current_catalog
 				{
@@ -1090,7 +1090,7 @@ func TestSystemInformationFunctions(t *testing.T) {
 				},
 				{
 					Query:       `SELECT * FROM current_catalog();`,
-					ExpectedErr: `ERROR: at or near "(": syntax error (SQLSTATE XX000)`,
+					ExpectedErr: `ERROR: at or near "(": syntax error (SQLSTATE 42601)`,
 				},
 			},
 		},

--- a/testing/go/sqlstate_test.go
+++ b/testing/go/sqlstate_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _go
+
+import (
+	"testing"
+)
+
+// TestSQLStateCodes asserts the SQLSTATE reported for the error classes that castSQLError maps.
+// Reporting the proper SQLSTATE is more than cosmetic: errors that reach a client with an XX-class
+// (internal error) code are treated as critical failures by some clients — Npgsql, for example,
+// closes the connection on any XX-class error — and error-handling code in applications and ORMs
+// dispatches on these codes.
+func TestSQLStateCodes(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "class 22 data exception",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:           "SELECT 1/0",
+					ExpectedErr:     "division by zero",
+					ExpectedErrCode: "22012",
+				},
+				{
+					Query:           "SELECT 5 % 0",
+					ExpectedErr:     "division by zero",
+					ExpectedErrCode: "22012",
+				},
+				{
+					Query:           "SELECT 'abc'::int4",
+					ExpectedErr:     "invalid input syntax for type int4",
+					ExpectedErrCode: "22P02",
+				},
+				{
+					Query:           "SELECT (2000000000)::int4 + (2000000000)::int4",
+					ExpectedErr:     "integer out of range",
+					ExpectedErrCode: "22003",
+				},
+				{
+					Query:           "SELECT acos(2.0)",
+					ExpectedErr:     "input is out of range",
+					ExpectedErrCode: "22003",
+				},
+			},
+		},
+		{
+			Name: "class 23 integrity constraint violation",
+			SetUpScript: []string{
+				"CREATE TABLE constraints_t (id INT PRIMARY KEY, u INT UNIQUE, n INT NOT NULL, c INT CHECK (c > 0))",
+				"INSERT INTO constraints_t VALUES (1, 1, 1, 1)",
+				"CREATE TABLE fk_parent (id INT PRIMARY KEY)",
+				"CREATE TABLE fk_child (id INT PRIMARY KEY, pid INT REFERENCES fk_parent(id))",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:           "INSERT INTO constraints_t VALUES (1, 2, 2, 2)",
+					ExpectedErr:     "duplicate primary key given",
+					ExpectedErrCode: "23505",
+				},
+				{
+					Query:           "INSERT INTO constraints_t VALUES (2, 1, 2, 2)",
+					ExpectedErr:     "duplicate unique key given",
+					ExpectedErrCode: "23505",
+				},
+				{
+					Query:           "INSERT INTO constraints_t VALUES (2, 2, NULL, 2)",
+					ExpectedErr:     "non-nullable",
+					ExpectedErrCode: "23502",
+				},
+				{
+					Query:           "INSERT INTO constraints_t VALUES (2, 2, 2, -1)",
+					ExpectedErr:     "Check constraint",
+					ExpectedErrCode: "23514",
+				},
+				{
+					Query:           "INSERT INTO fk_child VALUES (1, 99)",
+					ExpectedErr:     "Foreign key violation",
+					ExpectedErrCode: "23503",
+				},
+			},
+		},
+		{
+			Name: "class 42 undefined and duplicate objects",
+			SetUpScript: []string{
+				"CREATE TABLE existing_t (id INT PRIMARY KEY)",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:           "SELEC 1",
+					ExpectedErr:     "syntax error",
+					ExpectedErrCode: "42601",
+				},
+				{
+					Query:           "SELECT * FROM no_such_table",
+					ExpectedErr:     "table not found",
+					ExpectedErrCode: "42P01",
+				},
+				{
+					Query:           "SELECT no_such_col FROM existing_t",
+					ExpectedErr:     "could not be found",
+					ExpectedErrCode: "42703",
+				},
+				{
+					Query:           "SELECT no_such_function(1)",
+					ExpectedErr:     "not found",
+					ExpectedErrCode: "42883",
+				},
+				{
+					Query:           "CREATE TABLE existing_t (id INT PRIMARY KEY)",
+					ExpectedErr:     "already exists",
+					ExpectedErrCode: "42P07",
+				},
+				{
+					Query:           "SELECT 1::no_such_type",
+					ExpectedErr:     "unable to resolve type",
+					ExpectedErrCode: "42704",
+				},
+			},
+		},
+		{
+			Name: "class 3D undefined database",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:           "SELECT * FROM no_such_db.public.tbl",
+					ExpectedErr:     "database not found",
+					ExpectedErrCode: "3D000",
+				},
+			},
+		},
+		{
+			Name: "class 21 cardinality violation",
+			SetUpScript: []string{
+				"CREATE TABLE two_rows (id INT PRIMARY KEY)",
+				"INSERT INTO two_rows VALUES (1), (2)",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:           "SELECT (SELECT id FROM two_rows)",
+					ExpectedErr:     "more than 1 row",
+					ExpectedErrCode: "21000",
+				},
+			},
+		},
+	})
+}

--- a/testing/postgres-client-tests/dotnet/Program.cs
+++ b/testing/postgres-client-tests/dotnet/Program.cs
@@ -90,6 +90,90 @@ await RunPreparedQuery(
             throw new Exception($"expected 2 rows in test, got {size}");
     });
 
+// Error codes: Npgsql exposes the SQLSTATE as PostgresException.SqlState, and treats
+// XX-class (internal error) codes as critical failures that break the connection. These
+// checks confirm both that the correct codes arrive and that the connection stays open
+// after each error, which is what makes ORM error handling (EF Core et al.) work.
+foreach (var (sql, wantCode, label) in new[]
+{
+    ("INSERT INTO test (pk, value) VALUES (0, 0)", "23505", "unique violation"),
+    ("SELECT * FROM no_such_table", "42P01", "undefined table"),
+    ("SELECT 1/0", "22012", "division by zero"),
+    ("SELEC 1", "42601", "syntax error"),
+    ("SELECT 'abc'::int4", "22P02", "invalid text representation"),
+})
+{
+    try
+    {
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        await cmd.ExecuteNonQueryAsync();
+        throw new Exception($"{label}: expected SQLSTATE {wantCode}, but the query succeeded");
+    }
+    catch (PostgresException e)
+    {
+        if (e.SqlState != wantCode)
+            throw new Exception($"{label}: expected SQLSTATE {wantCode}, got {e.SqlState} ({e.MessageText})");
+    }
+    if (conn.State != System.Data.ConnectionState.Open)
+        throw new Exception($"{label}: connection did not survive the error");
+}
+
+// A failed statement inside a driver-API transaction must be rollback-able, with the
+// connection intact — the mechanism ORMs rely on for atomic writes.
+await using (var tx = await conn.BeginTransactionAsync())
+{
+    await using (var cmd = new NpgsqlCommand("INSERT INTO test (pk, value) VALUES (100, 100)", conn))
+        await cmd.ExecuteNonQueryAsync();
+    try
+    {
+        await using var cmd = new NpgsqlCommand("INSERT INTO test (pk, value) VALUES (100, 100)", conn);
+        await cmd.ExecuteNonQueryAsync();
+        throw new Exception("expected duplicate key error inside transaction");
+    }
+    catch (PostgresException e)
+    {
+        if (e.SqlState != "23505")
+            throw new Exception($"expected SQLSTATE 23505 inside transaction, got {e.SqlState}");
+    }
+    await tx.RollbackAsync();
+}
+await using (var cmd = new NpgsqlCommand("SELECT COUNT(*) FROM test WHERE pk = 100", conn))
+{
+    var count = (long)(await cmd.ExecuteScalarAsync())!;
+    if (count != 0)
+        throw new Exception($"expected rolled-back insert to leave 0 rows, got {count}");
+}
+
+// Conflicting concurrent transactions: the losing COMMIT must report 40001
+// (serialization_failure), the code retry logic dispatches on.
+await using (var conn2 = new NpgsqlConnection(connStr))
+{
+    await conn2.OpenAsync();
+    await using var tx = await conn.BeginTransactionAsync();
+    await using (var cmd = new NpgsqlCommand("UPDATE test SET value = 10 WHERE pk = 0", conn))
+        await cmd.ExecuteNonQueryAsync();
+    await using (var cmd = new NpgsqlCommand("UPDATE test SET value = 20 WHERE pk = 0", conn2))
+        await cmd.ExecuteNonQueryAsync();
+    try
+    {
+        await tx.CommitAsync();
+        throw new Exception("expected serialization failure on conflicting commit");
+    }
+    catch (PostgresException e)
+    {
+        if (e.SqlState != "40001")
+            throw new Exception($"expected SQLSTATE 40001 on conflicting commit, got {e.SqlState}");
+    }
+}
+
+// ... and the session must be usable again immediately.
+await using (var cmd = new NpgsqlCommand("SELECT COUNT(*) FROM test", conn))
+{
+    var count = (long)(await cmd.ExecuteScalarAsync())!;
+    if (count != 2)
+        throw new Exception($"expected 2 rows after recovery, got {count}");
+}
+
 Console.WriteLine("Npgsql test passed");
 
 async Task RunPreparedQuery(string query, object[] queryArgs, Func<NpgsqlDataReader, Task> check)

--- a/testing/postgres-client-tests/node/errors.js
+++ b/testing/postgres-client-tests/node/errors.js
@@ -1,0 +1,81 @@
+import pkg from "pg";
+import { getConfig } from "./helpers.js";
+
+const { Client } = pkg;
+
+// Tests that Doltgres reports errors with the correct SQLSTATE and that the
+// connection remains usable afterwards. node-postgres exposes the SQLSTATE as
+// `err.code`, which is what applications and libraries dispatch on.
+
+async function newClient() {
+  const client = new Client(getConfig());
+  await client.connect();
+  return client;
+}
+
+async function expectCode(client, sql, wantCode, label) {
+  let err;
+  try {
+    await client.query(sql);
+  } catch (e) {
+    err = e;
+  }
+  if (err === undefined) {
+    throw new Error(`${label}: expected SQLSTATE ${wantCode}, but the query succeeded`);
+  }
+  if (err.code !== wantCode) {
+    throw new Error(
+      `${label}: expected SQLSTATE ${wantCode}, got ${err.code} (${err.message})`
+    );
+  }
+}
+
+async function main() {
+  const client = await newClient();
+  await client.query("DROP TABLE IF EXISTS err_test");
+  await client.query(
+    "CREATE TABLE err_test (id INT PRIMARY KEY, val INT NOT NULL CHECK (val >= 0))"
+  );
+  await client.query("INSERT INTO err_test VALUES (1, 1)");
+
+  await expectCode(client, "INSERT INTO err_test VALUES (1, 1)", "23505", "unique violation");
+  await expectCode(client, "INSERT INTO err_test VALUES (2, NULL)", "23502", "not-null violation");
+  await expectCode(client, "INSERT INTO err_test VALUES (2, -1)", "23514", "check violation");
+  await expectCode(client, "SELECT * FROM no_such_table", "42P01", "undefined table");
+  await expectCode(client, "SELECT no_such_col FROM err_test", "42703", "undefined column");
+  await expectCode(client, "SELECT no_such_function(1)", "42883", "undefined function");
+  await expectCode(client, "SELECT 1/0", "22012", "division by zero");
+  await expectCode(client, "SELEC 1", "42601", "syntax error");
+  await expectCode(client, "SELECT 'abc'::int4", "22P02", "invalid text representation");
+
+  // The connection must have survived every error above.
+  const res = await client.query("SELECT count(*)::int4 AS n FROM err_test");
+  if (res.rows[0].n !== 1) {
+    throw new Error(`expected 1 row after failed statements, got ${res.rows[0].n}`);
+  }
+
+  // Conflicting concurrent transactions: the losing COMMIT must report 40001
+  // (serialization_failure), the code retry logic dispatches on.
+  const client2 = await newClient();
+  await client.query("BEGIN");
+  await client.query("UPDATE err_test SET val = 10 WHERE id = 1");
+  await client2.query("UPDATE err_test SET val = 20 WHERE id = 1");
+  await expectCode(client, "COMMIT", "40001", "serialization failure");
+
+  // ... and the session must be usable again immediately.
+  await client.query("UPDATE err_test SET val = 30 WHERE id = 1");
+  const after = await client.query("SELECT val FROM err_test WHERE id = 1");
+  if (after.rows[0].val !== 30) {
+    throw new Error(`expected val=30 after recovery, got ${after.rows[0].val}`);
+  }
+
+  await client.end();
+  await client2.end();
+  console.log("node error-code tests passed");
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/testing/postgres-client-tests/postgres-client-tests.bats
+++ b/testing/postgres-client-tests/postgres-client-tests.bats
@@ -30,6 +30,10 @@ teardown() {
     node $BATS_TEST_DIRNAME/node/index.js $USER $PORT
 }
 
+@test "node postgres client, error codes" {
+    node $BATS_TEST_DIRNAME/node/errors.js $USER $PORT
+}
+
 @test "knex node postgres client" {
     DOLTGRES_VERSION=$( doltgres --version | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p' )
     echo $DOLTGRES_VERSION
@@ -53,6 +57,10 @@ teardown() {
 
 @test "ruby Sequel client" {
     ruby $BATS_TEST_DIRNAME/ruby/sequel-test.rb $USER $PORT
+}
+
+@test "ruby Sequel client, serialization failure retry" {
+    ruby $BATS_TEST_DIRNAME/ruby/sequel-retry-test.rb $USER $PORT
 }
 
 @test "ruby ActiveRecord client" {

--- a/testing/postgres-client-tests/python/psycopg2_test.py
+++ b/testing/postgres-client-tests/python/psycopg2_test.py
@@ -86,6 +86,68 @@ def compliance_test(cur):
     print("Compliance queries executed OK.", flush=True)
 
 
+# error_code_test asserts that errors arrive with the correct SQLSTATE and are interpreted
+# correctly by the client. psycopg2 constructs its exception classes from the SQLSTATE the
+# server reports (psycopg2.errors), so catching the specific class checks both at once.
+def error_code_test(user, port):
+    print("\n=== Part 3: Error codes ===", flush=True)
+    from psycopg2 import errors
+
+    conn = connect(user, port)
+    cur = conn.cursor()
+    run(cur, "DROP TABLE IF EXISTS err_test")
+    run(cur, "CREATE TABLE err_test (id INT PRIMARY KEY, val INT NOT NULL)")
+    run(cur, "INSERT INTO err_test VALUES (1, 1)")
+
+    cases = [
+        ("INSERT INTO err_test VALUES (1, 1)", errors.UniqueViolation, "23505"),
+        ("INSERT INTO err_test VALUES (2, NULL)", errors.NotNullViolation, "23502"),
+        ("SELECT * FROM no_such_table", errors.UndefinedTable, "42P01"),
+        ("SELECT no_such_col FROM err_test", errors.UndefinedColumn, "42703"),
+        ("SELECT 1/0", errors.DivisionByZero, "22012"),
+        ("SELEC 1", errors.SyntaxError, "42601"),
+        ("SELECT 'abc'::int4", errors.InvalidTextRepresentation, "22P02"),
+    ]
+    for sql, exc_class, code in cases:
+        print(f"SQL> {sql}  (expect {exc_class.__name__} / {code})", flush=True)
+        try:
+            cur.execute(sql)
+        except exc_class as e:
+            if e.pgcode != code:
+                raise AssertionError(f"{sql}: expected pgcode {code}, got {e.pgcode}")
+        else:
+            raise AssertionError(f"{sql}: expected {exc_class.__name__}, but query succeeded")
+
+    # the connection must have survived every error above
+    cur.execute("SELECT COUNT(*) FROM err_test")
+    if cur.fetchone()[0] != 1:
+        raise AssertionError("unexpected row count after failed statements")
+
+    # Conflicting concurrent transactions: the losing commit must raise
+    # SerializationFailure (SQLSTATE 40001), which retry logic dispatches on.
+    conn_a = connect(user, port)
+    conn_a.autocommit = False
+    conn_b = conn  # autocommit, plays the concurrent writer
+    cur_a = conn_a.cursor()
+    cur_a.execute("UPDATE err_test SET val = 10 WHERE id = 1")
+    cur.execute("UPDATE err_test SET val = 20 WHERE id = 1")
+    try:
+        conn_a.commit()
+        raise AssertionError("expected SerializationFailure on conflicting commit")
+    except errors.SerializationFailure as e:
+        if e.pgcode != "40001":
+            raise AssertionError(f"expected pgcode 40001, got {e.pgcode}")
+
+    # ... and the session must be usable again immediately
+    conn_a.rollback()
+    cur_a.execute("SELECT COUNT(*) FROM err_test")
+    if cur_a.fetchone()[0] != 1:
+        raise AssertionError("connection unusable after serialization failure")
+    conn_a.close()
+
+    print("Error code tests OK.", flush=True)
+
+
 def main():
     if len(sys.argv) != 3:
         print("Usage: python3 psycopg2_test.py <user> <port>")
@@ -100,6 +162,8 @@ def main():
             with conn.cursor() as cur:
                 load_test(cur, load_rows)
                 compliance_test(cur)
+
+        error_code_test(user, port)
 
         print("\n✅ All tests passed.", flush=True)
         return 0

--- a/testing/postgres-client-tests/ruby/sequel-retry-test.rb
+++ b/testing/postgres-client-tests/ruby/sequel-retry-test.rb
@@ -1,0 +1,74 @@
+#!/usr/bin/ruby
+
+# Tests that Sequel's built-in transaction retry semantics work against Doltgres.
+#
+# When two transactions modify the same row concurrently, Doltgres reports the losing
+# COMMIT with SQLSTATE 40001 (serialization_failure). The pg driver surfaces that
+# SQLSTATE as PG::TRSerializationFailure, Sequel maps it to Sequel::SerializationFailure,
+# and Sequel's `transaction(retry_on: ...)` re-runs the block — the standard ORM recipe
+# for handling optimistic-concurrency conflicts. All three layers key off the SQLSTATE,
+# so this test fails if the server reports the conflict with any other code.
+
+require 'sequel'
+
+user = ARGV[0]
+port = ARGV[1].to_i
+
+def connect(user, port)
+  Sequel.connect(
+    adapter: 'postgres',
+    host: 'localhost',
+    port: port,
+    database: 'postgres',
+    user: user,
+    password: 'password'
+  )
+end
+
+db1 = connect(user, port)
+db2 = connect(user, port)
+
+db1.run("DROP TABLE IF EXISTS retry_test")
+db1.run("CREATE TABLE retry_test (id INT PRIMARY KEY, val INT, who TEXT)")
+db1[:retry_test].insert(id: 1, val: 0, who: 'nobody')
+
+# Part 1: interpretation. A conflicting concurrent commit must surface as
+# Sequel::SerializationFailure — the exception class Sequel documents for
+# retry_on — which it derives from SQLSTATE 40001.
+begin
+  db1.transaction do
+    db1[:retry_test].where(id: 1).update(val: 100, who: 'txn1')
+    # conflicting write from a second connection, autocommitted while txn1 is open
+    db2[:retry_test].where(id: 1).update(val: 200, who: 'txn2')
+  end
+  raise "expected the conflicting transaction to raise, but it committed"
+rescue Sequel::SerializationFailure => e
+  puts "conflict surfaced as #{e.class} (driver: #{e.wrapped_exception.class})"
+end
+
+# The session must remain usable after the failed commit.
+one = db1["SELECT 1 AS one"].first[:one]
+raise "connection unusable after serialization failure" unless one == 1
+
+# Part 2: retry. Sequel re-runs the block on Sequel::SerializationFailure; the
+# second attempt has no concurrent writer, so it must commit.
+db1[:retry_test].where(id: 1).update(val: 0, who: 'nobody')
+attempts = 0
+db1.transaction(retry_on: Sequel::SerializationFailure, num_retries: 5) do
+  attempts += 1
+  db1[:retry_test].where(id: 1).update(val: 100, who: 'txn1')
+  if attempts == 1
+    db2[:retry_test].where(id: 1).update(val: 200, who: 'txn2')
+  end
+end
+
+raise "expected the transaction to be attempted twice, got #{attempts}" unless attempts == 2
+
+row = db1[:retry_test].where(id: 1).first
+unless row[:val] == 100 && row[:who] == 'txn1'
+  raise "expected the retried transaction's write to win, got #{row}"
+end
+
+db1.disconnect
+db2.disconnect
+puts "Sequel serialization-failure retry test passed (attempts=#{attempts})"


### PR DESCRIPTION
This PR audits error code processing to ensure that all common error codes typically examined by clients are correctly returned by the server. In particular, some clients interpret an XX000 error code by terminating the connection to the server, so we need to be careful to only return that code on a catastrophic, unexpected error.

Also adds new client library tests that ensure clients behave as expected in response to these codes.