### PR TITLE
Fix IN clause failing on schema-qualified dolt system tables

### DIFF
--- a/server/analyzer/type_sanitizer.go
+++ b/server/analyzer/type_sanitizer.go
@@ -16,11 +16,11 @@ package analyzer
 
 import (
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/errors"
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/analyzer"
 	"github.com/dolthub/go-mysql-server/sql/expression"
@@ -54,16 +54,19 @@ func TypeSanitizer(ctx *sql.Context, a *analyzer.Analyzer, node sql.Node, scope 
 				if alias, ok := child.(*plan.TableAlias); ok {
 					child = alias.Child
 				}
-				// Some dolt_ tables and table functions do not have doltgres types for their columns,
-				// so we convert them here
-				var name string
+				// Dolt system tables and table functions do not have doltgres types for their columns, so we
+				// convert them here.
+				var name, schemaName string
 				switch child := child.(type) {
 				case *plan.ResolvedTable:
 					name = child.Name()
+					if dbSchema, ok := child.Database().(sql.DatabaseSchema); ok {
+						schemaName = dbSchema.SchemaName()
+					}
 				case sql.TableFunction:
 					name = child.Name()
 				}
-				if strings.HasPrefix(strings.ToLower(name), "dolt_") {
+				if doltdb.IsSystemTable(doltdb.TableName{Name: name, Schema: schemaName}) {
 					// This is a projection on a table, so we can safely convert the type
 					if _, ok := expr.Type(ctx).(*pgtypes.DoltgresType); !ok {
 						return pgexprs.NewGMSCast(expr), transform.NewTree, nil

--- a/testing/go/dolt_tables_test.go
+++ b/testing/go/dolt_tables_test.go
@@ -118,6 +118,19 @@ func TestUserSpaceDoltTables(t *testing.T) {
 					Query:    `SELECT "dolt_branches"."name" FROM "dolt_branches" WHERE "dolt_branches"."name" IN ('main') ORDER BY "dolt_branches"."name" DESC LIMIT 21;`,
 					Expected: []sql.Row{{"main"}},
 				},
+				{
+					// https://github.com/dolthub/doltgresql/issues/3115
+					Query:    `SELECT name FROM dolt.branches WHERE name IN ('main')`,
+					Expected: []sql.Row{{"main"}},
+				},
+				{
+					Query:    `SELECT name FROM dolt.branches WHERE name IN ('main', 'nonexistent')`,
+					Expected: []sql.Row{{"main"}},
+				},
+				{
+					Query:    `SELECT name FROM dolt.branches WHERE name NOT IN ('nonexistent')`,
+					Expected: []sql.Row{{"main"}},
+				},
 			},
 		},
 		{
@@ -1853,6 +1866,10 @@ WHERE to_commit = dolt_hashof('HEAD')
 					Expected: []sql.Row{{2}},
 				},
 				{
+					Query:    `SELECT count(*) FROM dolt.log WHERE message IN ('Initialize data repository')`,
+					Expected: []sql.Row{{1}},
+				},
+				{
 					Query:       `SELECT * FROM public.log`,
 					ExpectedErr: "table not found",
 				},
@@ -2645,6 +2662,10 @@ WHERE to_commit = dolt_hashof('HEAD')
 				},
 				{
 					Query:    `SELECT dolt_remotes.name FROM dolt_remotes`,
+					Expected: []sql.Row{{"origin"}},
+				},
+				{
+					Query:    `SELECT name FROM dolt.remotes WHERE name IN ('origin')`,
 					Expected: []sql.Row{{"origin"}},
 				},
 				{


### PR DESCRIPTION
Dolt system tables without the `dolt_` prefix were not getting wrapped with GMSCast elements correctly, which caused incorrect execution. 

Fixes: https://github.com/dolthub/doltgresql/issues/3115