### PR TITLE
Fix `array_to_string()` panic on int2vector/oidvector values 

### DIFF
--- a/server/types/type.go
+++ b/server/types/type.go
@@ -160,13 +160,19 @@ func (t *DoltgresType) AnalyzeFuncName() string {
 
 // ArrayBaseType returns the base type of an array type.
 func (t *DoltgresType) ArrayBaseType() *DoltgresType {
-	if !t.IsArrayType() {
-		return t
-	}
 	// Some array types have no declared element type for pg_catalog compatibility, but still have a logical type
 	// we return for analysis.
 	if t.ID == AnyArray.ID {
 		return AnyElement
+	}
+	// TODO: IsArrayType() currently conflates different meanings (iterable via t.Elem, array versus
+	// vector output formatting, how ToArrayType() checks if a type is already an array type).
+	// Types like int2vector and oidvector have meanings that diverge for some of those
+	// and need to be handled differently. Longer term, we should probably untangle these different
+	// traits into separate APIs that can be queried for types, but for now, we just check if Elem
+	// is the NULL type here to determine if the type contains a nested element type or not.
+	if t.Elem.ID == id.NullType {
+		return t
 	}
 	return t.Elem.WithAttTypMod(t.attTypMod)
 }

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -1945,6 +1945,28 @@ func TestArrayFunctions(t *testing.T) {
 			},
 		},
 		{
+			// https://github.com/dolthub/doltgresql/issues/3108
+			Name: "array_to_string on vector types (int2vector, oidvector)",
+			SetUpScript: []string{
+				`CREATE TABLE vectest (pk INT PRIMARY KEY, a INT, b INT);`,
+				`CREATE INDEX vectest_ab ON vectest (a, b);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT array_to_string(indkey, ',') FROM pg_index WHERE indexrelid = 'vectest_ab'::regclass;`,
+					Expected: []sql.Row{{"2,3"}},
+				},
+				{
+					Query:    `SELECT array_to_string(indkey, ',') FROM pg_index WHERE indexrelid = 'vectest_pkey'::regclass;`,
+					Expected: []sql.Row{{"1"}},
+				},
+				{
+					Query:    `SELECT array_to_string(indclass, ',') FROM pg_index WHERE indexrelid = 'vectest_ab'::regclass;`,
+					Expected: []sql.Row{{""}},
+				},
+			},
+		},
+		{
 			Name: "array_upper",
 			Assertions: []ScriptTestAssertion{
 				{


### PR DESCRIPTION
Caused by ArrayBaseType() returning the wrong element type.

Fixes: https://github.com/dolthub/doltgresql/issues/3108