### PR TITLE
Fix nil pointer panic in `IsDistinctFrom`/`IsNotDistinctFrom` 

### DIFF
--- a/server/expression/is_distinct_from.go
+++ b/server/expression/is_distinct_from.go
@@ -92,6 +92,9 @@ func (n *IsDistinctFrom) Resolved() bool {
 
 // String implements the sql.Expression interface.
 func (n *IsDistinctFrom) String() string {
+	if n.leftExpr == nil || n.rightExpr == nil {
+		return "? IS DISTINCT FROM ?"
+	}
 	return n.leftExpr.String() + " IS DISTINCT FROM " + n.rightExpr.String()
 }
 

--- a/server/expression/is_not_distinct_from.go
+++ b/server/expression/is_not_distinct_from.go
@@ -92,6 +92,9 @@ func (n *IsNotDistinctFrom) Resolved() bool {
 
 // String implements the sql.Expression interface.
 func (n *IsNotDistinctFrom) String() string {
+	if n.leftExpr == nil || n.rightExpr == nil {
+		return "? IS NOT DISTINCT FROM ?"
+	}
 	return n.leftExpr.String() + " IS NOT DISTINCT FROM " + n.rightExpr.String()
 }
 

--- a/testing/go/expressions_test.go
+++ b/testing/go/expressions_test.go
@@ -410,6 +410,24 @@ func TestBinaryLogic(t *testing.T) {
 				},
 			},
 		},
+		{
+			// https://github.com/dolthub/doltgresql/issues/3096
+			Name: "IS DISTINCT FROM and IS NOT DISTINCT FROM inside a subquery",
+			SetUpScript: []string{
+				`CREATE TABLE t_indf (id INT PRIMARY KEY, v TEXT);`,
+				`INSERT INTO t_indf VALUES (1, 'a'), (2, NULL);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT count(*) FROM t_indf o WHERE EXISTS (SELECT 1 FROM t_indf i WHERE i.v IS NOT DISTINCT FROM o.v);`,
+					Expected: []sql.Row{{2}},
+				},
+				{
+					Query:    `SELECT count(*) FROM t_indf o WHERE EXISTS (SELECT 1 FROM t_indf i WHERE i.v IS DISTINCT FROM o.v);`,
+					Expected: []sql.Row{{2}},
+				},
+			},
+		},
 	})
 }
 


### PR DESCRIPTION
IsDistinctFrom/IsNotDistinctFrom are wired in as vitess.InjectedExpr templates with nil children that get filled in later via WithResolvedChildren, but Vitess can call String() on the template beforehand (e.g. while building an EXISTS subquery's SQL text), and their String() methods dereferenced the nil children directly, causing a panic. 

Fixes: https://github.com/dolthub/doltgresql/issues/3096 by guarding both String() implementations against nil children (matching the existing pattern in Not and BinaryOperator) and adds a regression test reproducing the reported EXISTS subquery panic.