### PR TITLE
audited string and []byte function params for wrapped args

### DIFF
--- a/server/cast/bit.go
+++ b/server/cast/bit.go
@@ -39,7 +39,11 @@ func bitExplicit(builtInCasts map[id.Cast]casts.Cast) {
 		CastType: casts.CastType_Explicit,
 		Function: id.NullFunction,
 		BuiltIn: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			array, err := tree.ParseDBitArray(val.(string))
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			array, err := tree.ParseDBitArray(str)
 			if err != nil {
 				return nil, err
 			}
@@ -56,7 +60,11 @@ func bitExplicit(builtInCasts map[id.Cast]casts.Cast) {
 		CastType: casts.CastType_Explicit,
 		Function: id.NullFunction,
 		BuiltIn: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			array, err := tree.ParseDBitArray(val.(string))
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			array, err := tree.ParseDBitArray(str)
 			if err != nil {
 				return nil, err
 			}
@@ -75,7 +83,10 @@ func bitImplicit(builtInCasts map[id.Cast]casts.Cast) {
 		FromType: pgtypes.Bit,
 		ToType:   pgtypes.Bit,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			input := val.(string)
+			input, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
 			array, err := tree.ParseDBitArray(input)
 			if err != nil {
 				return nil, err
@@ -91,7 +102,10 @@ func bitImplicit(builtInCasts map[id.Cast]casts.Cast) {
 		FromType: pgtypes.Bit,
 		ToType:   pgtypes.VarBit,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			input := val.(string)
+			input, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
 			array, err := tree.ParseDBitArray(input)
 			if err != nil {
 				return nil, err

--- a/server/cast/char.go
+++ b/server/cast/char.go
@@ -40,7 +40,11 @@ func charAssignment(builtInCasts map[id.Cast]casts.Cast) {
 		FromType: pgtypes.BpChar,
 		ToType:   pgtypes.InternalChar,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return targetType.IoInput(ctx, val.(string))
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			return targetType.IoInput(ctx, str)
 		},
 	})
 }
@@ -51,12 +55,16 @@ func charExplicit(builtInCasts map[id.Cast]casts.Cast) {
 		FromType: pgtypes.BpChar,
 		ToType:   pgtypes.Int32,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			out, err := strconv.ParseInt(strings.TrimSpace(val.(string)), 10, 32)
+			str, err := framework.UnwrapString(ctx, val)
 			if err != nil {
-				return nil, errors.Errorf("invalid input syntax for type %s: %q", targetType.String(), val.(string))
+				return nil, err
+			}
+			out, err := strconv.ParseInt(strings.TrimSpace(str), 10, 32)
+			if err != nil {
+				return nil, errors.Errorf("invalid input syntax for type %s: %q", targetType.String(), str)
 			}
 			if out > 2147483647 || out < -2147483648 {
-				return nil, errors.Errorf("value %q is out of range for type %s", val.(string), targetType.String())
+				return nil, errors.Errorf("value %q is out of range for type %s", str, targetType.String())
 			}
 			return int32(out), nil
 		},
@@ -69,14 +77,22 @@ func charImplicit(builtInCasts map[id.Cast]casts.Cast) {
 		FromType: pgtypes.BpChar,
 		ToType:   pgtypes.BpChar,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return targetType.IoInput(ctx, val.(string))
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			return targetType.IoInput(ctx, str)
 		},
 	})
 	framework.MustAddImplicitTypeCast(builtInCasts, framework.TypeCast{
 		FromType: pgtypes.BpChar,
 		ToType:   pgtypes.Name,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return handleStringCast(val.(string), targetType)
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			return handleStringCast(str, targetType)
 		},
 	})
 	framework.MustAddImplicitTypeCast(builtInCasts, framework.TypeCast{
@@ -90,7 +106,11 @@ func charImplicit(builtInCasts map[id.Cast]casts.Cast) {
 		FromType: pgtypes.BpChar,
 		ToType:   pgtypes.VarChar,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return handleStringCast(val.(string), targetType)
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			return handleStringCast(str, targetType)
 		},
 	})
 }

--- a/server/cast/internal_char.go
+++ b/server/cast/internal_char.go
@@ -39,14 +39,22 @@ func internalCharAssignment(builtInCasts map[id.Cast]casts.Cast) {
 		FromType: pgtypes.InternalChar,
 		ToType:   pgtypes.BpChar,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return targetType.IoInput(ctx, val.(string))
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			return targetType.IoInput(ctx, str)
 		},
 	})
 	framework.MustAddAssignmentTypeCast(builtInCasts, framework.TypeCast{
 		FromType: pgtypes.InternalChar,
 		ToType:   pgtypes.VarChar,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return handleStringCast(val.(string), targetType)
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			return handleStringCast(str, targetType)
 		},
 	})
 }
@@ -57,7 +65,10 @@ func internalCharExplicit(builtInCasts map[id.Cast]casts.Cast) {
 		FromType: pgtypes.InternalChar,
 		ToType:   pgtypes.Int32,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			s := val.(string)
+			s, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
 			if len(s) == 0 {
 				return int32(0), nil
 			}

--- a/server/cast/name.go
+++ b/server/cast/name.go
@@ -36,14 +36,22 @@ func nameAssignment(builtInCasts map[id.Cast]casts.Cast) {
 		FromType: pgtypes.Name,
 		ToType:   pgtypes.BpChar,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return handleStringCast(val.(string), targetType)
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			return handleStringCast(str, targetType)
 		},
 	})
 	framework.MustAddAssignmentTypeCast(builtInCasts, framework.TypeCast{
 		FromType: pgtypes.Name,
 		ToType:   pgtypes.VarChar,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return handleStringCast(val.(string), targetType)
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			return handleStringCast(str, targetType)
 		},
 	})
 }

--- a/server/cast/text.go
+++ b/server/cast/text.go
@@ -36,7 +36,11 @@ func textAssignment(builtInCasts map[id.Cast]casts.Cast) {
 		FromType: pgtypes.Text,
 		ToType:   pgtypes.InternalChar,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return handleStringCast(val.(string), targetType)
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			return handleStringCast(str, targetType)
 		},
 	})
 }
@@ -47,28 +51,44 @@ func textImplicit(builtInCasts map[id.Cast]casts.Cast) {
 		FromType: pgtypes.Text,
 		ToType:   pgtypes.BpChar,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return handleStringCast(val.(string), targetType)
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			return handleStringCast(str, targetType)
 		},
 	})
 	framework.MustAddImplicitTypeCast(builtInCasts, framework.TypeCast{
 		FromType: pgtypes.Text,
 		ToType:   pgtypes.Name,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return handleStringCast(val.(string), targetType)
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			return handleStringCast(str, targetType)
 		},
 	})
 	framework.MustAddImplicitTypeCast(builtInCasts, framework.TypeCast{
 		FromType: pgtypes.Text,
 		ToType:   pgtypes.Regclass,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return targetType.IoInput(ctx, val.(string))
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			return targetType.IoInput(ctx, str)
 		},
 	})
 	framework.MustAddImplicitTypeCast(builtInCasts, framework.TypeCast{
 		FromType: pgtypes.Text,
 		ToType:   pgtypes.VarChar,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return handleStringCast(val.(string), targetType)
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			return handleStringCast(str, targetType)
 		},
 	})
 }

--- a/server/cast/varbit.go
+++ b/server/cast/varbit.go
@@ -35,7 +35,10 @@ func varBitImplicit(builtInCasts map[id.Cast]casts.Cast) {
 		FromType: pgtypes.VarBit,
 		ToType:   pgtypes.Bit,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			input := val.(string)
+			input, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
 			array, err := tree.ParseDBitArray(input)
 			if err != nil {
 				return nil, err
@@ -51,7 +54,10 @@ func varBitImplicit(builtInCasts map[id.Cast]casts.Cast) {
 		FromType: pgtypes.VarBit,
 		ToType:   pgtypes.VarBit,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			input := val.(string)
+			input, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
 			array, err := tree.ParseDBitArray(input)
 			if err != nil {
 				return nil, err

--- a/server/cast/varchar.go
+++ b/server/cast/varchar.go
@@ -36,7 +36,11 @@ func varcharAssignment(builtInCasts map[id.Cast]casts.Cast) {
 		FromType: pgtypes.VarChar,
 		ToType:   pgtypes.InternalChar,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return handleStringCast(val.(string), targetType)
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			return handleStringCast(str, targetType)
 		},
 	})
 }
@@ -47,14 +51,22 @@ func varcharImplicit(builtInCasts map[id.Cast]casts.Cast) {
 		FromType: pgtypes.VarChar,
 		ToType:   pgtypes.BpChar,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return handleStringCast(val.(string), targetType)
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			return handleStringCast(str, targetType)
 		},
 	})
 	framework.MustAddImplicitTypeCast(builtInCasts, framework.TypeCast{
 		FromType: pgtypes.VarChar,
 		ToType:   pgtypes.Name,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return handleStringCast(val.(string), targetType)
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			return handleStringCast(str, targetType)
 		},
 	})
 	framework.MustAddImplicitTypeCast(builtInCasts, framework.TypeCast{
@@ -68,7 +80,11 @@ func varcharImplicit(builtInCasts map[id.Cast]casts.Cast) {
 		FromType: pgtypes.VarChar,
 		ToType:   pgtypes.VarChar,
 		Function: func(ctx *sql.Context, val any, _, targetType *pgtypes.DoltgresType) (any, error) {
-			return handleStringCast(val.(string), targetType)
+			str, err := framework.UnwrapString(ctx, val)
+			if err != nil {
+				return nil, err
+			}
+			return handleStringCast(str, targetType)
 		},
 	})
 }

--- a/server/extensions/uuid-ossp/v1_1/uuid_ossp.go
+++ b/server/extensions/uuid-ossp/v1_1/uuid_ossp.go
@@ -101,7 +101,7 @@ func uuidGenerateV1mc(ctx *sql.Context, args ...any) (any, error) {
 // uuidGenerateV3 implements uuid_generate_v3, which returns a version 3 UUID formed from the MD5 hash
 // of the given namespace and name.
 func uuidGenerateV3(ctx *sql.Context, args ...any) (any, error) {
-	namespace, name, err := namespaceAndName(args)
+	namespace, name, err := namespaceAndName(ctx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func uuidGenerateV4(ctx *sql.Context, args ...any) (any, error) {
 // uuidGenerateV5 implements uuid_generate_v5, which returns a version 5 UUID formed from the SHA-1
 // hash of the given namespace and name.
 func uuidGenerateV5(ctx *sql.Context, args ...any) (any, error) {
-	namespace, name, err := namespaceAndName(args)
+	namespace, name, err := namespaceAndName(ctx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -126,12 +126,15 @@ func uuidGenerateV5(ctx *sql.Context, args ...any) (any, error) {
 
 // namespaceAndName reads the namespace and name arguments that uuid_generate_v3 and uuid_generate_v5
 // share.
-func namespaceAndName(args []any) (uuid.UUID, string, error) {
+func namespaceAndName(ctx *sql.Context, args []any) (uuid.UUID, string, error) {
 	namespace, ok := args[0].(uuid.UUID)
 	if !ok {
 		return uuid.Nil, "", errors.Errorf("expected a UUID namespace, received `%T`", args[0])
 	}
-	name, ok := args[1].(string)
+	name, ok, err := sql.Unwrap[string](ctx, args[1])
+	if err != nil {
+		return uuid.Nil, "", err
+	}
 	if !ok {
 		return uuid.Nil, "", errors.Errorf("expected a TEXT name, received `%T`", args[1])
 	}

--- a/server/functions/array.go
+++ b/server/functions/array.go
@@ -179,7 +179,10 @@ var array_recv = framework.Function3{
 
 // array_recv_callable is the function definition of array_recv.
 func array_recv_callable(ctx *sql.Context, t [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-	data := val1.([]byte)
+	data, err := framework.UnwrapBytes(ctx, val1)
+	if err != nil {
+		return nil, err
+	}
 	if data == nil {
 		return nil, nil
 	}

--- a/server/functions/array.go
+++ b/server/functions/array.go
@@ -44,7 +44,10 @@ var array_in = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Cstring, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		input := val1.(string)
+		input, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		baseTypeOid := val2.(id.Id)
 		baseType := pgtypes.IDToBuiltInDoltgresType[id.Type(baseTypeOid)]
 		if baseType == nil {
@@ -67,7 +70,6 @@ var array_in = framework.Function3{
 		// We'll remove the surrounding braces since we've already verified that they're there
 		input = input[1 : len(input)-1]
 		var values []any
-		var err error
 		sb := strings.Builder{}
 		quoteStartCount := 0
 		quoteEndCount := 0

--- a/server/functions/array_to_string.go
+++ b/server/functions/array_to_string.go
@@ -39,7 +39,10 @@ var array_to_string_anyarray_text = framework.Function2{
 	Strict:             true,
 	Callable: func(ctx *sql.Context, paramsAndReturn [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
 		arr := val1.([]any)
-		delimiter := val2.(string)
+		delimiter, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
 		return getStringArrFromAnyArray(ctx, paramsAndReturn[0], arr, delimiter, nil)
 	},
 }
@@ -58,7 +61,10 @@ var array_to_string_anyarray_text_text = framework.Function3{
 			return nil, nil
 		}
 		arr := val1.([]any)
-		delimiter := val2.(string)
+		delimiter, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
 		return getStringArrFromAnyArray(ctx, paramsAndReturn[0], arr, delimiter, val3)
 	},
 }
@@ -76,7 +82,11 @@ func getStringArrFromAnyArray(ctx *sql.Context, arrType *pgtypes.DoltgresType, a
 			}
 			strs = append(strs, v)
 		} else if nullEntry != nil {
-			strs = append(strs, nullEntry.(string))
+			nullEntryStr, err := framework.UnwrapString(ctx, nullEntry)
+			if err != nil {
+				return "", err
+			}
+			strs = append(strs, nullEntryStr)
 		}
 	}
 	return strings.Join(strs, delimiter), nil

--- a/server/functions/ascii.go
+++ b/server/functions/ascii.go
@@ -33,7 +33,10 @@ var ascii_text = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1Interface any) (any, error) {
-		val1 := val1Interface.(string)
+		val1, err := framework.UnwrapString(ctx, val1Interface)
+		if err != nil {
+			return nil, err
+		}
 		if len(val1) == 0 {
 			return int32(0), nil
 		}

--- a/server/functions/binary/concatenate.go
+++ b/server/functions/binary/concatenate.go
@@ -47,7 +47,11 @@ func anytextcat_callable(ctx *sql.Context, paramsAndReturn [3]*pgtypes.DoltgresT
 	if err != nil {
 		return nil, err
 	}
-	return val1String + val2.(string), nil
+	val2String, err := framework.UnwrapString(ctx, val2)
+	if err != nil {
+		return nil, err
+	}
+	return val1String + val2String, nil
 }
 
 // anytextcat represents the PostgreSQL function of the same name, taking the same parameters.
@@ -198,7 +202,11 @@ func textanycat_callable(ctx *sql.Context, paramsAndReturn [3]*pgtypes.DoltgresT
 	if err != nil {
 		return nil, err
 	}
-	return val1.(string) + val2String, nil
+	val1String, err := framework.UnwrapString(ctx, val1)
+	if err != nil {
+		return nil, err
+	}
+	return val1String + val2String, nil
 }
 
 // textanycat represents the PostgreSQL function of the same name, taking the same parameters.
@@ -212,7 +220,15 @@ var textanycat = framework.Function2{
 
 // textcat_callable is the callable logic for the textcat function.
 func textcat_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-	return val1.(string) + val2.(string), nil
+	val1String, err := framework.UnwrapString(ctx, val1)
+	if err != nil {
+		return nil, err
+	}
+	val2String, err := framework.UnwrapString(ctx, val2)
+	if err != nil {
+		return nil, err
+	}
+	return val1String + val2String, nil
 }
 
 // textcat represents the PostgreSQL function of the same name, taking the same parameters.

--- a/server/functions/binary/concatenate.go
+++ b/server/functions/binary/concatenate.go
@@ -124,8 +124,14 @@ var array_prepend = framework.Function2{
 
 // byteacat_callable is the callable logic for the byteacat function.
 func byteacat_callable(ctx *sql.Context, paramsAndReturn [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-	v1 := val1.([]byte)
-	v2 := val2.([]byte)
+	v1, err := framework.UnwrapBytes(ctx, val1)
+	if err != nil {
+		return nil, err
+	}
+	v2, err := framework.UnwrapBytes(ctx, val2)
+	if err != nil {
+		return nil, err
+	}
 	copied := make([]byte, len(v1)+len(v2))
 	copy(copied, v1)
 	copy(copied[len(v1):], v2)

--- a/server/functions/binary/equal.go
+++ b/server/functions/binary/equal.go
@@ -100,7 +100,7 @@ var booleq = framework.Function2{
 
 // bpchareq_callable is the callable logic for the bpchareq function.
 func bpchareq_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-	res, err := pgtypes.BpChar.Compare(ctx, val1.(string), val2.(string))
+	res, err := pgtypes.BpChar.Compare(ctx, val1, val2)
 	return res == 0, err
 }
 
@@ -130,7 +130,7 @@ var byteaeq = framework.Function2{
 
 // chareq_callable is the callable logic for the chareq function.
 func chareq_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-	res, err := pgtypes.InternalChar.Compare(ctx, val1.(string), val2.(string))
+	res, err := pgtypes.InternalChar.Compare(ctx, val1, val2)
 	return res == 0, err
 }
 
@@ -446,7 +446,7 @@ var jsonb_eq = framework.Function2{
 
 // nameeq_callable is the callable logic for the nameeq function.
 func nameeq_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-	res, err := pgtypes.Name.Compare(ctx, val1.(string), val2.(string))
+	res, err := pgtypes.Name.Compare(ctx, val1, val2)
 	return res == 0, err
 }
 
@@ -461,7 +461,7 @@ var nameeq = framework.Function2{
 
 // nameeqtext_callable is the callable logic for the nameeqtext function.
 func nameeqtext_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-	res, err := pgtypes.Text.Compare(ctx, val1.(string), val2.(string))
+	res, err := pgtypes.Text.Compare(ctx, val1, val2)
 	return res == 0, err
 }
 
@@ -522,7 +522,7 @@ var oidvectoreq = framework.Function2{
 
 // texteqname_callable is the callable logic for the texteqname function.
 func texteqname_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-	res, err := pgtypes.Text.Compare(ctx, val1.(string), val2.(string))
+	res, err := pgtypes.Text.Compare(ctx, val1, val2)
 	return res == 0, err
 }
 

--- a/server/functions/binary/greater.go
+++ b/server/functions/binary/greater.go
@@ -98,7 +98,7 @@ var bpchargt = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.BpChar.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.BpChar.Compare(ctx, val1, val2)
 		return res == 1, err
 	},
 }
@@ -122,7 +122,7 @@ var chargt = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.InternalChar, pgtypes.InternalChar},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.InternalChar.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.InternalChar.Compare(ctx, val1, val2)
 		return res == 1, err
 	},
 }
@@ -362,7 +362,7 @@ var namegt = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Name.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Name.Compare(ctx, val1, val2)
 		return res == 1, err
 	},
 }
@@ -374,7 +374,7 @@ var namegttext = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Text.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Text.Compare(ctx, val1, val2)
 		return res == 1, err
 	},
 }
@@ -422,7 +422,7 @@ var textgtname = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Text.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Text.Compare(ctx, val1, val2)
 		return res == 1, err
 	},
 }

--- a/server/functions/binary/greater_equal.go
+++ b/server/functions/binary/greater_equal.go
@@ -110,7 +110,7 @@ var byteage = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Bytea, pgtypes.Bytea},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Bytea.Compare(ctx, val1.([]byte), val2.([]byte))
+		res, err := pgtypes.Bytea.Compare(ctx, val1, val2)
 		return res >= 0, err
 	},
 }

--- a/server/functions/binary/greater_equal.go
+++ b/server/functions/binary/greater_equal.go
@@ -98,7 +98,7 @@ var bpcharge = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.BpChar.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.BpChar.Compare(ctx, val1, val2)
 		return res >= 0, err
 	},
 }
@@ -122,7 +122,7 @@ var charge = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.InternalChar, pgtypes.InternalChar},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.InternalChar.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.InternalChar.Compare(ctx, val1, val2)
 		return res >= 0, err
 	},
 }
@@ -362,7 +362,7 @@ var namege = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Name.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Name.Compare(ctx, val1, val2)
 		return res >= 0, err
 	},
 }
@@ -374,7 +374,7 @@ var namegetext = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Text.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Text.Compare(ctx, val1, val2)
 		return res >= 0, err
 	},
 }
@@ -422,7 +422,7 @@ var textgename = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Text.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Text.Compare(ctx, val1, val2)
 		return res >= 0, err
 	},
 }
@@ -434,7 +434,7 @@ var text_ge = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Text.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Text.Compare(ctx, val1, val2)
 		return res >= 0, err
 	},
 }

--- a/server/functions/binary/json.go
+++ b/server/functions/binary/json.go
@@ -259,7 +259,10 @@ var jsonb_object_field = framework.Function2{
 		if !ok {
 			return nil, nil
 		}
-		key := val2.(string)
+		key, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
 		// Fast path: for a ComparableJSON wrapper backed by an indexed JSON
 		// object, use Lookup to fetch the value without materializing the
 		// entire document.
@@ -432,7 +435,10 @@ func jsonb_extract_path_callable(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, v
 		if cur == nil {
 			return nil, nil
 		}
-		textPath, ok := path.(string)
+		textPath, ok, err := sql.Unwrap[string](ctx, path)
+		if err != nil {
+			return nil, err
+		}
 		if !ok {
 			return nil, nil
 		}
@@ -637,7 +643,10 @@ var jsonb_exists = framework.Function2{
 		if !ok {
 			return false, nil
 		}
-		key := val2.(string)
+		key, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
 		// Fast path: for an indexed JSON object, use Lookup to test for the
 		// key without materializing the document.
 		if isObj, err := isComparableJsonObject(ctx, wrapper); err != nil {
@@ -698,13 +707,21 @@ var jsonb_exists_any = framework.Function2{
 			return false, nil
 		}
 		keys := val2.([]interface{})
+		keyStrs := make([]string, len(keys))
+		for i, key := range keys {
+			keyStr, err := framework.UnwrapString(ctx, key)
+			if err != nil {
+				return nil, err
+			}
+			keyStrs[i] = keyStr
+		}
 		// Fast path: for an indexed JSON object, test each key with Lookup
 		// instead of materializing the document.
 		if isObj, err := isComparableJsonObject(ctx, wrapper); err != nil {
 			return nil, err
 		} else if isObj {
-			for _, key := range keys {
-				found, err := types.LookupJSONValue(ctx, wrapper, makeObjectKeyPath(key.(string)))
+			for _, key := range keyStrs {
+				found, err := types.LookupJSONValue(ctx, wrapper, makeObjectKeyPath(key))
 				if err != nil {
 					return nil, err
 				}
@@ -720,24 +737,24 @@ var jsonb_exists_any = framework.Function2{
 		}
 		switch v := value.(type) {
 		case map[string]interface{}:
-			for _, key := range keys {
-				if _, ok := v[key.(string)]; ok {
+			for _, key := range keyStrs {
+				if _, ok := v[key]; ok {
 					return true, nil
 				}
 			}
 			return false, nil
 		case []interface{}:
-			for _, key := range keys {
+			for _, key := range keyStrs {
 				for _, item := range v {
-					if s, ok := item.(string); ok && s == key.(string) {
+					if s, ok := item.(string); ok && s == key {
 						return true, nil
 					}
 				}
 			}
 			return false, nil
 		case string:
-			for _, key := range keys {
-				if v == key.(string) {
+			for _, key := range keyStrs {
+				if v == key {
 					return true, nil
 				}
 			}
@@ -760,13 +777,21 @@ var jsonb_exists_all = framework.Function2{
 			return false, nil
 		}
 		keys := val2.([]interface{})
+		keyStrs := make([]string, len(keys))
+		for i, key := range keys {
+			keyStr, err := framework.UnwrapString(ctx, key)
+			if err != nil {
+				return nil, err
+			}
+			keyStrs[i] = keyStr
+		}
 		// Fast path: for an indexed JSON object, test each key with Lookup
 		// instead of materializing the document.
 		if isObj, err := isComparableJsonObject(ctx, wrapper); err != nil {
 			return nil, err
 		} else if isObj {
-			for _, key := range keys {
-				found, err := types.LookupJSONValue(ctx, wrapper, makeObjectKeyPath(key.(string)))
+			for _, key := range keyStrs {
+				found, err := types.LookupJSONValue(ctx, wrapper, makeObjectKeyPath(key))
 				if err != nil {
 					return nil, err
 				}
@@ -782,17 +807,17 @@ var jsonb_exists_all = framework.Function2{
 		}
 		switch v := value.(type) {
 		case map[string]interface{}:
-			for _, key := range keys {
-				if _, ok := v[key.(string)]; !ok {
+			for _, key := range keyStrs {
+				if _, ok := v[key]; !ok {
 					return false, nil
 				}
 			}
 			return true, nil
 		case []interface{}:
-			for _, key := range keys {
+			for _, key := range keyStrs {
 				found := false
 				for _, item := range v {
-					if s, ok := item.(string); ok && s == key.(string) {
+					if s, ok := item.(string); ok && s == key {
 						found = true
 						break
 					}
@@ -803,8 +828,8 @@ var jsonb_exists_all = framework.Function2{
 			}
 			return true, nil
 		case string:
-			for _, key := range keys {
-				if v != key.(string) {
+			for _, key := range keyStrs {
+				if v != key {
 					return false, nil
 				}
 			}

--- a/server/functions/binary/less.go
+++ b/server/functions/binary/less.go
@@ -98,7 +98,7 @@ var bpcharlt = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.BpChar.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.BpChar.Compare(ctx, val1, val2)
 		return res == -1, err
 	},
 }
@@ -122,7 +122,7 @@ var charlt = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.InternalChar, pgtypes.InternalChar},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.InternalChar.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.InternalChar.Compare(ctx, val1, val2)
 		return res == -1, err
 	},
 }
@@ -362,7 +362,7 @@ var namelt = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Name.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Name.Compare(ctx, val1, val2)
 		return res == -1, err
 	},
 }
@@ -374,7 +374,7 @@ var namelttext = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Text.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Text.Compare(ctx, val1, val2)
 		return res == -1, err
 	},
 }
@@ -422,7 +422,7 @@ var textltname = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Text.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Text.Compare(ctx, val1, val2)
 		return res == -1, err
 	},
 }

--- a/server/functions/binary/less_equal.go
+++ b/server/functions/binary/less_equal.go
@@ -98,7 +98,7 @@ var bpcharle = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.BpChar.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.BpChar.Compare(ctx, val1, val2)
 		return res <= 0, err
 	},
 }
@@ -122,7 +122,7 @@ var charle = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.InternalChar, pgtypes.InternalChar},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.InternalChar.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.InternalChar.Compare(ctx, val1, val2)
 		return res <= 0, err
 	},
 }
@@ -362,7 +362,7 @@ var namele = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Name.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Name.Compare(ctx, val1, val2)
 		return res <= 0, err
 	},
 }
@@ -374,7 +374,7 @@ var nameletext = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Text.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Text.Compare(ctx, val1, val2)
 		return res <= 0, err
 	},
 }
@@ -422,7 +422,7 @@ var textlename = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Text.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Text.Compare(ctx, val1, val2)
 		return res <= 0, err
 	},
 }
@@ -434,7 +434,7 @@ var text_le = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Text.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Text.Compare(ctx, val1, val2)
 		return res <= 0, err
 	},
 }

--- a/server/functions/binary/less_equal.go
+++ b/server/functions/binary/less_equal.go
@@ -110,7 +110,7 @@ var byteale = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Bytea, pgtypes.Bytea},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Bytea.Compare(ctx, val1.([]byte), val2.([]byte))
+		res, err := pgtypes.Bytea.Compare(ctx, val1, val2)
 		return res <= 0, err
 	},
 }

--- a/server/functions/binary/not_equal.go
+++ b/server/functions/binary/not_equal.go
@@ -110,7 +110,7 @@ var byteane = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Bytea, pgtypes.Bytea},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Bytea.Compare(ctx, val1.([]byte), val2.([]byte))
+		res, err := pgtypes.Bytea.Compare(ctx, val1, val2)
 		return res != 0, err
 	},
 }

--- a/server/functions/binary/not_equal.go
+++ b/server/functions/binary/not_equal.go
@@ -98,7 +98,7 @@ var bpcharne = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.BpChar.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.BpChar.Compare(ctx, val1, val2)
 		return res != 0, err
 	},
 }
@@ -122,7 +122,7 @@ var charne = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.InternalChar, pgtypes.InternalChar},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.InternalChar.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.InternalChar.Compare(ctx, val1, val2)
 		return res != 0, err
 	},
 }
@@ -362,7 +362,7 @@ var namene = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Name.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Name.Compare(ctx, val1, val2)
 		return res != 0, err
 	},
 }
@@ -374,7 +374,7 @@ var namenetext = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Text.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Text.Compare(ctx, val1, val2)
 		return res != 0, err
 	},
 }
@@ -422,7 +422,7 @@ var textnename = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Text.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Text.Compare(ctx, val1, val2)
 		return res != 0, err
 	},
 }
@@ -434,7 +434,7 @@ var text_ne = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		res, err := pgtypes.Text.Compare(ctx, val1.(string), val2.(string))
+		res, err := pgtypes.Text.Compare(ctx, val1, val2)
 		return res != 0, err
 	},
 }

--- a/server/functions/bit.go
+++ b/server/functions/bit.go
@@ -46,7 +46,10 @@ var bitin = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Cstring, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, _, val3 any) (any, error) {
-		input := val1.(string)
+		input, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		typmod := val3.(int32)
 
 		// validation and normalization
@@ -70,7 +73,10 @@ var bitout = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Bit},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, t [2]*pgtypes.DoltgresType, val any) (any, error) {
-		bitStr := val.(string)
+		bitStr, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		return bitStr, nil
 	},
 }
@@ -147,7 +153,7 @@ var bittypmodin = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.CstringArray},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		typmod, err := getTypModFromStringArr("bit", val.([]any))
+		typmod, err := getTypModFromStringArr(ctx, "bit", val.([]any))
 		if err != nil {
 			return nil, err
 		}

--- a/server/functions/bit.go
+++ b/server/functions/bit.go
@@ -88,13 +88,16 @@ var bitrecv = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Internal, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		data := val1.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}
 		typmod := val3.(int32)
 		var out pgtype.Bit
-		err := out.DecodeBinary(nil, data)
+		err = out.DecodeBinary(nil, data)
 		if err != nil {
 			return nil, err
 		}

--- a/server/functions/bool.go
+++ b/server/functions/bool.go
@@ -77,7 +77,10 @@ var boolrecv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if len(data) == 0 {
 			return nil, nil
 		}

--- a/server/functions/bool.go
+++ b/server/functions/bool.go
@@ -40,7 +40,11 @@ var boolin = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		val = strings.TrimSpace(strings.ToLower(val.(string)))
+		valStr, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
+		val = strings.TrimSpace(strings.ToLower(valStr))
 		if val == "true" || val == "t" || val == "yes" || val == "on" || val == "1" {
 			return true, nil
 		} else if val == "false" || val == "f" || val == "no" || val == "off" || val == "0" {

--- a/server/functions/bpchar.go
+++ b/server/functions/bpchar.go
@@ -103,7 +103,10 @@ var bpcharrecv = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Internal, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, t [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		data := val1.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/bpchar.go
+++ b/server/functions/bpchar.go
@@ -46,7 +46,10 @@ var bpcharin = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Cstring, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		input := val1.(string)
+		input, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		typmod := val3.(int32)
 		maxChars := int32(pgtypes.StringMaxLength)
 		if typmod != -1 {
@@ -71,16 +74,20 @@ var bpcharout = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.BpChar},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, t [2]*pgtypes.DoltgresType, val any) (any, error) {
+		valStr, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		typ := t[0]
 		tm := typ.GetAttTypMod()
 		if tm == -1 {
-			return val.(string), nil
+			return valStr, nil
 		}
 		maxChars := pgtypes.GetCharLengthFromTypmod(tm)
 		if maxChars < 1 {
-			return val.(string), nil
+			return valStr, nil
 		} else {
-			str, runeCount := truncateString(val.(string), maxChars)
+			str, runeCount := truncateString(valStr, maxChars)
 			if runeCount < maxChars {
 				return str + strings.Repeat(" ", int(maxChars-runeCount)), nil
 			}
@@ -138,7 +145,7 @@ var bpchartypmodin = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.CstringArray},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		return getTypModFromStringArr("char", val.([]any))
+		return getTypModFromStringArr(ctx, "char", val.([]any))
 	},
 }
 
@@ -165,7 +172,15 @@ var bpcharcmp = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.BpChar, pgtypes.BpChar},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		return int32(bytes.Compare([]byte(val1.(string)), []byte(val2.(string)))), nil
+		val1Str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		val2Str, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
+		return int32(bytes.Compare([]byte(val1Str), []byte(val2Str))), nil
 	},
 }
 
@@ -182,14 +197,18 @@ func truncateString(val string, runeLimit int32) (string, int32) {
 	return val, n
 }
 
-func getTypModFromStringArr(typName string, inputArr []any) (int32, error) {
+func getTypModFromStringArr(ctx *sql.Context, typName string, inputArr []any) (int32, error) {
 	if len(inputArr) == 0 {
 		return 0, pgtypes.ErrTypmodArrayMustBe1D.New()
 	} else if len(inputArr) > 1 {
 		return 0, errors.Errorf("invalid type modifier")
 	}
 
-	l, err := strconv.ParseInt(inputArr[0].(string), 10, 32)
+	lStr, err := framework.UnwrapString(ctx, inputArr[0])
+	if err != nil {
+		return 0, err
+	}
+	l, err := strconv.ParseInt(lStr, 10, 32)
 	if err != nil {
 		return 0, err
 	}

--- a/server/functions/bytea.go
+++ b/server/functions/bytea.go
@@ -42,7 +42,10 @@ var byteain = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if strings.HasPrefix(input, `\x`) {
 			return hex.DecodeString(input[2:])
 		} else {

--- a/server/functions/bytea.go
+++ b/server/functions/bytea.go
@@ -61,7 +61,11 @@ var byteaout = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Bytea},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		return `\x` + hex.EncodeToString(val.([]byte)), nil
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
+		return `\x` + hex.EncodeToString(data), nil
 	},
 }
 
@@ -106,6 +110,14 @@ var byteacmp = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Bytea, pgtypes.Bytea},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		return int32(bytes.Compare(val1.([]byte), val2.([]byte))), nil
+		val1Bytes, err := framework.UnwrapBytes(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		val2Bytes, err := framework.UnwrapBytes(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
+		return int32(bytes.Compare(val1Bytes, val2Bytes)), nil
 	},
 }

--- a/server/functions/char.go
+++ b/server/functions/char.go
@@ -78,7 +78,10 @@ var charrecv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/char.go
+++ b/server/functions/char.go
@@ -41,7 +41,10 @@ var charin = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		c := []byte(input)
 		if uint32(len(c)) > pgtypes.InternalCharLength {
 			return input[:pgtypes.InternalCharLength], nil
@@ -57,7 +60,10 @@ var charout = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.InternalChar},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, t [2]*pgtypes.DoltgresType, val any) (any, error) {
-		str := val.(string)
+		str, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if uint32(len(str)) > pgtypes.InternalCharLength {
 			return str[:pgtypes.InternalCharLength], nil
 		}
@@ -120,8 +126,16 @@ var btcharcmp = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.InternalChar, pgtypes.InternalChar},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		ab := strings.TrimRight(val1.(string), " ")
-		bb := strings.TrimRight(val2.(string), " ")
+		val1Str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		val2Str, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
+		ab := strings.TrimRight(val1Str, " ")
+		bb := strings.TrimRight(val2Str, " ")
 		if ab == bb {
 			return int32(0), nil
 		} else if ab < bb {

--- a/server/functions/cid.go
+++ b/server/functions/cid.go
@@ -40,7 +40,10 @@ var cidin = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		uVal, err := strconv.ParseUint(strings.TrimSpace(input), 10, 32)
 		if err != nil {
 			return uint32(0), err

--- a/server/functions/cid.go
+++ b/server/functions/cid.go
@@ -70,7 +70,10 @@ var cidrecv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/cstring.go
+++ b/server/functions/cstring.go
@@ -66,7 +66,10 @@ var cstring_recv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.([]byte)
+		input, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		return string(input), nil
 	},
 }

--- a/server/functions/cstring.go
+++ b/server/functions/cstring.go
@@ -36,7 +36,10 @@ var cstring_in = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		return input, nil
 	},
 }
@@ -48,7 +51,10 @@ var cstring_out = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		return input, nil
 	},
 }
@@ -72,7 +78,10 @@ var cstring_send = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		return []byte(input), nil
 	},
 }

--- a/server/functions/current_setting.go
+++ b/server/functions/current_setting.go
@@ -38,7 +38,11 @@ var current_setting_text = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
-		return getCurSetting(ctx, val1.(string), false)
+		val1Str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		return getCurSetting(ctx, val1Str, false)
 	},
 }
 
@@ -49,7 +53,11 @@ var current_setting_text_bool = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Bool},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		return getCurSetting(ctx, val1.(string), val2.(bool))
+		val1Str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		return getCurSetting(ctx, val1Str, val2.(bool))
 	},
 }
 

--- a/server/functions/date.go
+++ b/server/functions/date.go
@@ -43,10 +43,12 @@ var date_in = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		formatsInOrder := getDateStyleInputFormat(ctx)
 		var date pgdate.Date
-		var err error
 		for _, format := range formatsInOrder {
 			date, _, err = pgdate.ParseDate(time.Now(), format, input)
 			if err == nil {

--- a/server/functions/date.go
+++ b/server/functions/date.go
@@ -77,12 +77,15 @@ var date_recv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}
 		var out pgtype.Date
-		err := out.DecodeBinary(nil, data)
+		err = out.DecodeBinary(nil, data)
 		if err != nil {
 			return nil, err
 		}

--- a/server/functions/date_part.go
+++ b/server/functions/date_part.go
@@ -46,7 +46,10 @@ var date_part_text_date = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Date},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		field := val1.(string)
+		field, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		dateVal := val2.(time.Time)
 		switch strings.ToLower(field) {
 		case "hour", "hours", "microsecond", "microseconds", "millisecond", "milliseconds",
@@ -72,7 +75,10 @@ var date_part_text_time = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Time},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		field := val1.(string)
+		field, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		timeVal := val2.(timeofday.TimeOfDay).ToTime()
 		switch strings.ToLower(field) {
 		case "century", "centuries", "day", "days", "decade", "decades", "dow", "doy",
@@ -97,7 +103,10 @@ var date_part_text_timetz = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.TimeTZ},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		field := val1.(string)
+		field, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		timetzVal := val2.(timetz.TimeTZ).ToTime()
 		_, currentOffset := timetzVal.Zone()
 		switch strings.ToLower(field) {
@@ -129,7 +138,10 @@ var date_part_text_timestamp = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Timestamp},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		field := val1.(string)
+		field, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		tsVal := val2.(time.Time)
 		switch strings.ToLower(field) {
 		case "timezone", "timezone_hour", "timezone_minute":
@@ -152,7 +164,10 @@ var date_part_text_timestamptz = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.TimestampTZ},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		field := val1.(string)
+		field, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		loc, err := GetServerLocation(ctx)
 		if err != nil {
 			return nil, err
@@ -186,7 +201,10 @@ var date_part_text_interval = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Interval},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		field := val1.(string)
+		field, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		dur := val2.(duration.Duration)
 
 		// This mirrors the exact logic from extract_text_interval

--- a/server/functions/date_trunc.go
+++ b/server/functions/date_trunc.go
@@ -41,7 +41,10 @@ var date_trunc_text_timestamp = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Timestamp},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		unit := val1.(string)
+		unit, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		ts := val2.(time.Time)
 		return truncateTime(unit, ts)
 	},
@@ -54,7 +57,10 @@ var date_trunc_text_timestamptz = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.TimestampTZ},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		unit := val1.(string)
+		unit, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		ts := val2.(time.Time)
 		// Convert to server location for consistent behavior
 		loc, err := GetServerLocation(ctx)
@@ -77,9 +83,15 @@ var date_trunc_text_timestamptz_text = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.TimestampTZ, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		unit := val1.(string)
+		unit, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		ts := val2.(time.Time)
-		timezone := val3.(string)
+		timezone, err := framework.UnwrapString(ctx, val3)
+		if err != nil {
+			return nil, err
+		}
 
 		// Convert timezone string to offset
 		_, newOffset, _, err := convertTzToOffsetSecs(ts, timezone)
@@ -115,7 +127,10 @@ var date_trunc_text_interval = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Interval},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		unit := val1.(string)
+		unit, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		interval := val2.(duration.Duration)
 		return truncateInterval(unit, interval)
 	},

--- a/server/functions/domain.go
+++ b/server/functions/domain.go
@@ -53,7 +53,10 @@ var domain_recv = framework.Function3{
 	Return:     pgtypes.Any,
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Internal, pgtypes.Oid, pgtypes.Int32},
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		data := val1.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		baseTypeOid := val2.(id.Id)
 		t := pgtypes.IDToBuiltInDoltgresType[id.Type(baseTypeOid)]
 		typmod := val3.(int32)

--- a/server/functions/domain.go
+++ b/server/functions/domain.go
@@ -35,7 +35,10 @@ var domain_in = framework.Function3{
 	Return:     pgtypes.Any,
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Cstring, pgtypes.Oid, pgtypes.Int32},
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		str := val1.(string)
+		str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		baseTypeOid := val2.(id.Id)
 		t := pgtypes.IDToBuiltInDoltgresType[id.Type(baseTypeOid)]
 		typmod := val3.(int32)

--- a/server/functions/encode.go
+++ b/server/functions/encode.go
@@ -38,7 +38,10 @@ var encode = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Bytea, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		data := val1.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		format, err := framework.UnwrapString(ctx, val2)
 		if err != nil {
 			return nil, err

--- a/server/functions/encode.go
+++ b/server/functions/encode.go
@@ -39,7 +39,10 @@ var encode = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
 		data := val1.([]byte)
-		format := val2.(string)
+		format, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
 		switch strings.ToLower(format) {
 		case "hex":
 			return hex.EncodeToString(data), nil

--- a/server/functions/enum.go
+++ b/server/functions/enum.go
@@ -81,7 +81,10 @@ var enum_recv = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Internal, pgtypes.Oid},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		data := val1.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/enum.go
+++ b/server/functions/enum.go
@@ -50,7 +50,10 @@ var enum_in = framework.Function2{
 			return nil, errors.Errorf(`"%s" is not an enum type`, typ.Name())
 		}
 
-		value := val1.(string)
+		value, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		if _, exists := typ.EnumLabels[value]; !exists {
 			return nil, pgtypes.ErrInvalidInputValueForEnum.New(typ.Name(), value)
 		}
@@ -67,7 +70,7 @@ var enum_out = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		// TODO: should receive the index instead of label?
-		return val.(string), nil
+		return framework.UnwrapString(ctx, val)
 	},
 }
 
@@ -116,8 +119,14 @@ var enum_cmp = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.AnyEnum, pgtypes.AnyEnum},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, t [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		ab := val1.(string)
-		bb := val2.(string)
+		ab, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		bb, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
 		enumType := t[0]
 		if enumType.EnumLabels == nil {
 			return nil, errors.Errorf(`enum label lookup failed for type %s`, enumType.Name())

--- a/server/functions/extract.go
+++ b/server/functions/extract.go
@@ -51,7 +51,10 @@ var extract_text_date = framework.Function2{
 	IsNonDeterministic: true,
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		field := val1.(string)
+		field, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		dateVal := val2.(time.Time)
 		switch strings.ToLower(field) {
 		case "hour", "hours", "microsecond", "microseconds", "millisecond", "milliseconds",
@@ -73,7 +76,10 @@ var extract_text_time = framework.Function2{
 	IsNonDeterministic: true,
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		field := val1.(string)
+		field, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		timeVal := val2.(timeofday.TimeOfDay).ToTime()
 		switch strings.ToLower(field) {
 		case "century", "centuries", "day", "days", "decade", "decades", "dow", "doy",
@@ -94,7 +100,10 @@ var extract_text_timetz = framework.Function2{
 	IsNonDeterministic: true,
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		field := val1.(string)
+		field, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		timetzVal := val2.(timetz.TimeTZ).ToTime()
 		_, currentOffset := timetzVal.Zone()
 		switch strings.ToLower(field) {
@@ -122,7 +131,10 @@ var extract_text_timestamp = framework.Function2{
 	IsNonDeterministic: true,
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		field := val1.(string)
+		field, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		tsVal := val2.(time.Time)
 		switch strings.ToLower(field) {
 		case "timezone", "timezone_hour", "timezone_minute":
@@ -141,7 +153,10 @@ var extract_text_timestamptz = framework.Function2{
 	IsNonDeterministic: true,
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		field := val1.(string)
+		field, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		loc, err := GetServerLocation(ctx)
 		if err != nil {
 			return nil, err
@@ -177,7 +192,10 @@ var extract_text_interval = framework.Function2{
 	IsNonDeterministic: true,
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		field := val1.(string)
+		field, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		dur := val2.(duration.Duration)
 		switch strings.ToLower(field) {
 		case "century", "centuries":

--- a/server/functions/float4.go
+++ b/server/functions/float4.go
@@ -72,7 +72,10 @@ var float4recv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/float4.go
+++ b/server/functions/float4.go
@@ -42,7 +42,10 @@ var float4in = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		fVal, err := strconv.ParseFloat(strings.TrimSpace(input), 32)
 		if err != nil {
 			return nil, pgtypes.ErrInvalidSyntaxForType.New("float4", input)

--- a/server/functions/float8.go
+++ b/server/functions/float8.go
@@ -72,7 +72,10 @@ var float8recv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/float8.go
+++ b/server/functions/float8.go
@@ -42,7 +42,10 @@ var float8in = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		fVal, err := strconv.ParseFloat(strings.TrimSpace(input), 64)
 		if err != nil {
 			return nil, pgtypes.ErrInvalidSyntaxForType.New("float8", input)

--- a/server/functions/framework/unwrap.go
+++ b/server/functions/framework/unwrap.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// UnwrapString converts a string-typed function argument into a string. Large string values may arrive as a wrapper
+// (e.g. *val.TextStorage) whose contents are stored out-of-band, in which case this loads the full value into memory.
+// An error is returned if the value is neither a string nor a wrapper around one.
+func UnwrapString(ctx *sql.Context, val any) (string, error) {
+	str, ok, err := sql.Unwrap[string](ctx, val)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", errors.Errorf("expected string value, got %T", val)
+	}
+	return str, nil
+}

--- a/server/functions/framework/unwrap.go
+++ b/server/functions/framework/unwrap.go
@@ -32,3 +32,17 @@ func UnwrapString(ctx *sql.Context, val any) (string, error) {
 	}
 	return str, nil
 }
+
+// UnwrapBytes converts a bytes-typed function argument into a []byte. Large bytea values may arrive as a wrapper
+// (e.g. *val.ByteArray) whose contents are stored out-of-band, in which case this loads the full value into memory.
+// An error is returned if the value is neither a []byte nor a wrapper around one.
+func UnwrapBytes(ctx *sql.Context, val any) ([]byte, error) {
+	data, ok, err := sql.Unwrap[[]byte](ctx, val)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, errors.Errorf("expected []byte value, got %T", val)
+	}
+	return data, nil
+}

--- a/server/functions/initcap.go
+++ b/server/functions/initcap.go
@@ -36,6 +36,10 @@ var initcap_text = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
-		return cases.Title(language.English).String(val1.(string)), nil
+		str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		return cases.Title(language.English).String(str), nil
 	},
 }

--- a/server/functions/int2.go
+++ b/server/functions/int2.go
@@ -43,7 +43,10 @@ var int2in = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		iVal, err := strconv.ParseInt(strings.TrimSpace(input), 10, 16)
 		if err != nil {
 			return nil, pgtypes.ErrInvalidSyntaxForType.New("int2", input)

--- a/server/functions/int2.go
+++ b/server/functions/int2.go
@@ -76,7 +76,10 @@ var int2recv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/int2vector.go
+++ b/server/functions/int2vector.go
@@ -39,7 +39,10 @@ var int2vectorin = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		strValues := strings.Split(input, " ")
 		var values = make([]any, len(strValues))
 		for i, strValue := range strValues {

--- a/server/functions/int4.go
+++ b/server/functions/int4.go
@@ -76,7 +76,10 @@ var int4recv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/int4.go
+++ b/server/functions/int4.go
@@ -43,7 +43,10 @@ var int4in = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		iVal, err := strconv.ParseInt(strings.TrimSpace(input), 10, 32)
 		if err != nil {
 			return nil, pgtypes.ErrInvalidSyntaxForType.New("int4", input)

--- a/server/functions/int8.go
+++ b/server/functions/int8.go
@@ -76,7 +76,10 @@ var int8recv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/int8.go
+++ b/server/functions/int8.go
@@ -43,7 +43,10 @@ var int8in = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		iVal, err := strconv.ParseInt(strings.TrimSpace(input), 10, 64)
 		if err != nil {
 			return nil, pgtypes.ErrInvalidSyntaxForType.New("int8", input)

--- a/server/functions/internal.go
+++ b/server/functions/internal.go
@@ -34,7 +34,11 @@ var internal_in = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		// TODO
-		return []byte(val.(string)), nil
+		str, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
+		return []byte(str), nil
 	},
 }
 

--- a/server/functions/internal.go
+++ b/server/functions/internal.go
@@ -50,6 +50,10 @@ var internal_out = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		// TODO
-		return string(val.([]byte)), nil
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
+		return string(data), nil
 	},
 }

--- a/server/functions/interval.go
+++ b/server/functions/interval.go
@@ -44,7 +44,10 @@ var interval_in = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Cstring, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		input := val1.(string)
+		input, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		//oid := val2.(id.Id)
 		//typmod := val3.(int32)
 		dInterval, err := tree.ParseDInterval(input)

--- a/server/functions/interval.go
+++ b/server/functions/interval.go
@@ -76,12 +76,15 @@ var interval_recv = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Internal, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		data := val1.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}
 		var out pgtype.Interval
-		err := out.DecodeBinary(nil, data)
+		err = out.DecodeBinary(nil, data)
 		if err != nil {
 			return nil, err
 		}

--- a/server/functions/json.go
+++ b/server/functions/json.go
@@ -56,9 +56,12 @@ var json_in = framework.Function1{
 }
 
 func json_in_callable(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-	input := val.(string)
+	input, err := framework.UnwrapString(ctx, val)
+	if err != nil {
+		return nil, err
+	}
 	var jsonVal any
-	err := json.Unmarshal(unsafe.Slice(unsafe.StringData(input), len(input)), &jsonVal)
+	err = json.Unmarshal(unsafe.Slice(unsafe.StringData(input), len(input)), &jsonVal)
 	if err != nil {
 		if len(input) > 10 {
 			input = input[:10] + "..."
@@ -216,7 +219,7 @@ var json_build_object = framework.Function1{
 }
 
 func json_build_object_callable(ctx *sql.Context, argTypes [2]*pgtypes.DoltgresType, val1 any) (any, error) {
-	json, err := buildJsonObject("json_build_object", argTypes, val1)
+	json, err := buildJsonObject(ctx, "json_build_object", argTypes, val1)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +227,7 @@ func json_build_object_callable(ctx *sql.Context, argTypes [2]*pgtypes.DoltgresT
 }
 
 // buildJsonObject constructs a json object from the input array provided, which are alternating keys and values.
-func buildJsonObject(fnName string, _ [2]*pgtypes.DoltgresType, val1 any) (types.JSONDocument, error) {
+func buildJsonObject(ctx *sql.Context, fnName string, _ [2]*pgtypes.DoltgresType, val1 any) (types.JSONDocument, error) {
 	inputArray := val1.([]any)
 	if len(inputArray)%2 != 0 {
 		return types.JSONDocument{}, sql.ErrInvalidArgumentNumber.New(fnName, "even number of arguments", len(inputArray))
@@ -234,7 +237,11 @@ func buildJsonObject(fnName string, _ [2]*pgtypes.DoltgresType, val1 any) (types
 	for i, e := range inputArray {
 		if i%2 == 0 {
 			var ok bool
-			key, ok = e.(string)
+			var err error
+			key, ok, err = sql.Unwrap[string](ctx, e)
+			if err != nil {
+				return types.JSONDocument{}, err
+			}
 			if !ok {
 				// TODO: This isn't correct for every type we might use as a value. To get better type info to transform
 				//  every value into its string format, we need to pass detailed arg type info for the vararg params (the

--- a/server/functions/json.go
+++ b/server/functions/json.go
@@ -151,7 +151,10 @@ var json_recv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/jsonb.go
+++ b/server/functions/jsonb.go
@@ -62,7 +62,10 @@ var jsonb_recv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, t [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/left.go
+++ b/server/functions/left.go
@@ -33,7 +33,10 @@ var left_text_int32 = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, strInt any, nInt any) (any, error) {
-		str := strInt.(string)
+		str, err := framework.UnwrapString(ctx, strInt)
+		if err != nil {
+			return nil, err
+		}
 		n := nInt.(int32)
 		if n >= 0 {
 			if int(n) > len(str) {

--- a/server/functions/lower.go
+++ b/server/functions/lower.go
@@ -36,6 +36,10 @@ var lower_text = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
 		//TODO: this doesn't respect collations
-		return strings.ToLower(val1.(string)), nil
+		str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		return strings.ToLower(str), nil
 	},
 }

--- a/server/functions/lpad.go
+++ b/server/functions/lpad.go
@@ -49,9 +49,17 @@ var lpad_text_int32_text = framework.Function3{
 		if length.(int32) <= 0 {
 			return "", nil
 		}
-		runes := []rune(str.(string))
+		strStr, err := framework.UnwrapString(ctx, str)
+		if err != nil {
+			return nil, err
+		}
+		fillStr, err := framework.UnwrapString(ctx, fill)
+		if err != nil {
+			return nil, err
+		}
+		runes := []rune(strStr)
 		fillTarget := length.(int32) - int32(len(runes))
-		fillRunes := []rune(fill.(string))
+		fillRunes := []rune(fillStr)
 		var result []rune
 		if fillTarget > 0 {
 			if len(fillRunes) > 0 {

--- a/server/functions/ltrim.go
+++ b/server/functions/ltrim.go
@@ -46,9 +46,17 @@ var ltrim_text_text = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, str any, characters any) (any, error) {
-		runes := []rune(str.(string))
+		strStr, err := framework.UnwrapString(ctx, str)
+		if err != nil {
+			return nil, err
+		}
+		charactersStr, err := framework.UnwrapString(ctx, characters)
+		if err != nil {
+			return nil, err
+		}
+		runes := []rune(strStr)
 		trimChars := make(map[rune]struct{})
-		for _, c := range characters.(string) {
+		for _, c := range charactersStr {
 			trimChars[c] = struct{}{}
 		}
 		trimIdx := 0

--- a/server/functions/make_timestamp.go
+++ b/server/functions/make_timestamp.go
@@ -70,7 +70,10 @@ var make_timestamptz_int32_int32_int32_int32_int32_float64_text = framework.Func
 	IsNonDeterministic: true,
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [8]*pgtypes.DoltgresType, val1, val2, val3, val4, val5, val6, val7 any) (any, error) {
-		tz := val7.(string)
+		tz, err := framework.UnwrapString(ctx, val7)
+		if err != nil {
+			return nil, err
+		}
 		loc, _, _, err := convertTzToOffsetSecs(time.Now().UTC(), tz)
 		if err != nil {
 			return nil, errors.Errorf(`time zone "%s" not recognized`, tz)

--- a/server/functions/md5.go
+++ b/server/functions/md5.go
@@ -36,6 +36,10 @@ var md5_text = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
-		return fmt.Sprintf("%x", md5_package.Sum([]byte(val1.(string)))), nil
+		str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		return fmt.Sprintf("%x", md5_package.Sum([]byte(str))), nil
 	},
 }

--- a/server/functions/name.go
+++ b/server/functions/name.go
@@ -40,7 +40,10 @@ var namein = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		input, _ = truncateString(input, pgtypes.NameLength)
 		return input, nil
 	},
@@ -53,7 +56,11 @@ var nameout = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Name},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		str, _ := truncateString(val.(string), pgtypes.NameLength)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
+		str, _ := truncateString(input, pgtypes.NameLength)
 		return str, nil
 	},
 }
@@ -104,8 +111,14 @@ var btnamecmp = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Name, pgtypes.Name},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		ab := val1.(string)
-		bb := val2.(string)
+		ab, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		bb, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
 		if ab == bb {
 			return int32(0), nil
 		} else if ab < bb {
@@ -123,8 +136,14 @@ var btnametextcmp = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Name, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		ab := val1.(string)
-		bb := val2.(string)
+		ab, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		bb, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
 		if ab == bb {
 			return int32(0), nil
 		} else if ab < bb {

--- a/server/functions/name.go
+++ b/server/functions/name.go
@@ -72,7 +72,10 @@ var namerecv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/nextval.go
+++ b/server/functions/nextval.go
@@ -96,7 +96,11 @@ var nextval_text = framework.Function1{
 		if err != nil {
 			return 0, err
 		}
-		return nextval(ctx, ait, val.(string))
+		relationName, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return 0, err
+		}
+		return nextval(ctx, ait, relationName)
 	},
 }
 

--- a/server/functions/numeric.go
+++ b/server/functions/numeric.go
@@ -46,7 +46,10 @@ var numeric_in = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Cstring, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		input := val1.(string)
+		input, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		typmod := val3.(int32)
 		dec, _, err := apd.NewFromString(strings.TrimSpace(input))
 		if err != nil {
@@ -277,14 +280,22 @@ var numerictypmodin = framework.Function1{
 			return nil, pgtypes.ErrInvalidTypMod.New("NUMERIC")
 		}
 
-		p, err := strconv.ParseInt(arr[0].(string), 10, 32)
+		precisionStr, err := framework.UnwrapString(ctx, arr[0])
+		if err != nil {
+			return nil, err
+		}
+		p, err := strconv.ParseInt(precisionStr, 10, 32)
 		if err != nil {
 			return nil, err
 		}
 		precision := int32(p)
 		scale := int32(0)
 		if len(arr) == 2 {
-			s, err := strconv.ParseInt(arr[1].(string), 10, 32)
+			scaleStr, err := framework.UnwrapString(ctx, arr[1])
+			if err != nil {
+				return nil, err
+			}
+			s, err := strconv.ParseInt(scaleStr, 10, 32)
 			if err != nil {
 				return nil, err
 			}

--- a/server/functions/numeric.go
+++ b/server/functions/numeric.go
@@ -84,7 +84,10 @@ var numeric_recv = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Internal, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		data := val1.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/octet_length.go
+++ b/server/functions/octet_length.go
@@ -33,6 +33,10 @@ var octet_length_text = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
-		return int32(len(val1.(string))), nil
+		str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		return int32(len(str)), nil
 	},
 }

--- a/server/functions/oid.go
+++ b/server/functions/oid.go
@@ -45,7 +45,10 @@ var oidin = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		iVal, err := strconv.ParseInt(strings.TrimSpace(input), 10, 64)
 		if err != nil {
 			return id.Null, pgtypes.ErrInvalidSyntaxForType.New("oid", input)

--- a/server/functions/oid.go
+++ b/server/functions/oid.go
@@ -83,7 +83,10 @@ var oidrecv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/oidvector.go
+++ b/server/functions/oidvector.go
@@ -40,7 +40,10 @@ var oidvectorin = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		strValues := strings.Split(input, " ")
 		var values = make([]any, len(strValues))
 		for i, strValue := range strValues {

--- a/server/functions/pg_char_to_encoding.go
+++ b/server/functions/pg_char_to_encoding.go
@@ -36,10 +36,14 @@ var pg_char_to_encoding_name = framework.Function1{
 	IsNonDeterministic: true,
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
+		valStr, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		// Encoding names are normalized by lowercasing and dropping any characters that are not ASCII letters or
 		// digits, matching Postgres (e.g. "UTF-8" matches "utf8").
 		var sb strings.Builder
-		for _, r := range strings.ToLower(val.(string)) {
+		for _, r := range strings.ToLower(valStr) {
 			if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
 				sb.WriteRune(r)
 			}

--- a/server/functions/pg_get_serial_sequence.go
+++ b/server/functions/pg_get_serial_sequence.go
@@ -42,11 +42,16 @@ var pg_get_serial_sequence_text_text = framework.Function2{
 	IsNonDeterministic: false,
 	Strict:             true,
 	Callable: func(ctx *sql.Context, paramsAndReturn [3]*pgtypes.DoltgresType, val1 any, val2 any) (any, error) {
-		tableName := val1.(string)
-		columnName := val2.(string)
+		tableName, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		columnName, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
 
 		// Parse out the schema if one was supplied
-		var err error
 		schemaName := ""
 		if strings.Contains(tableName, ".") {
 			schemaName, tableName, err = ParseRelationName(ctx, tableName)

--- a/server/functions/quote_ident.go
+++ b/server/functions/quote_ident.go
@@ -36,6 +36,10 @@ var quote_ident_text = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		return fmt.Sprintf(`"%s"`, strings.Replace(val.(string), "\"", "\"\"", -1)), nil
+		valStr, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
+		return fmt.Sprintf(`"%s"`, strings.Replace(valStr, "\"", "\"\"", -1)), nil
 	},
 }

--- a/server/functions/record.go
+++ b/server/functions/record.go
@@ -76,7 +76,10 @@ var record_recv = framework.Function3{
 
 // record_recv_callable is the function definition of record_recv.
 func record_recv_callable(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-	data := val1.([]byte)
+	data, err := framework.UnwrapBytes(ctx, val1)
+	if err != nil {
+		return nil, err
+	}
 	if data == nil {
 		return nil, nil
 	}

--- a/server/functions/record.go
+++ b/server/functions/record.go
@@ -179,8 +179,14 @@ var btrecordcmp = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
 		// TODO
-		ab := val1.(string)
-		bb := val2.(string)
+		ab, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		bb, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
 		if ab == bb {
 			return int32(0), nil
 		} else if ab < bb {

--- a/server/functions/regclass.go
+++ b/server/functions/regclass.go
@@ -45,7 +45,10 @@ var regclassin = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		// If the string just represents a number, then we return it.
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if parsedOid, err := strconv.ParseUint(input, 10, 32); err == nil {
 			if internalID := id.Cache().ToInternal(uint32(parsedOid)); internalID.IsValid() {
 				return internalID, nil

--- a/server/functions/regclass.go
+++ b/server/functions/regclass.go
@@ -208,7 +208,10 @@ var regclassrecv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/regproc.go
+++ b/server/functions/regproc.go
@@ -109,7 +109,10 @@ var regprocrecv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/regproc.go
+++ b/server/functions/regproc.go
@@ -42,7 +42,10 @@ var regprocin = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		// If the string just represents a number, then we return it.
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if parsedOid, err := strconv.ParseUint(input, 10, 32); err == nil {
 			if internalID := id.Cache().ToInternal(uint32(parsedOid)); internalID.IsValid() {
 				return internalID, nil

--- a/server/functions/regtype.go
+++ b/server/functions/regtype.go
@@ -121,7 +121,10 @@ var regtyperecv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/regtype.go
+++ b/server/functions/regtype.go
@@ -45,7 +45,10 @@ var regtypein = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		// If the string just represents a number, then we return it.
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if parsedOid, err := strconv.ParseUint(input, 10, 32); err == nil {
 			if internalID := id.Cache().ToInternal(uint32(parsedOid)); internalID.IsValid() {
 				return internalID, nil

--- a/server/functions/repeat.go
+++ b/server/functions/repeat.go
@@ -35,6 +35,10 @@ var repeat_text_int32 = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, str any, num any) (any, error) {
-		return strings.Repeat(str.(string), int(num.(int32))), nil
+		strStr, err := framework.UnwrapString(ctx, str)
+		if err != nil {
+			return nil, err
+		}
+		return strings.Repeat(strStr, int(num.(int32))), nil
 	},
 }

--- a/server/functions/replace.go
+++ b/server/functions/replace.go
@@ -35,9 +35,21 @@ var replace_text_text_text = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, str any, from any, to any) (any, error) {
-		if len(from.(string)) == 0 {
+		fromStr, err := framework.UnwrapString(ctx, from)
+		if err != nil {
+			return nil, err
+		}
+		if len(fromStr) == 0 {
 			return str, nil
 		}
-		return strings.ReplaceAll(str.(string), from.(string), to.(string)), nil
+		strStr, err := framework.UnwrapString(ctx, str)
+		if err != nil {
+			return nil, err
+		}
+		toStr, err := framework.UnwrapString(ctx, to)
+		if err != nil {
+			return nil, err
+		}
+		return strings.ReplaceAll(strStr, fromStr, toStr), nil
 	},
 }

--- a/server/functions/reverse.go
+++ b/server/functions/reverse.go
@@ -33,7 +33,11 @@ var reverse_text = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
-		runes := []rune(val1.(string))
+		val1Str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		runes := []rune(val1Str)
 		for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
 			runes[i], runes[j] = runes[j], runes[i]
 		}

--- a/server/functions/right.go
+++ b/server/functions/right.go
@@ -33,7 +33,10 @@ var right_text_int32 = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, strInt any, nInt any) (any, error) {
-		str := strInt.(string)
+		str, err := framework.UnwrapString(ctx, strInt)
+		if err != nil {
+			return nil, err
+		}
 		n := nInt.(int32)
 		if n >= 0 {
 			if len(str)-int(n) < 0 {

--- a/server/functions/rpad.go
+++ b/server/functions/rpad.go
@@ -49,8 +49,16 @@ var rpad_text_int32_text = framework.Function3{
 		if length.(int32) <= 0 {
 			return "", nil
 		}
-		runes := []rune(str.(string))
-		fillRunes := []rune(fill.(string))
+		strStr, err := framework.UnwrapString(ctx, str)
+		if err != nil {
+			return nil, err
+		}
+		fillStr, err := framework.UnwrapString(ctx, fill)
+		if err != nil {
+			return nil, err
+		}
+		runes := []rune(strStr)
+		fillRunes := []rune(fillStr)
 		if len(fillRunes) > 0 {
 			for int32(len(runes)) < length.(int32) {
 				runes = append(runes, fillRunes...)

--- a/server/functions/rtrim.go
+++ b/server/functions/rtrim.go
@@ -46,9 +46,17 @@ var rtrim_text_text = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, str any, characters any) (any, error) {
-		runes := []rune(str.(string))
+		strStr, err := framework.UnwrapString(ctx, str)
+		if err != nil {
+			return nil, err
+		}
+		charactersStr, err := framework.UnwrapString(ctx, characters)
+		if err != nil {
+			return nil, err
+		}
+		runes := []rune(strStr)
 		trimChars := make(map[rune]struct{})
-		for _, c := range characters.(string) {
+		for _, c := range charactersStr {
 			trimChars[c] = struct{}{}
 		}
 		trimIdx := len(runes)

--- a/server/functions/set_config.go
+++ b/server/functions/set_config.go
@@ -49,19 +49,28 @@ var set_config_text_text_boolean = framework.Function3{
 			return nil, errors.Errorf("setting configuration values for the current transaction is not supported yet")
 		}
 
+		settingNameStr, err := framework.UnwrapString(ctx, settingName)
+		if err != nil {
+			return nil, err
+		}
+		newValueStr, err := framework.UnwrapString(ctx, newValue)
+		if err != nil {
+			return nil, err
+		}
+
 		// set_config can set system configuration or user configuration. System configuration settings are in top
 		// level settings, while user configuration settings are namespaced.
-		isUserConfig := strings.Contains(settingName.(string), ".")
+		isUserConfig := strings.Contains(settingNameStr, ".")
 		if isUserConfig {
-			if err := ctx.SetUserVariable(ctx, settingName.(string), newValue.(string), pgtypes.Text); err != nil {
+			if err := ctx.SetUserVariable(ctx, settingNameStr, newValueStr, pgtypes.Text); err != nil {
 				return nil, err
 			}
 		} else {
-			if err := ctx.SetSessionVariable(ctx, settingName.(string), newValue.(string)); err != nil {
+			if err := ctx.SetSessionVariable(ctx, settingNameStr, newValueStr); err != nil {
 				return nil, err
 			}
 		}
 
-		return newValue.(string), nil
+		return newValueStr, nil
 	},
 }

--- a/server/functions/setval.go
+++ b/server/functions/setval.go
@@ -61,7 +61,10 @@ var setval_text_int64_boolean = framework.Function3{
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1 any, val2 any, val3 any) (any, error) {
 		// TODO: this needs a database name to support inserts into other databases (including inserts on other branches than the current one)
-		relationName := val1.(string)
+		relationName, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		newVal := val2.(int64)
 		autoAdvance := val3.(bool)
 		collection, err := core.GetSequencesCollectionFromContext(ctx, ctx.GetCurrentDatabase())

--- a/server/functions/split_part.go
+++ b/server/functions/split_part.go
@@ -40,11 +40,19 @@ var split_part_text_text_int32 = framework.Function3{
 		if n.(int32) == 0 {
 			return nil, errors.Errorf("field position must not be zero")
 		}
+		strStr, err := framework.UnwrapString(ctx, str)
+		if err != nil {
+			return nil, err
+		}
+		delimiterStr, err := framework.UnwrapString(ctx, delimiter)
+		if err != nil {
+			return nil, err
+		}
 		var parts []string
-		if len(delimiter.(string)) > 0 {
-			parts = strings.Split(str.(string), delimiter.(string))
+		if len(delimiterStr) > 0 {
+			parts = strings.Split(strStr, delimiterStr)
 		} else {
-			parts = []string{str.(string)}
+			parts = []string{strStr}
 		}
 		if int(utils.Abs(n.(int32))) > len(parts) {
 			return "", nil

--- a/server/functions/strpos.go
+++ b/server/functions/strpos.go
@@ -35,7 +35,15 @@ var strpos_varchar = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.VarChar, pgtypes.VarChar},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, str any, substring any) (any, error) {
-		idx := strings.Index(str.(string), substring.(string))
+		strStr, err := framework.UnwrapString(ctx, str)
+		if err != nil {
+			return nil, err
+		}
+		substringStr, err := framework.UnwrapString(ctx, substring)
+		if err != nil {
+			return nil, err
+		}
+		idx := strings.Index(strStr, substringStr)
 		if idx == -1 {
 			return int32(0), nil
 		}

--- a/server/functions/text.go
+++ b/server/functions/text.go
@@ -39,7 +39,7 @@ var textin = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		return val.(string), nil
+		return framework.UnwrapString(ctx, val)
 	},
 }
 
@@ -99,8 +99,14 @@ var bttextcmp = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		ab := val1.(string)
-		bb := val2.(string)
+		ab, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		bb, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
 		if ab == bb {
 			return int32(0), nil
 		} else if ab < bb {
@@ -118,8 +124,14 @@ var bttextnamecmp = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		ab := val1.(string)
-		bb := val2.(string)
+		ab, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		bb, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
 		if ab == bb {
 			return int32(0), nil
 		} else if ab < bb {

--- a/server/functions/text.go
+++ b/server/functions/text.go
@@ -61,7 +61,10 @@ var textrecv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/tid.go
+++ b/server/functions/tid.go
@@ -44,7 +44,11 @@ var tidin = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := strings.TrimSpace(val.(string))
+		valStr, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
+		input := strings.TrimSpace(valStr)
 		commaIdx := strings.Index(input, ",")
 		if len(input) < 5 || input[0] != '(' || input[len(input)-1] != ')' || commaIdx == -1 {
 			return nil, pgtypes.ErrInvalidSyntaxForType.New(pgtypes.Tid.Name(), input)

--- a/server/functions/tid.go
+++ b/server/functions/tid.go
@@ -87,7 +87,10 @@ var tidrecv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/time.go
+++ b/server/functions/time.go
@@ -86,12 +86,15 @@ var time_recv = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Internal, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		data := val1.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}
 		var out pgtype.Time
-		err := out.DecodeBinary(nil, data)
+		err = out.DecodeBinary(nil, data)
 		if err != nil {
 			return nil, err
 		}

--- a/server/functions/time.go
+++ b/server/functions/time.go
@@ -45,7 +45,11 @@ var time_in = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Cstring, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		input := strings.TrimSpace(val1.(string))
+		val1Str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		input := strings.TrimSpace(val1Str)
 		typmod := val3.(int32)
 		if typmod == -1 {
 			typmod = 6

--- a/server/functions/timestamp.go
+++ b/server/functions/timestamp.go
@@ -47,7 +47,10 @@ var timestamp_in = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Cstring, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		input := val1.(string)
+		input, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		//oid := val2.(id.Id)
 		//typmod := val3.(int32)
 		// TODO: decode typmod to precision
@@ -170,12 +173,16 @@ func getDateStyleOutputFormat(ctx *sql.Context) string {
 	if err != nil {
 		return format
 	}
+	valStr, err := framework.UnwrapString(ctx, val)
+	if err != nil {
+		return format
+	}
 
 	defer func() {
 		_ = core.SetDateStyleOutputFormat(ctx, format)
 	}()
 
-	values := strings.Split(strings.ReplaceAll(val.(string), " ", ""), ",")
+	values := strings.Split(strings.ReplaceAll(valStr, " ", ""), ",")
 	for _, value := range values {
 		switch value {
 		case DateStyleISO, DateStyleSQL, DateStylePostgres, DateStyleGerman:

--- a/server/functions/timestamp.go
+++ b/server/functions/timestamp.go
@@ -82,12 +82,15 @@ var timestamp_recv = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Internal, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		data := val1.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}
 		var out pgtype.Timestamp
-		err := out.DecodeBinary(nil, data)
+		err = out.DecodeBinary(nil, data)
 		if err != nil {
 			return nil, err
 		}

--- a/server/functions/timestamptz.go
+++ b/server/functions/timestamptz.go
@@ -44,7 +44,10 @@ var timestamptz_in = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Cstring, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		input := val1.(string)
+		input, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		//oid := val2.(id.Id)
 		//typmod := val3.(int32)
 		// TODO: decode typmod to precision

--- a/server/functions/timestamptz.go
+++ b/server/functions/timestamptz.go
@@ -89,12 +89,15 @@ var timestamptz_recv = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Internal, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		data := val1.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}
 		var out pgtype.Timestamptz
-		err := out.DecodeBinary(nil, data)
+		err = out.DecodeBinary(nil, data)
 		if err != nil {
 			return nil, err
 		}

--- a/server/functions/timetz.go
+++ b/server/functions/timetz.go
@@ -92,7 +92,10 @@ var timetz_recv = framework.Function3{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
 		// TODO: decode typmod to precision
-		data := val1.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/timetz.go
+++ b/server/functions/timetz.go
@@ -46,7 +46,11 @@ var timetz_in = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Cstring, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		input := strings.TrimSpace(val1.(string))
+		val1Str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		input := strings.TrimSpace(val1Str)
 		typmod := val3.(int32)
 		if typmod == -1 {
 			typmod = 6
@@ -162,7 +166,11 @@ func GetServerLocation(ctx *sql.Context) (*time.Location, error) {
 	if err != nil {
 		return nil, err
 	}
+	valStr, err := framework.UnwrapString(ctx, val)
+	if err != nil {
+		return nil, err
+	}
 
-	loc, _, _, err := convertTzToOffsetSecs(time.Now(), val.(string))
+	loc, _, _, err := convertTzToOffsetSecs(time.Now(), valStr)
 	return loc, err
 }

--- a/server/functions/timezone.go
+++ b/server/functions/timezone.go
@@ -60,7 +60,10 @@ var timezone_text_timestamptz = framework.Function2{
 	IsNonDeterministic: true,
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		tz := val1.(string)
+		tz, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		timeVal := val2.(time.Time)
 		_, newOffset, _, err := convertTzToOffsetSecs(timeVal, tz)
 		if err != nil {
@@ -78,7 +81,10 @@ var timezone_text_timetz = framework.Function2{
 	IsNonDeterministic: true,
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		tz := val1.(string)
+		tz, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		timeVal := val2.(timetz.TimeTZ).ToTime()
 		_, newOffset, _, err := convertTzToOffsetSecs(timeVal, tz)
 		if err != nil {
@@ -115,7 +121,10 @@ var timezone_text_timestamp = framework.Function2{
 	IsNonDeterministic: true,
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		tz := val1.(string)
+		tz, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		timeVal := val2.(time.Time)
 		_, newOffset, isOffset, err := convertTzToOffsetSecs(timeVal, tz)
 		if err != nil {

--- a/server/functions/to_char.go
+++ b/server/functions/to_char.go
@@ -43,7 +43,10 @@ var to_char_timestamp_text = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
 		timestamp := val1.(time.Time)
-		format := val2.(string)
+		format, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
 
 		loc, err := GetServerLocation(ctx)
 		if err != nil {
@@ -63,7 +66,10 @@ var to_char_timestamptz_text = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
 		timestamp := val1.(time.Time)
-		format := val2.(string)
+		format, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
 
 		loc, err := GetServerLocation(ctx)
 		if err != nil {
@@ -108,7 +114,10 @@ var to_char_interval_text = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
 		interval := val1.(duration.Duration)
-		format := val2.(string)
+		format, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
 
 		ttc := &tmToChar{}
 		ttc.year = int(interval.Months) / monthsPerYear

--- a/server/functions/to_date.go
+++ b/server/functions/to_date.go
@@ -35,8 +35,14 @@ var to_date_text_text = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		input := val1.(string)
-		format := val2.(string)
+		input, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		format, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
 
 		// Parse the date using PostgreSQL format patterns
 		t, err := getDateTimeFromFormat(ctx, input, format)

--- a/server/functions/to_regclass.go
+++ b/server/functions/to_regclass.go
@@ -37,11 +37,15 @@ var to_regclass_text = framework.Function1{
 	IsNonDeterministic: true,
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
+		val1Str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		// If the string just represents a number, then we return nil.
-		if _, err := strconv.ParseUint(val1.(string), 10, 32); err == nil {
+		if _, err := strconv.ParseUint(val1Str, 10, 32); err == nil {
 			return nil, nil
 		}
-		oid, err := pgtypes.Regclass.IoInput(ctx, val1.(string))
+		oid, err := pgtypes.Regclass.IoInput(ctx, val1Str)
 		if err != nil {
 			// Specifically for the "does not exist" error, we return nil instead of the error.
 			// https://www.postgresql.org/docs/15/functions-info.html#FUNCTIONS-INFO-CATALOG-TABLE

--- a/server/functions/to_regproc.go
+++ b/server/functions/to_regproc.go
@@ -37,11 +37,15 @@ var to_regproc_text = framework.Function1{
 	IsNonDeterministic: true,
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
+		val1Str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		// If the string just represents a number, then we return nil.
-		if _, err := strconv.ParseUint(val1.(string), 10, 32); err == nil {
+		if _, err := strconv.ParseUint(val1Str, 10, 32); err == nil {
 			return nil, nil
 		}
-		oid, err := pgtypes.Regproc.IoInput(ctx, val1.(string))
+		oid, err := pgtypes.Regproc.IoInput(ctx, val1Str)
 		if err != nil {
 			// Specifically for the "does not exist" and "more than one function" errors, we return nil instead of the error.
 			// https://www.postgresql.org/docs/15/functions-info.html#FUNCTIONS-INFO-CATALOG-TABLE

--- a/server/functions/to_regtype.go
+++ b/server/functions/to_regtype.go
@@ -37,11 +37,15 @@ var to_regtype_text = framework.Function1{
 	IsNonDeterministic: true,
 	Strict:             true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
+		val1Str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		// If the string just represents a number, then we return nil.
-		if _, err := strconv.ParseUint(val1.(string), 10, 32); err == nil {
+		if _, err := strconv.ParseUint(val1Str, 10, 32); err == nil {
 			return nil, nil
 		}
-		oid, err := pgtypes.Regtype.IoInput(ctx, val1.(string))
+		oid, err := pgtypes.Regtype.IoInput(ctx, val1Str)
 		if err != nil {
 			// Specifically for the "does not exist" error, we return nil instead of the error.
 			// https://www.postgresql.org/docs/15/functions-info.html#FUNCTIONS-INFO-CATALOG-TABLE

--- a/server/functions/to_timestamp.go
+++ b/server/functions/to_timestamp.go
@@ -79,8 +79,14 @@ var to_timestamp_text_text = framework.Function2{
 	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
-		input := val1.(string)
-		format := val2.(string)
+		input, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		format, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
 
 		// Parse the timestamp using PostgreSQL format patterns
 		return getDateTimeFromFormat(ctx, input, format)

--- a/server/functions/translate.go
+++ b/server/functions/translate.go
@@ -33,9 +33,20 @@ var translate_text_text_text = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text, pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		str := val1.(string)
-		from := []rune(val2.(string))
-		to := []rune(val3.(string))
+		str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		fromStr, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
+		toStr, err := framework.UnwrapString(ctx, val3)
+		if err != nil {
+			return nil, err
+		}
+		from := []rune(fromStr)
+		to := []rune(toStr)
 		toLen := len(to)
 		fromMap := make(map[string]int)
 		for i, l := range from {

--- a/server/functions/unknown.go
+++ b/server/functions/unknown.go
@@ -68,7 +68,10 @@ var unknownrecv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		reader := utils.NewReader(data)
 		return reader.String(), nil
 	},

--- a/server/functions/unknown.go
+++ b/server/functions/unknown.go
@@ -39,7 +39,7 @@ var unknownin = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		return val.(string), nil
+		return framework.UnwrapString(ctx, val)
 	},
 }
 
@@ -50,7 +50,10 @@ var unknownout = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Unknown},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		str, ok := val.(string)
+		str, ok, err := sql.Unwrap[string](ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if !ok {
 			return nil, errors.Errorf("unknown type received %T result", val)
 		}

--- a/server/functions/upper.go
+++ b/server/functions/upper.go
@@ -36,6 +36,10 @@ var upper_text = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
 		//TODO: this doesn't respect collations
-		return strings.ToUpper(val1.(string)), nil
+		val1Str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		return strings.ToUpper(val1Str), nil
 	},
 }

--- a/server/functions/uuid.go
+++ b/server/functions/uuid.go
@@ -72,12 +72,15 @@ var uuid_recv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}
 		var out pgtype.UUID
-		err := out.DecodeBinary(nil, data)
+		err = out.DecodeBinary(nil, data)
 		if err != nil {
 			return nil, err
 		}

--- a/server/functions/uuid.go
+++ b/server/functions/uuid.go
@@ -42,7 +42,10 @@ var uuid_in = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		newUUID, err := uuid.FromString(input)
 		if err != nil {
 			return nil, pgtypes.ErrInvalidSyntaxForType.New("uuid", input)

--- a/server/functions/varbit.go
+++ b/server/functions/varbit.go
@@ -94,13 +94,16 @@ var varbitrecv = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Internal, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		data := val1.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}
 		typmod := val3.(int32)
 		var out pgtype.Varbit
-		err := out.DecodeBinary(nil, data)
+		err = out.DecodeBinary(nil, data)
 		if err != nil {
 			return nil, err
 		}

--- a/server/functions/varbit.go
+++ b/server/functions/varbit.go
@@ -46,7 +46,10 @@ var varbitin = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Cstring, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, _, val3 any) (any, error) {
-		input := val1.(string)
+		input, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		typmod := val3.(int32)
 
 		// validation and normalization
@@ -157,7 +160,7 @@ var varbittypmodin = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.CstringArray},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		typmod, err := getTypModFromStringArr("bit varying", val.([]any))
+		typmod, err := getTypModFromStringArr(ctx, "bit varying", val.([]any))
 		if err != nil {
 			return nil, err
 		}

--- a/server/functions/varchar.go
+++ b/server/functions/varchar.go
@@ -42,7 +42,10 @@ var varcharin = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Cstring, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		input := val1.(string)
+		input, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		typmod := val3.(int32)
 		maxChars := pgtypes.GetCharLengthFromTypmod(typmod)
 		if maxChars < pgtypes.StringUnbounded {
@@ -131,7 +134,7 @@ var varchartypmodin = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.CstringArray},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		return getTypModFromStringArr("varchar", val.([]any))
+		return getTypModFromStringArr(ctx, "varchar", val.([]any))
 	},
 }
 

--- a/server/functions/varchar.go
+++ b/server/functions/varchar.go
@@ -92,7 +92,10 @@ var varcharrecv = framework.Function3{
 	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Internal, pgtypes.Oid, pgtypes.Int32},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, t [4]*pgtypes.DoltgresType, val1, val2, val3 any) (any, error) {
-		data := val1.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/functions/void.go
+++ b/server/functions/void.go
@@ -63,7 +63,10 @@ var void_recv = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
 		// TODO
-		data := val1.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
 		if len(data) == 0 {
 			return nil, nil
 		}

--- a/server/functions/void.go
+++ b/server/functions/void.go
@@ -39,7 +39,7 @@ var void_in = framework.Function2{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
 		// TODO
-		return val1.(string), nil
+		return framework.UnwrapString(ctx, val1)
 	},
 }
 
@@ -80,7 +80,10 @@ var void_send = framework.Function1{
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
 		// TODO
-		str := val.(string)
+		str, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		writer := utils.NewWriter(uint64(len(str) + 4))
 		writer.String(str)
 		return writer.Data(), nil

--- a/server/functions/xid.go
+++ b/server/functions/xid.go
@@ -40,7 +40,10 @@ var xidin = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Cstring},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		input := val.(string)
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		uVal, err := strconv.ParseInt(strings.TrimSpace(input), 10, 64)
 		if err != nil {
 			return uint32(0), nil

--- a/server/functions/xid.go
+++ b/server/functions/xid.go
@@ -70,7 +70,10 @@ var xidrecv = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Internal},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
-		data := val.([]byte)
+		data, err := framework.UnwrapBytes(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if data == nil {
 			return nil, nil
 		}

--- a/server/types/bit.go
+++ b/server/types/bit.go
@@ -79,7 +79,10 @@ func NewBitType(width int32) (*DoltgresType, error) {
 // serializeTypeBit handles serialization from the standard representation to our serialized representation that is
 // written in Dolt.
 func serializeTypeBit(ctx *sql.Context, t *DoltgresType, val any) ([]byte, error) {
-	str := val.(string)
+	str, err := unwrapSerializationString(ctx, "bit", val)
+	if err != nil {
+		return nil, err
+	}
 	wr := utils.NewWriter(uint64(4 + len(str)))
 	wr.String(str)
 	return wr.Data(), nil

--- a/server/types/char.go
+++ b/server/types/char.go
@@ -72,7 +72,10 @@ func NewCharType(length int32) (*DoltgresType, error) {
 // serializeTypeBpChar handles serialization from the standard representation to our serialized representation that is
 // written in Dolt.
 func serializeTypeBpChar(ctx *sql.Context, t *DoltgresType, val any) ([]byte, error) {
-	str := val.(string)
+	str, err := unwrapSerializationString(ctx, "bpchar", val)
+	if err != nil {
+		return nil, err
+	}
 	writer := utils.NewWriter(uint64(len(str) + 4))
 	writer.String(str)
 	return writer.Data(), nil

--- a/server/types/enum.go
+++ b/server/types/enum.go
@@ -87,7 +87,10 @@ func NewEnumLabel(ctx *sql.Context, labelID id.EnumLabel, so float32) EnumLabel 
 // serializeTypeEnum handles serialization from the standard representation to our serialized representation that is
 // written in Dolt.
 func serializeTypeEnum(ctx *sql.Context, t *DoltgresType, val any) ([]byte, error) {
-	str := val.(string)
+	str, err := unwrapSerializationString(ctx, "enum", val)
+	if err != nil {
+		return nil, err
+	}
 	writer := utils.NewWriter(uint64(len(str) + 4))
 	writer.String(str)
 	return writer.Data(), nil

--- a/server/types/internal_char.go
+++ b/server/types/internal_char.go
@@ -66,7 +66,10 @@ var InternalChar = &DoltgresType{
 // serializeTypeInternalChar handles serialization from the standard representation to our serialized representation that is
 // written in Dolt.
 func serializeTypeInternalChar(ctx *sql.Context, t *DoltgresType, val any) ([]byte, error) {
-	str := val.(string)
+	str, err := unwrapSerializationString(ctx, `"char"`, val)
+	if err != nil {
+		return nil, err
+	}
 	writer := utils.NewWriter(uint64(len(str) + 4))
 	writer.String(str)
 	return writer.Data(), nil

--- a/server/types/json.go
+++ b/server/types/json.go
@@ -61,7 +61,11 @@ var Json = &DoltgresType{
 // serializeTypeJson handles serialization from the standard representation to our serialized representation that is
 // written in Dolt.
 func serializeTypeJson(ctx *sql.Context, t *DoltgresType, val any) ([]byte, error) {
-	return []byte(val.(string)), nil
+	str, err := unwrapSerializationString(ctx, "json", val)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(str), nil
 }
 
 // deserializeTypeJson handles deserialization from the Dolt serialized format to our standard representation used by

--- a/server/types/name.go
+++ b/server/types/name.go
@@ -65,7 +65,10 @@ var Name = &DoltgresType{
 // serializeTypeName handles serialization from the standard representation to our serialized representation that is
 // written in Dolt.
 func serializeTypeName(ctx *sql.Context, t *DoltgresType, val any) ([]byte, error) {
-	str := val.(string)
+	str, err := unwrapSerializationString(ctx, "name", val)
+	if err != nil {
+		return nil, err
+	}
 	writer := utils.NewWriter(uint64(len(str) + 1))
 	writer.String(str)
 	return writer.Data(), nil

--- a/server/types/serialize_string.go
+++ b/server/types/serialize_string.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// unwrapSerializationString converts the value given to a serialization function into a string. String values may
+// arrive as a wrapper (e.g. *val.TextStorage) whose contents are stored out-of-band, in which case this loads the
+// full value into memory. An error is returned if the value is neither a string nor a wrapper around one.
+func unwrapSerializationString(ctx *sql.Context, typeName string, val any) (string, error) {
+	str, ok, err := sql.Unwrap[string](ctx, val)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", errors.Errorf("%q serialization requires a string argument, got %T", typeName, val)
+	}
+	return str, nil
+}

--- a/server/types/text.go
+++ b/server/types/text.go
@@ -15,7 +15,6 @@
 package types
 
 import (
-	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/core/id"
@@ -63,12 +62,9 @@ var Text = &DoltgresType{
 // serializeTypeText handles serialization from the standard representation to our serialized representation that is
 // written in Dolt.
 func serializeTypeText(ctx *sql.Context, t *DoltgresType, val any) ([]byte, error) {
-	str, ok, err := sql.Unwrap[string](ctx, val)
+	str, err := unwrapSerializationString(ctx, "text", val)
 	if err != nil {
 		return nil, err
-	}
-	if !ok {
-		return nil, errors.Errorf(`"text" serialization requires a string argument, got %T`, val)
 	}
 	writer := utils.NewWriter(uint64(len(str) + 4))
 	writer.String(str)

--- a/server/types/type.go
+++ b/server/types/type.go
@@ -501,7 +501,11 @@ func (t *DoltgresType) Convert(ctx context.Context, v interface{}) (interface{},
 			return v, sql.InRange, nil
 		}
 	case "bytea":
-		if _, ok := v.([]byte); ok {
+		_, ok, err := sql.Unwrap[[]byte](ctx, v)
+		if err != nil {
+			return nil, sql.InRange, err
+		}
+		if ok {
 			return v, sql.InRange, nil
 		}
 	case "bpchar", "char", "name", "text", "varchar":
@@ -544,7 +548,11 @@ func (t *DoltgresType) Convert(ctx context.Context, v interface{}) (interface{},
 		if _, ok := v.(sql.JSONWrapper); ok {
 			return v, sql.InRange, nil
 		}
-		if _, ok := v.(string); ok {
+		_, ok, err := sql.Unwrap[string](ctx, v)
+		if err != nil {
+			return nil, sql.InRange, err
+		}
+		if ok {
 			return v, sql.InRange, nil
 		}
 	case "oid", "regclass", "regproc", "regtype":

--- a/server/types/unknown.go
+++ b/server/types/unknown.go
@@ -62,7 +62,10 @@ var Unknown = &DoltgresType{
 // serializeTypeUnknown handles serialization from the standard representation to our serialized representation that is
 // written in Dolt.
 func serializeTypeUnknown(ctx *sql.Context, t *DoltgresType, val any) ([]byte, error) {
-	str := val.(string)
+	str, err := unwrapSerializationString(ctx, "unknown", val)
+	if err != nil {
+		return nil, err
+	}
 	writer := utils.NewWriter(uint64(len(str) + 4))
 	writer.String(str)
 	return writer.Data(), nil

--- a/server/types/varbit.go
+++ b/server/types/varbit.go
@@ -79,7 +79,10 @@ func NewVarBitType(width int32) (*DoltgresType, error) {
 // serializeTypeVarbit handles serialization from the standard representation to our serialized representation that is
 // written in Dolt.
 func serializeTypeVarbit(ctx *sql.Context, t *DoltgresType, val any) ([]byte, error) {
-	bitStr := val.(string)
+	bitStr, err := unwrapSerializationString(ctx, "varbit", val)
+	if err != nil {
+		return nil, err
+	}
 	writer := utils.NewWriter(uint64(len(bitStr) + 4))
 	writer.String(bitStr)
 	return writer.Data(), nil

--- a/server/types/varchar.go
+++ b/server/types/varchar.go
@@ -113,7 +113,10 @@ func GetCharLengthFromTypmod(typmod int32) int32 {
 // serializeTypeVarChar handles serialization from the standard representation to our serialized representation that is
 // written in Dolt.
 func serializeTypeVarChar(ctx *sql.Context, t *DoltgresType, val any) ([]byte, error) {
-	str := val.(string)
+	str, err := unwrapSerializationString(ctx, "varchar", val)
+	if err != nil {
+		return nil, err
+	}
 	writer := utils.NewWriter(uint64(len(str) + 4))
 	writer.String(str)
 	return writer.Data(), nil

--- a/testing/go/adaptive_encoding_test.go
+++ b/testing/go/adaptive_encoding_test.go
@@ -15,7 +15,9 @@
 package _go
 
 import (
+	"crypto/md5"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/dolthub/go-mysql-server/enginetest/scriptgen/setup"
@@ -220,6 +222,101 @@ func TestAdaptiveEncodingText(t *testing.T) {
 								{"HT", halfSizeString},
 								{"TT", tinyString},
 							},
+						},
+					},
+				},
+			})
+		})
+	}
+}
+
+// TestStringFunctionsOnOutOfBandValues checks that functions, operators, and casts taking string arguments work when
+// the argument is a large value stored out-of-band (represented in memory as a wrapper such as *val.TextStorage,
+// rather than a string).
+func TestStringFunctionsOnOutOfBandValues(t *testing.T) {
+	bigString := strings.Repeat("x", 20000)
+	bigStringMd5 := fmt.Sprintf("%x", md5.Sum([]byte(bigString)))
+	for _, columnType := range []string{"varchar", "text"} {
+		t.Run(columnType, func(t *testing.T) {
+			RunScripts(t, []ScriptTest{
+				{
+					Name: "string functions on out-of-band values",
+					SetUpScript: setup.SetupScript{
+						fmt.Sprintf(`create table t_big (id int primary key, body %s);`, columnType),
+						`insert into t_big values (1, repeat('x', 20000));`,
+					},
+					Assertions: []ScriptTestAssertion{
+						{
+							Query:    "select length(body) from t_big;",
+							Expected: []sql.Row{{int32(20000)}},
+						},
+						{
+							Query:    "select length(replace(body, 'x', 'y')) from t_big;",
+							Expected: []sql.Row{{int32(20000)}},
+						},
+						{
+							Query:    "select length(upper(body)), length(lower(body)) from t_big;",
+							Expected: []sql.Row{{int32(20000), int32(20000)}},
+						},
+						{
+							Query:    "select left(body, 3), right(body, 3) from t_big;",
+							Expected: []sql.Row{{"xxx", "xxx"}},
+						},
+						{
+							Query:    "select ascii(body) from t_big;",
+							Expected: []sql.Row{{int32(120)}},
+						},
+						{
+							Query:    "select strpos(body, 'x') from t_big;",
+							Expected: []sql.Row{{int32(1)}},
+						},
+						{
+							Query:    "select length(reverse(body)) from t_big;",
+							Expected: []sql.Row{{int32(20000)}},
+						},
+						{
+							Query:    "select length(translate(body, 'x', 'z')) from t_big;",
+							Expected: []sql.Row{{int32(20000)}},
+						},
+						{
+							Query:    "select length(ltrim(body, 'x')), length(rtrim(body, 'x')), length(btrim(body, 'x')) from t_big;",
+							Expected: []sql.Row{{int32(0), int32(0), int32(0)}},
+						},
+						{
+							Query:    "select length(split_part(body, ',', 1)) from t_big;",
+							Expected: []sql.Row{{int32(20000)}},
+						},
+						{
+							Query:    "select length(repeat(body, 1)) from t_big;",
+							Expected: []sql.Row{{int32(20000)}},
+						},
+						{
+							Query:    "select md5(body) from t_big;",
+							Expected: []sql.Row{{bigStringMd5}},
+						},
+						{
+							Query:    "select octet_length(body) from t_big;",
+							Expected: []sql.Row{{int32(20000)}},
+						},
+						{
+							Query:    "select initcap(left(body, 3)) from t_big;",
+							Expected: []sql.Row{{"Xxx"}},
+						},
+						{
+							Query:    "select body::varchar(5) from t_big;",
+							Expected: []sql.Row{{"xxxxx"}},
+						},
+						{
+							Query:    "select length(body || 'y') from t_big;",
+							Expected: []sql.Row{{int32(20001)}},
+						},
+						{
+							Query:    "select body = repeat('x', 20000) from t_big;",
+							Expected: []sql.Row{{"t"}},
+						},
+						{
+							Query:    "select body < repeat('y', 5) from t_big;",
+							Expected: []sql.Row{{"t"}},
 						},
 					},
 				},

--- a/testing/go/adaptive_encoding_test.go
+++ b/testing/go/adaptive_encoding_test.go
@@ -325,6 +325,53 @@ func TestStringFunctionsOnOutOfBandValues(t *testing.T) {
 	}
 }
 
+// TestByteaFunctionsOnOutOfBandValues checks that functions, operators, and casts taking bytea arguments work when
+// the argument is a large value stored out-of-band (represented in memory as a wrapper such as *val.ByteArray,
+// rather than a []byte).
+func TestByteaFunctionsOnOutOfBandValues(t *testing.T) {
+	bigBytes := []byte(strings.Repeat("x", 20000))
+	bigBytesHexLiteral := "'\\x" + strings.Repeat("78", 20000) + "'"
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "bytea functions on out-of-band values",
+			SetUpScript: setup.SetupScript{
+				`create table t_bytes (id int primary key, body bytea);`,
+				"insert into t_bytes values (1, " + bigBytesHexLiteral + ");",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    "select body from t_bytes;",
+					Expected: []sql.Row{{bigBytes}},
+				},
+				{
+					Query:    "select length(encode(body, 'hex')) from t_bytes;",
+					Expected: []sql.Row{{int32(40000)}},
+				},
+				{
+					Query:    "select left(encode(body, 'hex'), 4) from t_bytes;",
+					Expected: []sql.Row{{"7878"}},
+				},
+				{
+					Query:    "select length(encode(body || '\\x79', 'hex')) from t_bytes;",
+					Expected: []sql.Row{{int32(40002)}},
+				},
+				{
+					Query:    "select body = " + bigBytesHexLiteral + " from t_bytes;",
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					Query:    "select body <= '\\x79', body <> '\\x78', body >= '\\x78' from t_bytes;",
+					Expected: []sql.Row{{"t", "t", "t"}},
+				},
+				{
+					Query:    "select byteacmp(body, '\\x79') from t_bytes;",
+					Expected: []sql.Row{{int32(-1)}},
+				},
+			},
+		},
+	})
+}
+
 func TestAdaptiveEncodingVarbit(t *testing.T) {
 	columnType := "varbit"
 	RunScripts(t, []ScriptTest{


### PR DESCRIPTION
All casts to string and []byte now correctly unwrap their arguments first, as necessary.

Fixes https://github.com/dolthub/doltgresql/issues/3095