### PR TITLE
Fix `WITH ORDINALITY` use in nested derived tables

### DIFF
--- a/server/analyzer/optimize_functions.go
+++ b/server/analyzer/optimize_functions.go
@@ -33,11 +33,6 @@ import (
 // SRFs (set-returning functions) by setting the `IncludesNestedIters` flag on the Project node if any SRF is found
 // inside projection expressions.
 func OptimizeFunctions(ctx *sql.Context, a *analyzer.Analyzer, node sql.Node, scope *plan.Scope, selector analyzer.RuleSelector, qFlags *sql.QueryFlags) (sql.Node, transform.TreeIdentity, error) {
-	// This is supposed to be one of the last rules to run. Subqueries break that assumption, so we skip this rule in such cases.
-	if scope != nil && scope.CurrentNodeIsFromSubqueryExpression {
-		return node, transform.SameTree, nil
-	}
-
 	_, isInsertNode := node.(*plan.InsertInto)
 	return pgtransform.NodeWithOpaque(ctx, node, func(ctx *sql.Context, n sql.Node) (sql.Node, transform.TreeIdentity, error) {
 		projectNode, ok := n.(*plan.Project)

--- a/testing/go/issues_test.go
+++ b/testing/go/issues_test.go
@@ -462,6 +462,29 @@ limit 1`,
 			},
 		},
 		{
+			Name: "Issue #3138",
+			SetUpScript: []string{
+				"CREATE TABLE bug16_parent (id integer PRIMARY KEY);",
+				"CREATE TABLE bug16_child  (id integer PRIMARY KEY, parent_id integer REFERENCES bug16_parent(id));",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `SELECT c.conname,
+       array(SELECT colid FROM unnest(c.conkey) WITH ORDINALITY cols(colid, arridx) ORDER BY cols.arridx)
+FROM pg_constraint c JOIN pg_class cl ON c.conrelid = cl.oid WHERE cl.relname = 'bug16_child' ORDER BY c.conname;`,
+					Expected: []sql.Row{
+						{"bug16_child_parent_id_fkey", "{2}"},
+						{"bug16_child_pkey", "{1}"},
+					},
+				},
+				{
+					// non-correlated WITH ORDINALITY should still number rows correctly
+					Query:    `SELECT colid, arridx FROM unnest(ARRAY[1,2]) WITH ORDINALITY cols(colid, arridx);`,
+					Expected: []sql.Row{{1, 1}, {2, 2}},
+				},
+			},
+		},
+		{
 			Name: "Issue #3097",
 			SetUpScript: []string{
 				"CREATE TABLE g_bool (id INT4 PRIMARY KEY, flag BOOLEAN);",


### PR DESCRIPTION
A go-mysql-server fix for correlated-column resolution through nested derived tables (needed to fix `WITH ORDINALITY` inside a correlated subquery, https://github.com/dolthub/doltgresql/issues/3138) exposed a latent bug in the `OptimizeFunctions` analyzer rule, which relied on the old buggy scope behavior as a signal for when to mark set-returning-function projections for row expansion. This removes that incorrect early-return (the rule's transform is idempotent, so it's safe to just always run it) and adds a regression test covering the original issue.

Fixes: https://github.com/dolthub/doltgresql/issues/3138