### PR TITLE
Infer bind-variable parameter types from typed siblings.

### DIFF
--- a/server/analyzer/type_sanitizer.go
+++ b/server/analyzer/type_sanitizer.go
@@ -166,6 +166,12 @@ func sanitizeExprType(ctx *sql.Context, n sql.Node, expr sql.Expression) (sql.Ex
 					allDoltgresTypes := true
 					for _, child := range children {
 						if _, ok := child.Type(ctx).(*pgtypes.DoltgresType); !ok {
+							// An untyped bind variable (e.g. `coalesce($1, x)`) doesn't have a concrete type yet, but
+							// PgCoalesce.WithChildren resolves it from the other, already-typed arguments' common
+							// type, so it doesn't block the conversion the way any other unresolved type would.
+							if pgexprs.UnwrapBindVar(child) != nil {
+								continue
+							}
 							allDoltgresTypes = false
 							break
 						}

--- a/server/expression/any.go
+++ b/server/expression/any.go
@@ -310,6 +310,20 @@ func (a *AnyExpr) WithChildren(ctx *sql.Context, children ...sql.Expression) (sq
 				bv.Typ = leftType.ToArrayType()
 			}
 		}
+	} else if bv, ok := leftExpr.(*expression.BindVar); ok {
+		// Similarly, an untyped bind variable on the left (e.g. `$1 = ANY(arr_col)` or `$1 = ANY(SELECT ...)`) is
+		// resolved from the right side's element type: the array's base type, or the subquery's first column type.
+		if _, ok = bv.Typ.(*pgtypes.DoltgresType); !ok {
+			if sub, ok := rightExpr.(*plan.Subquery); ok {
+				if schema := sub.Query.Schema(ctx); len(schema) > 0 {
+					if colType, ok := schema[0].Type.(*pgtypes.DoltgresType); ok {
+						bv.Typ = colType
+					}
+				}
+			} else if rightType, ok := rightExpr.Type(ctx).(*pgtypes.DoltgresType); ok && rightType.IsArrayType() {
+				bv.Typ = rightType.BaseType()
+			}
+		}
 	}
 	anyExpr := &AnyExpr{
 		leftExpr:    leftExpr,

--- a/server/expression/coalesce.go
+++ b/server/expression/coalesce.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
@@ -91,9 +92,14 @@ func (c *PgCoalesce) WithChildren(ctx *sql.Context, children ...sql.Expression) 
 	}
 	newC := &PgCoalesce{args: children, typ: pgtypes.Unknown}
 	childTypes := make([]*pgtypes.DoltgresType, 0, len(children))
+	var bindVars []*expression.BindVar
 	for _, child := range children {
 		dt, ok := child.Type(ctx).(*pgtypes.DoltgresType)
 		if !ok {
+			if bv := UnwrapBindVar(child); bv != nil {
+				bindVars = append(bindVars, bv)
+				continue
+			}
 			return newC, nil
 		}
 		childTypes = append(childTypes, dt)
@@ -104,6 +110,11 @@ func (c *PgCoalesce) WithChildren(ctx *sql.Context, children ...sql.Expression) 
 	}
 	if commonType != nil {
 		newC.typ = commonType
+		for _, bv := range bindVars {
+			if _, ok := bv.Typ.(*pgtypes.DoltgresType); !ok {
+				bv.Typ = commonType
+			}
+		}
 	}
 	return newC, nil
 }

--- a/server/expression/greatest.go
+++ b/server/expression/greatest.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
 	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/doltgresql/core"
@@ -102,6 +103,15 @@ func (n *Greatest) WithResolvedChildren(ctx context.Context, children []any) (an
 	return n.WithChildren(ctx.(*sql.Context), args...)
 }
 
+// UnwrapBindVar returns the underlying *expression.BindVar if expr is a bind variable, or an Alias wrapping one.
+func UnwrapBindVar(expr sql.Expression) *expression.BindVar {
+	if alias, ok := expr.(*expression.Alias); ok {
+		expr = alias.Child
+	}
+	bv, _ := expr.(*expression.BindVar)
+	return bv
+}
+
 // argsResolved returns true when every expression in args is resolved.
 func argsResolved(args []sql.Expression) bool {
 	for _, arg := range args {
@@ -147,6 +157,16 @@ func getRetTypeAndCasts(ctx *sql.Context, children []sql.Expression) (*pgtypes.D
 	if retType.ID == pgtypes.Numeric.ID {
 		// use Numeric type with no precision
 		retType = pgtypes.Numeric
+	}
+
+	// Untyped bind variables (e.g. `greatest($1, x)`) don't contribute to nonNullTypes above, so the common type is
+	// resolved from the other, already-typed arguments.
+	for _, child := range children {
+		if bv := UnwrapBindVar(child); bv != nil {
+			if _, ok := bv.Typ.(*pgtypes.DoltgresType); !ok {
+				bv.Typ = retType
+			}
+		}
 	}
 
 	var castList = make([]casts.Cast, len(children))

--- a/server/expression/is_distinct_from.go
+++ b/server/expression/is_distinct_from.go
@@ -37,6 +37,7 @@ type IsDistinctFrom struct {
 
 var _ vitess.Injectable = (*IsDistinctFrom)(nil)
 var _ sql.Expression = (*IsDistinctFrom)(nil)
+var _ expression.BinaryExpression = (*IsDistinctFrom)(nil)
 
 // NewIsDistinctFrom returns a new *IsDistinctFrom.
 func NewIsDistinctFrom() *IsDistinctFrom {
@@ -80,6 +81,16 @@ func (n *IsDistinctFrom) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 // IsNullable implements the sql.Expression interface.
 func (n *IsDistinctFrom) IsNullable(ctx *sql.Context) bool {
 	return true
+}
+
+// Left implements the expression.BinaryExpression interface.
+func (n *IsDistinctFrom) Left() sql.Expression {
+	return n.leftExpr
+}
+
+// Right implements the expression.BinaryExpression interface.
+func (n *IsDistinctFrom) Right() sql.Expression {
+	return n.rightExpr
 }
 
 // Resolved implements the sql.Expression interface.

--- a/server/expression/is_not_distinct_from.go
+++ b/server/expression/is_not_distinct_from.go
@@ -37,6 +37,7 @@ type IsNotDistinctFrom struct {
 
 var _ vitess.Injectable = (*IsNotDistinctFrom)(nil)
 var _ sql.Expression = (*IsNotDistinctFrom)(nil)
+var _ expression.BinaryExpression = (*IsNotDistinctFrom)(nil)
 
 // NewIsNotDistinctFrom returns a new *IsNotDistinctFrom.
 func NewIsNotDistinctFrom() *IsNotDistinctFrom {
@@ -80,6 +81,16 @@ func (n *IsNotDistinctFrom) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 // IsNullable implements the sql.Expression interface.
 func (n *IsNotDistinctFrom) IsNullable(ctx *sql.Context) bool {
 	return true
+}
+
+// Left implements the expression.BinaryExpression interface.
+func (n *IsNotDistinctFrom) Left() sql.Expression {
+	return n.leftExpr
+}
+
+// Right implements the expression.BinaryExpression interface.
+func (n *IsNotDistinctFrom) Right() sql.Expression {
+	return n.rightExpr
 }
 
 // Resolved implements the sql.Expression interface.

--- a/server/expression/subscript.go
+++ b/server/expression/subscript.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
 	vitess "github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/doltgresql/server/types"
@@ -116,6 +117,13 @@ func (s Subscript) Children() []sql.Expression {
 func (s Subscript) WithChildren(ctx *sql.Context, children ...sql.Expression) (sql.Expression, error) {
 	if len(children) != 2 {
 		return nil, fmt.Errorf("expected 2 children, got %d", len(children))
+	}
+	// The subscript index is always int4, regardless of the array's element type, so an untyped bind variable
+	// (e.g. `arr[$1]`) can be resolved to int4 immediately.
+	if bv, ok := children[1].(*expression.BindVar); ok {
+		if _, ok := bv.Typ.(*types.DoltgresType); !ok {
+			bv.Typ = types.Int32
+		}
 	}
 	return NewSubscript(children[0], children[1]), nil
 }

--- a/testing/go/issues_test.go
+++ b/testing/go/issues_test.go
@@ -461,6 +461,58 @@ limit 1`,
 				},
 			},
 		},
+		{
+			Name: "Issue #3097",
+			SetUpScript: []string{
+				"CREATE TABLE g_bool (id INT4 PRIMARY KEY, flag BOOLEAN);",
+				"INSERT INTO g_bool VALUES (1, true), (2, false), (3, NULL);",
+				"CREATE TABLE g_arr (id INT4 PRIMARY KEY, v INT4, vals INT4[]);",
+				"INSERT INTO g_arr VALUES (1, 1, ARRAY[1,2,3]), (2, 2, ARRAY[4,5,6]);",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT count(*) FROM g_bool WHERE flag IS DISTINCT FROM $1;`,
+					BindVars: []any{true},
+					Expected: []sql.Row{{int64(2)}},
+				},
+				{
+					Query:    `SELECT count(*) FROM g_bool WHERE flag IS NOT DISTINCT FROM $1;`,
+					BindVars: []any{true},
+					Expected: []sql.Row{{int64(1)}},
+				},
+				{
+					Query:    `SELECT count(*) FROM g_arr WHERE $1 = ANY(vals);`,
+					BindVars: []any{int32(2)},
+					Expected: []sql.Row{{int64(1)}},
+				},
+				{
+					// Uncorrelated subquery: the comparison doesn't depend on the outer row, so it's all-or-nothing.
+					Query:    `SELECT count(*) FROM g_arr WHERE $1 = ANY(SELECT v FROM g_arr);`,
+					BindVars: []any{int32(2)},
+					Expected: []sql.Row{{int64(2)}},
+				},
+				{
+					Query:    `SELECT count(*) FROM g_arr WHERE vals[$1] = 2;`,
+					BindVars: []any{int32(2)},
+					Expected: []sql.Row{{int64(1)}},
+				},
+				{
+					Query:    `SELECT count(*) FROM g_arr WHERE coalesce($1, v) = 1;`,
+					BindVars: []any{nil},
+					Expected: []sql.Row{{int64(1)}},
+				},
+				{
+					Query:    `SELECT count(*) FROM g_arr WHERE greatest($1, v) = 2;`,
+					BindVars: []any{int32(0)},
+					Expected: []sql.Row{{int64(1)}},
+				},
+				{
+					Query:    `SELECT count(*) FROM g_arr WHERE least($1, v) = 1;`,
+					BindVars: []any{int32(5)},
+					Expected: []sql.Row{{int64(1)}},
+				},
+			},
+		},
 	})
 }
 
@@ -489,6 +541,99 @@ func TestIssuesWire(t *testing.T) {
 						},
 						&pgproto3.DataRow{Values: [][]byte{[]byte("foo")}},
 						&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+			},
+		},
+		{
+			Name: "Issue #3097",
+			SetUpScript: []string{
+				"CREATE TABLE g_arr (id INT4 PRIMARY KEY, v INT4, vals INT4[]);",
+			},
+			Assertions: []WireScriptTestAssertion{
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{Name: "s1", Query: "SELECT count(*) FROM g_arr WHERE $1 = ANY(vals)"},
+						&pgproto3.Describe{ObjectType: 'S', Name: "s1"},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{23}}, // int4
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{Name: []byte("count"), TableAttributeNumber: 1, DataTypeOID: 20, DataTypeSize: 20, TypeModifier: -1},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{Name: "s2", Query: "SELECT count(*) FROM g_arr WHERE $1 = ANY(SELECT v FROM g_arr)"},
+						&pgproto3.Describe{ObjectType: 'S', Name: "s2"},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{23}}, // int4
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{Name: []byte("count"), TableAttributeNumber: 1, DataTypeOID: 20, DataTypeSize: 20, TypeModifier: -1},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{Name: "s3", Query: "SELECT count(*) FROM g_arr WHERE vals[$1] = 2"},
+						&pgproto3.Describe{ObjectType: 'S', Name: "s3"},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{23}}, // int4
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{Name: []byte("count"), TableAttributeNumber: 1, DataTypeOID: 20, DataTypeSize: 20, TypeModifier: -1},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{Name: "s4", Query: "SELECT count(*) FROM g_arr WHERE coalesce($1, v) = 1"},
+						&pgproto3.Describe{ObjectType: 'S', Name: "s4"},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{23}}, // int4
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{Name: []byte("count"), TableAttributeNumber: 1, DataTypeOID: 20, DataTypeSize: 20, TypeModifier: -1},
+							},
+						},
+						&pgproto3.ReadyForQuery{TxStatus: 'I'},
+					},
+				},
+				{
+					Send: []pgproto3.FrontendMessage{
+						&pgproto3.Parse{Name: "s5", Query: "SELECT count(*) FROM g_arr WHERE greatest($1, v) = 1"},
+						&pgproto3.Describe{ObjectType: 'S', Name: "s5"},
+						&pgproto3.Sync{},
+					},
+					Receive: []pgproto3.BackendMessage{
+						&pgproto3.ParseComplete{},
+						&pgproto3.ParameterDescription{ParameterOIDs: []uint32{23}}, // int4
+						&pgproto3.RowDescription{
+							Fields: []pgproto3.FieldDescription{
+								{Name: []byte("count"), TableAttributeNumber: 1, DataTypeOID: 20, DataTypeSize: 20, TypeModifier: -1},
+							},
+						},
 						&pgproto3.ReadyForQuery{TxStatus: 'I'},
 					},
 				},


### PR DESCRIPTION
Paremters in expressions like `IS DISTINCT FROM $1` were being reported to clients as the unknown pseudo-type (OID 705) instead of the correct type, causing strict drivers such as pgx to fail to encode the parameter. Auditing for the same class of bug turned up four more affected constructs (`ANY`/`SOME` with an array or subquery, array subscripts, and `COALESCE`/`GREATEST`/`LEAST`), each confirmed broken via a wire-protocol reproduction and now fixed. New functional and wire-level regression tests cover all five cases.

Fixes: https://github.com/dolthub/doltgresql/issues/3097