### PR TITLE
Fix pg_index per-column vectors to have one entry per key column

### DIFF
--- a/server/tables/pgcatalog/pg_index.go
+++ b/server/tables/pgcatalog/pg_index.go
@@ -256,11 +256,28 @@ func (iter *pgIndexTableScanIter) Close(ctx *sql.Context) error {
 
 // pgIndexToRow converts a pgIndex to a sql.Row.
 func pgIndexToRow(index *pgIndex) sql.Row {
+	// indcollation, indclass, and indoption are per-column vectors that must have exactly one
+	// entry per index key column (the same length as indkey).
+	// indoption entries are bitmasks of per-column flags (INDOPTION_DESC = 0x0001,
+	// INDOPTION_NULLS_FIRST = 0x0002). Dolt indexes are always stored ascending and do not
+	// record per-column direction, so every entry is 0 (ASC NULLS LAST, the btree default).
+	// indcollation and indclass entries are collation and operator class OIDs respectively;
+	// we don't track those, so we emit the zero OID for each column.
+	numKeyCols := int(index.indnatts)
+	indCollation := make([]any, numKeyCols)
+	indClass := make([]any, numKeyCols)
+	indOption := make([]any, numKeyCols)
+	for i := 0; i < numKeyCols; i++ {
+		indCollation[i] = id.Null
+		indClass[i] = id.Null
+		indOption[i] = int16(0)
+	}
+
 	return sql.Row{
 		index.indexOid,         // indexrelid
 		index.tableOid,         // indrelid
 		index.indnatts,         // indnatts
-		int16(0),               // indnkeyatts
+		index.indnatts,         // indnkeyatts (we don't support INCLUDE columns, so all columns are key columns)
 		index.index.IsUnique(), // indisunique
 		false,                  // indnullsnotdistinct
 		index.indisprimary,     // indisprimary
@@ -273,9 +290,9 @@ func pgIndexToRow(index *pgIndex) sql.Row {
 		true,                   // indislive
 		false,                  // indisreplident
 		index.indkey,           // indkey
-		[]any{},                // indcollation
-		[]any{},                // indclass
-		[]any{int16(0)},        // indoption
+		indCollation,           // indcollation
+		indClass,               // indclass
+		indOption,              // indoption
 		nil,                    // indexprs
 		indexPred(index.index), // indpred
 	}

--- a/server/tables/pgcatalog/pg_index.go
+++ b/server/tables/pgcatalog/pg_index.go
@@ -258,11 +258,6 @@ func (iter *pgIndexTableScanIter) Close(ctx *sql.Context) error {
 func pgIndexToRow(index *pgIndex) sql.Row {
 	// indcollation, indclass, and indoption are per-column vectors that must have exactly one
 	// entry per index key column (the same length as indkey).
-	// indoption entries are bitmasks of per-column flags (INDOPTION_DESC = 0x0001,
-	// INDOPTION_NULLS_FIRST = 0x0002). Dolt indexes are always stored ascending and do not
-	// record per-column direction, so every entry is 0 (ASC NULLS LAST, the btree default).
-	// indcollation and indclass entries are collation and operator class OIDs respectively;
-	// we don't track those, so we emit the zero OID for each column.
 	numKeyCols := int(index.indnatts)
 	indCollation := make([]any, numKeyCols)
 	indClass := make([]any, numKeyCols)
@@ -270,6 +265,8 @@ func pgIndexToRow(index *pgIndex) sql.Row {
 	for i := 0; i < numKeyCols; i++ {
 		indCollation[i] = id.Null
 		indClass[i] = id.Null
+		// indoption entries are bitmasks of per-column flags (INDOPTION_DESC = 0x0001,
+		// INDOPTION_NULLS_FIRST = 0x0002), neither of which are supported
 		indOption[i] = int16(0)
 	}
 

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -2004,7 +2004,7 @@ func TestArrayFunctions(t *testing.T) {
 				},
 				{
 					Query:    `SELECT array_to_string(indclass, ',') FROM pg_index WHERE indexrelid = 'vectest_ab'::regclass;`,
-					Expected: []sql.Row{{""}},
+					Expected: []sql.Row{{"0,0"}},
 				},
 			},
 		},

--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -1754,9 +1754,9 @@ func TestPgIndex(t *testing.T) {
 						WHERE n.nspname = 'testschema' and left(c.relname, 5) <> 'dolt_'
 						ORDER BY 1;`,
 					Expected: []sql.Row{
-						{1067629180, 3120782595, 1, 0, "t", "f", "t", "f", "f", "f", "t", "f", "t", "t", "f", "1", "", "", "0", nil, nil},
-						{2070175302, 3120782595, 1, 0, "t", "f", "f", "f", "f", "f", "t", "f", "t", "t", "f", "2", "", "", "0", nil, nil},
-						{3185790121, 1784425749, 2, 0, "t", "f", "t", "f", "f", "f", "t", "f", "t", "t", "f", "1 2", "", "", "0", nil, nil},
+						{1067629180, 3120782595, 1, 1, "t", "f", "t", "f", "f", "f", "t", "f", "t", "t", "f", "1", "0", "0", "0", nil, nil},
+						{2070175302, 3120782595, 1, 1, "t", "f", "f", "f", "f", "f", "t", "f", "t", "t", "f", "2", "0", "0", "0", nil, nil},
+						{3185790121, 1784425749, 2, 2, "t", "f", "t", "f", "f", "f", "t", "f", "t", "t", "f", "1 2", "0 0", "0 0", "0 0", nil, nil},
 					},
 				},
 				{ // Different cases and quoted, so it fails
@@ -1790,6 +1790,33 @@ func TestPgIndex(t *testing.T) {
 				{
 					Query:    "SELECT unnest(indoption) FROM pg_index LIMIT 1;",
 					Expected: []sql.Row{{0}},
+				},
+			},
+		},
+		{
+			Name: "pg_index indoption has one entry per key column", // https://github.com/dolthub/doltgresql/issues/3110
+			SetUpScript: []string{
+				`CREATE TABLE bug13 (a integer, b integer);`,
+				`CREATE INDEX bug13_ab ON bug13 (a, b);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `SELECT indkey, indoption, array_length(indkey, 1), array_length(indoption, 1)
+						FROM pg_index WHERE indexrelid = 'bug13_ab'::regclass;`,
+					Expected: []sql.Row{
+						{"1 2", "0 0", 2, 2},
+					},
+				},
+				{
+					Query: `SELECT indnatts, indnkeyatts, array_length(indcollation, 1), array_length(indclass, 1)
+						FROM pg_index WHERE indexrelid = 'bug13_ab'::regclass;`,
+					Expected: []sql.Row{
+						{2, 2, 2, 2},
+					},
+				},
+				{
+					Query:    `SELECT unnest(indoption) FROM pg_index WHERE indexrelid = 'bug13_ab'::regclass;`,
+					Expected: []sql.Row{{0}, {0}},
 				},
 			},
 		},
@@ -5972,8 +5999,8 @@ func TestPgIndexIndexes(t *testing.T) {
 					Query: `SELECT * FROM pg_catalog.pg_index i 
 WHERE i.indrelid = 1496157034 order by 1`,
 					Expected: []sql.Row{
-						{3992679530, 1496157034, 1, 0, "t", "f", "t", "f", "f", "f", "t", "f", "t", "t", "f", "1", "", "", "0", nil, nil},
-						{4052612617, 1496157034, 1, 0, "f", "f", "f", "f", "f", "f", "t", "f", "t", "t", "f", "2", "", "", "0", nil, nil},
+						{3992679530, 1496157034, 1, 1, "t", "f", "t", "f", "f", "f", "t", "f", "t", "t", "f", "1", "0", "0", "0", nil, nil},
+						{4052612617, 1496157034, 1, 1, "f", "f", "f", "f", "f", "f", "t", "f", "t", "t", "f", "2", "0", "0", "0", nil, nil},
 					},
 				},
 				{
@@ -6434,7 +6461,7 @@ WHERE pg_catalog.pg_index.indrelid IN (3491847678)
   AND NOT pg_catalog.pg_index.indisprimary
 ORDER BY pg_catalog.pg_index.indrelid, cls_idx.relname`,
 					Expected: []sql.Row{
-						{3491847678, "dolt_log_commit_hash_key", "t", "t", "0", interface{}(nil), "btree", interface{}(nil), 0, "f", "{commit_hash}", "{f}"},
+						{3491847678, "dolt_log_commit_hash_key", "t", "t", "0", interface{}(nil), "btree", interface{}(nil), 1, "f", "{commit_hash}", "{f}"},
 					},
 				},
 			},


### PR DESCRIPTION
Fixes pg_index per-column vectors (indoption, indcollation, indclass) to have one entry per key column, and populates indnkeyatts.

Fixes #3110.