### PR TITLE
Implement string_to_array() function

### DIFF
--- a/server/functions/init.go
+++ b/server/functions/init.go
@@ -212,6 +212,7 @@ func Init() {
 	initSplitPart()
 	initSqlConstant()
 	initSqrt()
+	initStringToArray()
 	initStrpos()
 	initSubstr()
 	initTan()

--- a/server/functions/string_to_array.go
+++ b/server/functions/string_to_array.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+import (
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// initStringToArray registers the functions to the catalog.
+func initStringToArray() {
+	framework.RegisterFunction(string_to_array_text_text)
+	framework.RegisterFunction(string_to_array_text_text_text)
+}
+
+// string_to_array_text_text represents the PostgreSQL function of the same name, taking the same parameters.
+var string_to_array_text_text = framework.Function2{
+	Name:       "string_to_array",
+	Return:     pgtypes.TextArray,
+	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text},
+	Strict:     false,
+	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, str any, delimiter any) (any, error) {
+		return stringToArray(ctx, str, delimiter, nil, false)
+	},
+}
+
+// string_to_array_text_text_text represents the PostgreSQL function of the same name, taking the same parameters.
+var string_to_array_text_text_text = framework.Function3{
+	Name:       "string_to_array",
+	Return:     pgtypes.TextArray,
+	Parameters: [3]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Text, pgtypes.Text},
+	Strict:     false,
+	Callable: func(ctx *sql.Context, _ [4]*pgtypes.DoltgresType, str any, delimiter any, nullStr any) (any, error) {
+		return stringToArray(ctx, str, delimiter, nullStr, nullStr != nil)
+	},
+}
+
+// stringToArray implements the semantics of the PostgreSQL string_to_array function. If the input string is NULL, the
+// result is NULL. If the delimiter is NULL, each character of the input string becomes a separate element. If the
+// delimiter is an empty string, the entire input string is returned as a single-element array. An empty input string
+// always produces an empty array. When hasNullStr is true, any field equal to nullStr is replaced with NULL.
+func stringToArray(ctx *sql.Context, str any, delimiter any, nullStr any, hasNullStr bool) (any, error) {
+	if str == nil {
+		return nil, nil
+	}
+	inputStr, err := framework.UnwrapString(ctx, str)
+	if err != nil {
+		return nil, err
+	}
+	var nullStrStr string
+	if hasNullStr {
+		nullStrStr, err = framework.UnwrapString(ctx, nullStr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var fields []string
+	if delimiter == nil {
+		// A NULL delimiter splits the string into individual characters
+		for _, r := range inputStr {
+			fields = append(fields, string(r))
+		}
+	} else {
+		delimiterStr, dErr := framework.UnwrapString(ctx, delimiter)
+		if dErr != nil {
+			return nil, dErr
+		}
+		if len(inputStr) == 0 {
+			// An empty input string always produces an empty array
+			return []any{}, nil
+		}
+		if len(delimiterStr) == 0 {
+			// An empty delimiter returns the entire input string as a single field
+			fields = []string{inputStr}
+		} else {
+			fields = strings.Split(inputStr, delimiterStr)
+		}
+	}
+
+	result := make([]any, len(fields))
+	for i, field := range fields {
+		if hasNullStr && field == nullStrStr {
+			result[i] = nil
+		} else {
+			result[i] = field
+		}
+	}
+	return result, nil
+}

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -2009,7 +2009,6 @@ func TestArrayFunctions(t *testing.T) {
 			},
 		},
 		{
-			// https://github.com/dolthub/doltgresql/issues/3122
 			Name: "string_to_array",
 			Assertions: []ScriptTestAssertion{
 				{

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -2009,6 +2009,76 @@ func TestArrayFunctions(t *testing.T) {
 			},
 		},
 		{
+			// https://github.com/dolthub/doltgresql/issues/3122
+			Name: "string_to_array",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT string_to_array('a,b,c', ',');`,
+					Expected: []sql.Row{{"{a,b,c}"}},
+				},
+				{
+					Query:    `SELECT string_to_array('xx~^~yy~^~zz', '~^~', 'yy');`,
+					Expected: []sql.Row{{"{xx,NULL,zz}"}},
+				},
+				{
+					// NULL delimiter splits into individual characters
+					Query:    `SELECT string_to_array('abc', NULL);`,
+					Expected: []sql.Row{{"{a,b,c}"}},
+				},
+				{
+					Query:    `SELECT string_to_array('abc', NULL, 'b');`,
+					Expected: []sql.Row{{"{a,NULL,c}"}},
+				},
+				{
+					// empty delimiter returns the whole string as a single element
+					Query:    `SELECT string_to_array('abc', '');`,
+					Expected: []sql.Row{{"{abc}"}},
+				},
+				{
+					// empty input string returns an empty array
+					Query:    `SELECT string_to_array('', ',');`,
+					Expected: []sql.Row{{"{}"}},
+				},
+				{
+					Query:    `SELECT string_to_array('', NULL);`,
+					Expected: []sql.Row{{"{}"}},
+				},
+				{
+					// NULL input string returns NULL
+					Query:    `SELECT string_to_array(NULL, ',');`,
+					Expected: []sql.Row{{nil}},
+				},
+				{
+					Query:    `SELECT string_to_array(NULL, ',', 'a');`,
+					Expected: []sql.Row{{nil}},
+				},
+				{
+					// NULL null_string performs no NULL substitution
+					Query:    `SELECT string_to_array('a,b,c', ',', NULL);`,
+					Expected: []sql.Row{{"{a,b,c}"}},
+				},
+				{
+					// delimiters at the edges produce empty-string fields
+					Query:    `SELECT string_to_array(',a,,b,', ',');`,
+					Expected: []sql.Row{{`{"",a,"",b,""}`}},
+				},
+				{
+					// empty null_string maps empty fields to NULL
+					Query:    `SELECT string_to_array(',a,', ',', '');`,
+					Expected: []sql.Row{{"{NULL,a,NULL}"}},
+				},
+				{
+					// result can be cast to other array types
+					Query:    `SELECT string_to_array('1,2,3', ',')::int4[];`,
+					Expected: []sql.Row{{"{1,2,3}"}},
+				},
+				{
+					Query:    `SELECT array_length(string_to_array('a,b,c', ','), 1);`,
+					Expected: []sql.Row{{int32(3)}},
+				},
+			},
+		},
+		{
 			Name: "array_upper",
 			Assertions: []ScriptTestAssertion{
 				{


### PR DESCRIPTION
Adds the PostgreSQL string_to_array(string, delimiter [, null_string]) function.

Fixes #3122.