### PR TITLE
Fix timestamp/timestamptz minus interval incorrect results

### DIFF
--- a/server/functions/binary/minus.go
+++ b/server/functions/binary/minus.go
@@ -337,7 +337,7 @@ var timestamptz_mi_interval = framework.Function2{
 		interval := val2.(duration.Duration)
 
 		// Subtract the interval from the timestamptz
-		return timestamptz.Add(-time.Duration(interval.Nanos())), nil
+		return intervalPlusNonInterval(interval.Mul(-1), timestamptz)
 	},
 }
 
@@ -368,7 +368,7 @@ var timestamp_mi_interval = framework.Function2{
 		interval := val2.(duration.Duration)
 
 		// Subtract the interval from the timestamp
-		return timestamp.Add(-time.Duration(interval.Nanos())), nil
+		return intervalPlusNonInterval(interval.Mul(-1), timestamp)
 	},
 }
 

--- a/server/functions/binary/plus.go
+++ b/server/functions/binary/plus.go
@@ -19,13 +19,11 @@ import (
 	"time"
 
 	"github.com/cockroachdb/apd/v3"
-	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/postgres/parser/duration"
 	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
 	"github.com/dolthub/doltgresql/postgres/parser/timetz"
-	"github.com/dolthub/doltgresql/server/functions"
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
@@ -603,15 +601,8 @@ var timetz_pl_interval = framework.Function2{
 }
 
 // intervalPlusNonInterval adds given interval duration to the given time.Time value.
-// During converting interval duration to time.Duration type, it can overflow.
+// It uses duration.Add so that the interval's months/days fields are applied as
+// calendar-aware.
 func intervalPlusNonInterval(d duration.Duration, t time.Time) (time.Time, error) {
-	seconds, ok := d.AsInt64()
-	if !ok {
-		return time.Time{}, errors.Errorf("interval overflow")
-	}
-	nanos := float64(seconds) * functions.NanosPerSec
-	if nanos > float64(math.MaxInt64) || nanos < float64(math.MinInt64) {
-		return time.Time{}, errors.Errorf("interval overflow")
-	}
-	return t.Add(time.Duration(nanos)), nil
+	return duration.Add(t, d), nil
 }

--- a/server/functions/binary/plus.go
+++ b/server/functions/binary/plus.go
@@ -19,9 +19,11 @@ import (
 	"time"
 
 	"github.com/cockroachdb/apd/v3"
+	"github.com/cockroachdb/errors"
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/postgres/parser/duration"
+	"github.com/dolthub/doltgresql/postgres/parser/sem/tree"
 	"github.com/dolthub/doltgresql/postgres/parser/timeofday"
 	"github.com/dolthub/doltgresql/postgres/parser/timetz"
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -604,5 +606,9 @@ var timetz_pl_interval = framework.Function2{
 // It uses duration.Add so that the interval's months/days fields are applied as
 // calendar-aware.
 func intervalPlusNonInterval(d duration.Duration, t time.Time) (time.Time, error) {
-	return duration.Add(t, d), nil
+	result := duration.Add(t, d)
+	if result.After(tree.MaxSupportedTime) || result.Before(tree.MinSupportedTime) {
+		return time.Time{}, errors.Newf("timestamp out of range: %q", result.Format(time.RFC3339))
+	}
+	return result, nil
 }

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -4071,6 +4071,28 @@ func TestDateAndTimeFunction(t *testing.T) {
 				},
 			},
 		},
+		{
+			// https://github.com/dolthub/doltgresql/issues/3090
+			Name: "timestamp/timestamptz minus interval with day component",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT timestamp '2026-08-15 12:00:00' - interval '90 days';`,
+					Expected: []sql.Row{{"2026-05-17 12:00:00"}},
+				},
+				{
+					Query:    `SELECT timestamptz '2026-08-15 12:00:00+00' - interval '90 days';`,
+					Expected: []sql.Row{{"2026-05-17 12:00:00+00"}},
+				},
+				{
+					Query:    `SELECT timestamp '2026-08-15 12:00:00' - interval '1 hour';`,
+					Expected: []sql.Row{{"2026-08-15 11:00:00"}},
+				},
+				{
+					Query:    `SELECT (timestamp '2026-08-15 12:00:00' - interval '90 days') = timestamp '2026-08-15 12:00:00';`,
+					Expected: []sql.Row{{"f"}},
+				},
+			},
+		},
 	})
 }
 

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -4133,6 +4133,34 @@ func TestDateAndTimeFunction(t *testing.T) {
 				},
 			},
 		},
+		{
+			// https://github.com/dolthub/doltgresql/pull/3162
+			Name: "timestamp/timestamptz plus/minus interval errors on out-of-range results",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:       `SELECT timestamp '2026-01-01' + interval '1000000000 years';`,
+					ExpectedErr: "timestamp out of range",
+				},
+				{
+					Query:       `SELECT timestamp '2026-01-01' - interval '1000000000 years';`,
+					ExpectedErr: "timestamp out of range",
+				},
+				{
+					Query:       `SELECT timestamptz '2026-01-01+00' + interval '1000000000 years';`,
+					ExpectedErr: "timestamp out of range",
+				},
+				{
+					// Confirms the session/connection survives an out-of-range error.
+					Query:    `SELECT timestamp '2026-01-01' + interval '1 day';`,
+					Expected: []sql.Row{{"2026-01-02 00:00:00"}},
+				},
+				{
+					// A large interval that stays within the supported range should still work.
+					Query:    `SELECT timestamp '2026-01-01' + interval '290000 years';`,
+					Expected: []sql.Row{{"292026-01-01 00:00:00"}},
+				},
+			},
+		},
 	})
 }
 

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -4093,6 +4093,46 @@ func TestDateAndTimeFunction(t *testing.T) {
 				},
 			},
 		},
+		{
+			// https://github.com/dolthub/doltgresql/issues/3163
+			Name: "timestamp/timestamptz plus/minus interval normalizes month-end overflow",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT timestamp '2026-03-31 12:00:00' - interval '1 month';`,
+					Expected: []sql.Row{{"2026-02-28 12:00:00"}},
+				},
+				{
+					Query:    `SELECT timestamptz '2026-03-31 12:00:00+00' - interval '1 month';`,
+					Expected: []sql.Row{{"2026-02-28 12:00:00+00"}},
+				},
+				{
+					Query:    `SELECT timestamp '2026-03-15 12:00:00' - interval '1 month';`,
+					Expected: []sql.Row{{"2026-02-15 12:00:00"}},
+				},
+				{
+					Query:    `SELECT timestamp '2026-01-31 00:00:00' + interval '1 month';`,
+					Expected: []sql.Row{{"2026-02-28 00:00:00"}},
+				},
+			},
+		},
+		{
+			// https://github.com/dolthub/doltgresql/pull/3162#discussion_r3825271782
+			Name: "timestamp/timestamptz plus/minus interval preserves sub-second precision",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT timestamp '2026-08-15 12:00:00.750000' - interval '0.250000 seconds';`,
+					Expected: []sql.Row{{"2026-08-15 12:00:00.5"}},
+				},
+				{
+					Query:    `SELECT timestamptz '2026-08-15 12:00:00.750000+00' - interval '0.250000 seconds';`,
+					Expected: []sql.Row{{"2026-08-15 12:00:00.5+00"}},
+				},
+				{
+					Query:    `SELECT timestamp '2026-08-15 12:00:00.5' + interval '0.25 seconds';`,
+					Expected: []sql.Row{{"2026-08-15 12:00:00.75"}},
+				},
+			},
+		},
 	})
 }
 


### PR DESCRIPTION
`timestamp - interval` and `timestamptz - interval` only subtracted the interval's fractional-nanosecond component, silently ignoring its days and months fields, so day-scale shifts like `now() - interval '90 days'` evaluated to `now()` unchanged. Fixed by routing both operators through the existing helper with the interval negated, and added a regression test covering day and hour-scale subtraction on both types.

Also fixes interval arithmetic to honor the correct calendar month lengths, instead of approximating all months at 30 days. 

Fixes: https://github.com/dolthub/doltgresql/issues/3090
Fixes: https://github.com/dolthub/doltgresql/issues/3163