### PR TITLE
Fix bind parameter type inference and array literal whitespace handling

### DIFF
--- a/server/connection_data.go
+++ b/server/connection_data.go
@@ -160,7 +160,7 @@ func extractBindVarTypes(ctx *sql.Context, queryPlan sql.Node) ([]uint32, error)
 		case *pgexprs.ExplicitCast:
 			if bindVar, ok := e.Child().(*expression.BindVar); ok {
 				var typOid uint32
-				if doltgresType, ok := bindVar.Type(ctx).(*pgtypes.DoltgresType); ok {
+				if doltgresType, ok := e.Type(ctx).(*pgtypes.DoltgresType); ok {
 					typOid = id.Cache().ToOID(doltgresType.ID.AsId())
 				} else {
 					typOid, err = VitessTypeToObjectID(e.Type(ctx))

--- a/server/functions/array.go
+++ b/server/functions/array.go
@@ -71,9 +71,16 @@ var array_in = framework.Function3{
 		input = input[1 : len(input)-1]
 		var values []any
 		sb := strings.Builder{}
+		pendingWS := strings.Builder{}
 		quoteStartCount := 0
 		quoteEndCount := 0
 		escaped := false
+		flushPendingWS := func() {
+			if sb.Len() > 0 {
+				sb.WriteString(pendingWS.String())
+			}
+			pendingWS.Reset()
+		}
 		// Iterate over each rune in the input to collect and process the rune elements
 		for _, r := range input {
 			if escaped {
@@ -91,16 +98,19 @@ var array_in = framework.Function3{
 			} else {
 				switch r {
 				case ' ', '\t', '\n', '\r':
-					continue
+					pendingWS.WriteRune(r)
 				case '\\':
+					flushPendingWS()
 					escaped = true
 				case '"':
+					flushPendingWS()
 					quoteStartCount++
 				case ',':
 					if quoteStartCount >= 2 {
 						// This is a malformed string, thus we treat it as a critical error.
 						return nil, errors.Errorf(`malformed array literal: "%s"`, input)
 					}
+					pendingWS.Reset()
 					str := sb.String()
 					var innerValue any
 					if quoteStartCount == 0 && strings.EqualFold(str, "null") {
@@ -121,6 +131,7 @@ var array_in = framework.Function3{
 					quoteStartCount = 0
 					quoteEndCount = 0
 				default:
+					flushPendingWS()
 					sb.WriteRune(r)
 				}
 			}

--- a/testing/go/binding_test.go
+++ b/testing/go/binding_test.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -460,4 +461,39 @@ func TestBindingJSONBExtractPathTextWithUntypedParam(t *testing.T) {
 	require.NoError(t, result.Err)
 	require.Len(t, result.Rows, 1)
 	assert.Equal(t, "1", string(result.Rows[0][0]))
+}
+
+// TestBindingExplicitCastToTimestamptzPreservesOffset is a regression test for
+// https://github.com/dolthub/doltgresql/issues/3093
+func TestBindingExplicitCastToTimestamptzPreservesOffset(t *testing.T) {
+	ctx, connection, controller := CreateServer(t, "postgres")
+	defer func() {
+		connection.Close(ctx)
+		controller.Stop()
+		require.NoError(t, controller.WaitForStop())
+	}()
+	conn := connection.Default
+
+	_, err := connection.Exec(ctx, "CREATE TABLE t9 (id INT PRIMARY KEY, ts timestamptz);")
+	require.NoError(t, err)
+
+	// Use an offset that doesn't match the test server's local zone, so a bug that drops the
+	// offset entirely (rather than double-applying it) can't coincidentally still pass.
+	const text = "2026-08-21 12:00:00+05:00"
+	want := time.Date(2026, 8, 21, 12, 0, 0, 0, time.FixedZone("", 5*3600))
+	_, err = connection.Exec(ctx, "INSERT INTO t9 VALUES (1, $1)", want)
+	require.NoError(t, err)
+
+	// Standalone cast: the placeholder's inferred type must be timestamptz, not timestamp, so
+	// the embedded offset is honored rather than discarded.
+	var castBack time.Time
+	err = conn.QueryRow(ctx, "SELECT $1::timestamptz", text).Scan(&castBack)
+	require.NoError(t, err)
+	assert.True(t, castBack.Equal(want), "got %v, want %v", castBack, want)
+
+	// The same cast used in a WHERE clause comparison must match the stored row.
+	var count int
+	err = conn.QueryRow(ctx, "SELECT count(*) FROM t9 WHERE ts = $1::timestamptz", text).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
 }

--- a/testing/go/types_test.go
+++ b/testing/go/types_test.go
@@ -867,6 +867,39 @@ var typesTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "Array literal parsing preserves internal whitespace in unquoted elements",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    `SELECT '{2026-08-21 12:00:00,2026-08-22 13:30:00}'::timestamp[];`,
+				Expected: []sql.Row{{`{"2026-08-21 12:00:00","2026-08-22 13:30:00"}`}},
+			},
+			{
+				// Compared by instant equality (not text) since the display offset depends
+				// on the session's local time zone.
+				Query:    `SELECT ('{2026-08-21 12:00:00+05:00}'::timestamptz[])[1] = '2026-08-21 07:00:00+00'::timestamptz;`,
+				Expected: []sql.Row{{"t"}},
+			},
+			{
+				Query:    `SELECT '{1 day 2 hours, 3 days}'::interval[];`,
+				Expected: []sql.Row{{`{"1 day 02:00:00","3 days"}`}},
+			},
+			{
+				// Insignificant whitespace around unquoted elements is still trimmed.
+				Query:    `SELECT '{ 1 , 2 , 3 }'::int[];`,
+				Expected: []sql.Row{{"{1,2,3}"}},
+			},
+			{
+				// A whitespace-only array body is still an empty array, not a single blank element.
+				Query:    `SELECT '{ }'::int[];`,
+				Expected: []sql.Row{{"{}"}},
+			},
+			{
+				Query:    `SELECT '{ NULL , 2 }'::int[];`,
+				Expected: []sql.Row{{"{NULL,2}"}},
+			},
+		},
+	},
+	{
 		Name: "2D array",
 		Skip: true, // multiple dimensions not supported yet
 		SetUpScript: []string{


### PR DESCRIPTION
Fixes two bugs found while investigating issue #3093: an explicitly-cast bind parameter (e.g. `$1::timestamptz`) had its wire-protocol type collapsed to a generic type that discarded timezone offsets, and the array-literal parser dropped all whitespace in unquoted elements, rejecting any array of timestamps, intervals, or other space-containing values. Both are fixed at their root cause with regression tests covering the original failures plus surrounding edge cases (reversed comparisons, mixed cast/raw placeholders, quoted elements, whitespace-only arrays).

Fixes: https://github.com/dolthub/doltgresql/issues/3093