### PR TITLE
Fix bit string length functions

### DIFF
--- a/server/cast/bit.go
+++ b/server/cast/bit.go
@@ -87,6 +87,11 @@ func bitImplicit(builtInCasts map[id.Cast]casts.Cast) {
 			if err != nil {
 				return nil, err
 			}
+			// A function declared to take bit has no type modifier. Preserve the
+			// input's width when resolving such a function call.
+			if targetType.GetAttTypMod() == -1 {
+				return input, nil
+			}
 			array, err := tree.ParseDBitArray(input)
 			if err != nil {
 				return nil, err

--- a/server/cast/varbit.go
+++ b/server/cast/varbit.go
@@ -39,6 +39,11 @@ func varBitImplicit(builtInCasts map[id.Cast]casts.Cast) {
 			if err != nil {
 				return nil, err
 			}
+			// A function declared to take bit has no type modifier. In that case,
+			// varbit is binary-coercible to bit and its current length is preserved.
+			if targetType.GetAttTypMod() == -1 {
+				return input, nil
+			}
 			array, err := tree.ParseDBitArray(input)
 			if err != nil {
 				return nil, err

--- a/server/functions/bit_length.go
+++ b/server/functions/bit_length.go
@@ -15,6 +15,8 @@
 package functions
 
 import (
+	"math"
+
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -24,6 +26,7 @@ import (
 // initBitLength registers the functions to the catalog.
 func initBitLength() {
 	framework.RegisterFunction(bit_length_text)
+	framework.RegisterFunction(bit_length_bit)
 }
 
 // bit_length_text represents the PostgreSQL function of the same name, taking the same parameters.
@@ -39,4 +42,27 @@ var bit_length_text = framework.Function1{
 		}
 		return result.(int32) * 8, nil
 	},
+}
+
+// bit_length_bit represents the PostgreSQL function of the same name, taking the same parameters.
+var bit_length_bit = framework.Function1{
+	Name:       "bit_length",
+	Return:     pgtypes.Int32,
+	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Bit},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
+		val1str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		return bitStringLength(uint64(len(val1str)))
+	},
+}
+
+// bitStringLength converts a bit string's length to the int4 returned by PostgreSQL's bit string length functions.
+func bitStringLength(length uint64) (int32, error) {
+	if length > math.MaxInt32 {
+		return 0, pgtypes.ErrOutOfRange.New("integer")
+	}
+	return int32(length), nil
 }

--- a/server/functions/bit_length_test.go
+++ b/server/functions/bit_length_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+func TestBitStringLength(t *testing.T) {
+	result, err := bitStringLength(math.MaxInt32)
+	require.NoError(t, err)
+	require.Equal(t, int32(math.MaxInt32), result)
+
+	result, err = bitStringLength(math.MaxInt32 + 1)
+	require.Zero(t, result)
+	require.Error(t, err)
+	require.True(t, pgtypes.ErrOutOfRange.Is(err))
+	require.EqualError(t, err, "integer out of range")
+}

--- a/server/functions/length.go
+++ b/server/functions/length.go
@@ -15,8 +15,6 @@
 package functions
 
 import (
-	"fmt"
-
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -26,6 +24,7 @@ import (
 // initLength registers the functions to the catalog.
 func initLength() {
 	framework.RegisterFunction(length_text)
+	framework.RegisterFunction(length_bit)
 }
 
 // length_text represents the PostgreSQL function of the same name, taking the same parameters.
@@ -35,13 +34,25 @@ var length_text = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
-		val1str, ok, err := sql.Unwrap[string](ctx, val1)
+		val1str, err := framework.UnwrapString(ctx, val1)
 		if err != nil {
 			return nil, err
 		}
-		if !ok {
-			return nil, fmt.Errorf("unexpected type for length input, expected string, got %T", val1)
-		}
 		return int32(len([]rune(val1str))), nil
+	},
+}
+
+// length_bit represents the PostgreSQL function of the same name, taking the same parameters.
+var length_bit = framework.Function1{
+	Name:       "length",
+	Return:     pgtypes.Int32,
+	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Bit},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
+		val1str, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		return bitStringLength(uint64(len(val1str)))
 	},
 }

--- a/testing/go/bit_string_length_test.go
+++ b/testing/go/bit_string_length_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _go
+
+import (
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+func TestBitStringLengthFunctions(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "length and bit_length for bit strings",
+			SetUpScript: []string{
+				"CREATE TABLE bit_lengths (v varbit, b bit(5));",
+				"INSERT INTO bit_lengths VALUES (B'101', B'00101'), (B'', B'00000'), (NULL, NULL);",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    "SELECT length('101'::varbit), bit_length('101'::varbit);",
+					Expected: []sql.Row{{int32(3), int32(3)}},
+				},
+				{
+					Query:    "SELECT length(B'10101'::bit(5)), bit_length(B'10101'::bit(5));",
+					Expected: []sql.Row{{int32(5), int32(5)}},
+				},
+				{
+					Query:    "SELECT length(''::varbit), bit_length(''::varbit);",
+					Expected: []sql.Row{{int32(0), int32(0)}},
+				},
+				{
+					Query:    "SELECT length(NULL::varbit), bit_length(NULL::varbit);",
+					Expected: []sql.Row{{nil, nil}},
+				},
+				{
+					Query:    "SELECT length(v), bit_length(v), length(b), bit_length(b) FROM bit_lengths WHERE v IS NOT NULL ORDER BY v;",
+					Expected: []sql.Row{{int32(0), int32(0), int32(5), int32(5)}, {int32(3), int32(3), int32(5), int32(5)}},
+				},
+				{
+					Query:    "SELECT length(v), bit_length(v), length(b), bit_length(b) FROM bit_lengths WHERE v IS NULL;",
+					Expected: []sql.Row{{nil, nil, nil, nil}},
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
Adds PostgreSQL-compatible length(bit) and bit_length(bit) overloads, including implicit varbit-to-bit function resolution that preserves the input width for unconstrained bit parameters.

Regression coverage includes varbit and bit(n) literals, stored values, empty bit strings, and NULLs. Expected SQL results were verified against PostgreSQL 15.17.

Tests:
- go test ./testing/go -run '^TestBitStringLengthFunctions$' -count=1
- go test ./server/functions ./server/cast -count=1
- go test ./testing/generation/function_coverage/output -run '^(Test_BitLength|Test_Length)$' -count=1
- go test ./testing/go -run '^TestTypes$' -count=1
- git diff --check

Fixes #3174.