### PR TITLE
Support ARRAY constructor casts to oidvector

### DIFF
--- a/server/expression/array.go
+++ b/server/expression/array.go
@@ -103,6 +103,49 @@ func (array *Array) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 	return values, nil
 }
 
+// evalOidvectorCast evaluates a direct ARRAY[...] constructor as an oidvector. PostgreSQL permits this coercion for
+// constructors whose elements coerce to oid, but does not expose a general array-to-oidvector cast.
+func (array *Array) evalOidvectorCast(ctx *sql.Context, row sql.Row) (any, error) {
+	if len(array.children) == 0 {
+		return nil, errors.New("array is not a valid oidvector")
+	}
+
+	castsColl, err := core.GetCastsCollectionFromContext(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]any, len(array.children))
+	for i, child := range array.children {
+		value, err := child.Eval(ctx, row)
+		if err != nil {
+			return nil, err
+		}
+		if value == nil {
+			return nil, errors.New("array is not a valid oidvector")
+		}
+		if _, nested := value.([]any); nested {
+			return nil, errors.New("array is not a valid oidvector")
+		}
+		sourceType, ok := child.Type(ctx).(*pgtypes.DoltgresType)
+		if !ok {
+			return nil, errors.New("array is not a valid oidvector")
+		}
+		cast, err := castsColl.GetImplicitCast(ctx, sourceType, pgtypes.Oid)
+		if err != nil {
+			return nil, err
+		}
+		if !cast.ID.IsValid() {
+			return nil, errors.New("array is not a valid oidvector")
+		}
+		result[i], err = cast.Eval(ctx, value, sourceType, pgtypes.Oid)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
 // IsNullable implements the sql.Expression interface.
 func (array *Array) IsNullable(ctx *sql.Context) bool {
 	// TODO: verify if this is actually nullable

--- a/server/expression/explicit_cast.go
+++ b/server/expression/explicit_cast.go
@@ -75,6 +75,9 @@ func (c *ExplicitCast) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 	if !c.castToType.IsResolvedType() {
 		return nil, errors.Errorf("cannot call ExplicitCast.Eval with unresolved cast to type: %s", c.castToType.String())
 	}
+	if array, ok := c.sqlChild.(*Array); ok && c.castToType.ID == pgtypes.Oidvector.ID {
+		return array.evalOidvectorCast(ctx, row)
+	}
 
 	val, err := c.sqlChild.Eval(ctx, row)
 	if err != nil {

--- a/testing/go/types_test.go
+++ b/testing/go/types_test.go
@@ -2095,8 +2095,59 @@ var typesTests = []ScriptTest{
 		SetUpScript: []string{
 			"CREATE TABLE t_oidvector (id INTEGER primary key, v1 oidvector);",
 			"INSERT INTO t_oidvector VALUES (1, '1234 5678 9012'), (2, '556 778 223');",
+			"CREATE TABLE t_regtype_array (v regtype[]);",
+			"INSERT INTO t_regtype_array VALUES (ARRAY['integer'::regtype]);",
 		},
 		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT ARRAY['character varying'::regtype]::oidvector;",
+				Expected: []sql.Row{{"1043"}},
+			},
+			{
+				Query:    "SELECT ARRAY['integer'::regtype, 'text'::regtype]::oidvector;",
+				Expected: []sql.Row{{"23 25"}},
+			},
+			{
+				Query:    "SELECT ARRAY[23::oid]::oidvector;",
+				Expected: []sql.Row{{"23"}},
+			},
+			{
+				Query: `SELECT ARRAY['pg_class'::regclass]::oidvector =
+					ARRAY['pg_class'::regclass::oid]::oidvector;`,
+				Expected: []sql.Row{{"t"}},
+			},
+			{
+				Query:    "SELECT ARRAY['textin'::regproc]::oidvector;",
+				Expected: []sql.Row{{"46"}},
+			},
+			{
+				Query:       "SELECT NULL::regtype[]::oidvector;",
+				ExpectedErr: "cast from `regtype[]` to `oidvector` does not exist",
+			},
+			{
+				Query:       "SELECT ARRAY[]::regtype[]::oidvector;",
+				ExpectedErr: "cast from `regtype[]` to `oidvector` does not exist",
+			},
+			{
+				Query:       "SELECT (ARRAY['integer'::regtype]::regtype[])::oidvector;",
+				ExpectedErr: "cast from `regtype[]` to `oidvector` does not exist",
+			},
+			{
+				Query:       "SELECT v::oidvector FROM t_regtype_array;",
+				ExpectedErr: "cast from `regtype[]` to `oidvector` does not exist",
+			},
+			{
+				Query:       "SELECT (ARRAY['integer'::regtype] || ARRAY['text'::regtype])::oidvector;",
+				ExpectedErr: "cast from `regtype[]` to `oidvector` does not exist",
+			},
+			{
+				Query:       "SELECT ARRAY['integer'::regtype, NULL]::oidvector;",
+				ExpectedErr: "array is not a valid oidvector",
+			},
+			{
+				Query:       "SELECT ARRAY[ARRAY[23::oid]]::oidvector;",
+				ExpectedErr: "array is not a valid oidvector",
+			},
 			{
 				Query: "SELECT * FROM t_oidvector ORDER BY id;",
 				Expected: []sql.Row{


### PR DESCRIPTION
Support direct `ARRAY[...]::oidvector` expressions for OID-compatible PostgreSQL identifier types, including `regtype`, `regclass`, and `regproc`. The coercion is limited to array constructors and does not add a global array-to-oidvector cast or alter `pg_cast`.

Fixes #3172