### PR TITLE
Implement to_json

### DIFF
--- a/server/functions/array_to_json.go
+++ b/server/functions/array_to_json.go
@@ -16,8 +16,8 @@ package functions
 
 import (
 	"strings"
+	"time"
 
-	"github.com/cockroachdb/apd/v3"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/goccy/go-json"
@@ -72,10 +72,21 @@ var array_to_json_anyarray_bool = framework.Function2{
 
 // arrayToJsonRaw converts an anyarray to a JSON byte slice.
 func arrayToJsonRaw(ctx *sql.Context, arrType *pgtypes.DoltgresType, arr []any) (json.RawMessage, error) {
-	baseType := arrType.ArrayBaseType()
+	return arrayElementsToJsonRaw(ctx, arrType.ArrayBaseType(), arr)
+}
+
+// arrayElementsToJsonRaw converts array elements to a JSON byte slice. PostgreSQL
+// arrays carry one element type regardless of their number of dimensions.
+func arrayElementsToJsonRaw(ctx *sql.Context, elemType *pgtypes.DoltgresType, arr []any) (json.RawMessage, error) {
 	elements := make([]json.RawMessage, len(arr))
 	for i, el := range arr {
-		raw, err := valueToJsonRaw(ctx, baseType, el)
+		var raw json.RawMessage
+		var err error
+		if nested, ok := el.([]any); ok {
+			raw, err = arrayElementsToJsonRaw(ctx, elemType, nested)
+		} else {
+			raw, err = valueToJsonRaw(ctx, elemType, el)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -89,13 +100,45 @@ func valueToJsonRaw(ctx *sql.Context, elemType *pgtypes.DoltgresType, val any) (
 	if val == nil {
 		return json.RawMessage("null"), nil
 	}
-	switch v := val.(type) {
-	case *apd.Decimal:
-		return json.RawMessage(v.Text('f')), nil
-	case pgtypes.JsonDocument:
+	if v, ok := val.(pgtypes.JsonDocument); ok {
 		sb := strings.Builder{}
 		pgtypes.JsonValueFormatter(&sb, v.Value)
 		return json.RawMessage(sb.String()), nil
+	}
+	conversionType := elemType
+	if conversionType != nil && conversionType.TypType == pgtypes.TypeType_Domain {
+		conversionType = conversionType.DomainUnderlyingBaseType()
+	}
+	if conversionType != nil && (conversionType.ID.TypeName() == "json" || conversionType.ID.TypeName() == "jsonb") {
+		output, err := elemType.IoOutput(ctx, val)
+		return json.RawMessage(output), err
+	}
+	if conversionType != nil {
+		switch conversionType.ID.TypeName() {
+		case "date":
+			return json.Marshal(FormatDateTimeWithBC(val.(time.Time), dateStyleFormatDateOnly_ISO, false))
+		case "timestamp":
+			return json.Marshal(FormatDateTimeWithBC(val.(time.Time), "2006-01-02T15:04:05.999999", false))
+		case "timestamptz":
+			location, err := GetServerLocation(ctx)
+			if err != nil {
+				return nil, err
+			}
+			t := val.(time.Time).In(location)
+			formatted := FormatDateTimeWithBC(t, "2006-01-02T15:04:05.999999", false)
+			if strings.HasSuffix(formatted, " BC") {
+				formatted = strings.TrimSuffix(formatted, " BC") + t.Format("-07:00") + " BC"
+			} else {
+				formatted += t.Format("-07:00")
+			}
+			return json.Marshal(formatted)
+		case "bool":
+			return json.Marshal(val)
+		case "int2", "int4", "int8", "float4", "float8", "numeric":
+			return marshalJsonNumber(ctx, elemType, val)
+		}
+	}
+	switch v := val.(type) {
 	case types.JSONDocument:
 		return json.Marshal(v.Val)
 	case sql.JSONWrapper:
@@ -104,17 +147,51 @@ func valueToJsonRaw(ctx *sql.Context, elemType *pgtypes.DoltgresType, val any) (
 			return nil, err
 		}
 		return json.Marshal(jsonVal)
+	case []pgtypes.RecordValue:
+		result, err := rowToJson(ctx, conversionType, v, false)
+		return json.RawMessage(result), err
 	case []any:
-		return arrayToJsonRaw(ctx, elemType, v)
-	case string:
-		// JSON-typed values are already valid JSON and should be embedded without re-quoting.
-		if elemType != nil && elemType.ID.TypeName() == "json" {
-			return json.RawMessage(v), nil
+		if conversionType != nil && conversionType.IsArrayType() {
+			return arrayToJsonRaw(ctx, conversionType, v)
 		}
-		return json.Marshal(v)
+		return arrayElementsToJsonRaw(ctx, nil, v)
 	default:
+		return marshalJsonTypeOutput(ctx, elemType, val)
+	}
+}
+
+// marshalJsonNumber formats PostgreSQL numeric types through their output
+// functions. Non-finite float and numeric values are JSON strings because they
+// are not valid JSON number tokens.
+func marshalJsonNumber(ctx *sql.Context, typ *pgtypes.DoltgresType, val any) (json.RawMessage, error) {
+	output, err := typ.IoOutput(ctx, val)
+	if err != nil {
+		return nil, err
+	}
+	switch output {
+	case "NaN":
+		return json.Marshal("NaN")
+	case "Infinity", "+Inf":
+		return json.Marshal("Infinity")
+	case "-Infinity", "-Inf":
+		return json.Marshal("-Infinity")
+	default:
+		return json.RawMessage(output), nil
+	}
+}
+
+// marshalJsonTypeOutput quotes a value's PostgreSQL text representation as a
+// JSON string. PostgreSQL uses type output functions for scalar types that are
+// not JSON booleans or ordinary finite JSON numbers.
+func marshalJsonTypeOutput(ctx *sql.Context, typ *pgtypes.DoltgresType, val any) (json.RawMessage, error) {
+	if typ == nil {
 		return json.Marshal(val)
 	}
+	output, err := typ.IoOutput(ctx, val)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(output)
 }
 
 // arrayToJsonPretty produces a pretty-printed JSON array where dimension-1 elements are

--- a/server/functions/init.go
+++ b/server/functions/init.go
@@ -221,6 +221,7 @@ func Init() {
 	initTimezone()
 	initToChar()
 	initToHex()
+	initToJson()
 	initToRegclass()
 	initToRegproc()
 	initToRegtype()

--- a/server/functions/regtype.go
+++ b/server/functions/regtype.go
@@ -105,6 +105,15 @@ var regtypeout = framework.Function1{
 		if internalID.Section() == id.Section_OID {
 			return internalID.Segment(0), nil
 		}
+		// GMS represents both PostgreSQL json and jsonb with its single JSON
+		// type, whose SQLStandardName is jsonb. Preserve the distinct
+		// PostgreSQL names when formatting regtype values.
+		if typ := pgtypes.GetTypeByID(id.Type(internalID)); typ != nil {
+			switch typ.ID.TypeName() {
+			case "json", "jsonb":
+				return typ.ID.TypeName(), nil
+			}
+		}
 		toid := id.Cache().ToOID(internalID)
 		if t, ok := types.OidToType[oid.Oid(toid)]; ok {
 			return t.SQLStandardName(), nil

--- a/server/functions/to_json.go
+++ b/server/functions/to_json.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// initToJson registers the functions to the catalog.
+func initToJson() {
+	framework.RegisterFunction(to_json_anyelement)
+}
+
+// to_json_anyelement represents the PostgreSQL function of the same name, taking the same parameters.
+var to_json_anyelement = framework.Function1{
+	Name:               "to_json",
+	Return:             pgtypes.Json,
+	Parameters:         [1]*pgtypes.DoltgresType{pgtypes.AnyElement},
+	IsNonDeterministic: true,
+	Strict:             true,
+	Callable: func(ctx *sql.Context, paramsAndReturn [2]*pgtypes.DoltgresType, val any) (any, error) {
+		raw, err := valueToJsonRaw(ctx, paramsAndReturn[0], val)
+		if err != nil {
+			return nil, err
+		}
+		return string(raw), nil
+	},
+}

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -1844,6 +1844,119 @@ func TestJsonFunctions(t *testing.T) {
 			},
 		},
 		{
+			Name: "to_json",
+			SetUpScript: []string{
+				`SET TIME ZONE 'UTC'`,
+				`SET DateStyle = 'SQL, MDY'`,
+				`CREATE TABLE to_json_test (id int4, label text)`,
+				`INSERT INTO to_json_test VALUES (7, 'named')`,
+				`CREATE DOMAIN to_json_int_domain AS int4`,
+				`CREATE DOMAIN to_json_oid_domain AS oid`,
+				`CREATE DOMAIN to_json_json_domain AS json`,
+				`CREATE DOMAIN to_json_int_array_domain AS int4[]`,
+				`CREATE TYPE to_json_named_record AS (id int4, label text)`,
+				`CREATE DOMAIN to_json_named_record_domain AS to_json_named_record`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT to_json(E'quote " slash \\ newline\n'::text)`,
+					Expected: []sql.Row{{`"quote \" slash \\ newline\n"`}},
+				},
+				{
+					Query:    `SELECT to_json(42::int4)`,
+					Expected: []sql.Row{{"42"}},
+				},
+				{
+					Query:    `SELECT pg_typeof(to_json(42)), pg_typeof(array_to_json(ARRAY[1])), pg_typeof(row_to_json(ROW(1)))`,
+					Expected: []sql.Row{{"json", "json", "json"}},
+				},
+				{
+					Query:    `SELECT to_json(123.450::numeric)`,
+					Expected: []sql.Row{{"123.450"}},
+				},
+				{
+					Query:    `SELECT to_json('NaN'::numeric), to_json('Infinity'::numeric), to_json('-Infinity'::numeric)`,
+					Expected: []sql.Row{{`"NaN"`, `"Infinity"`, `"-Infinity"`}},
+				},
+				{
+					Query:    `SELECT to_json(1.25::float8), to_json('NaN'::float8), to_json('Infinity'::float8), to_json('-Infinity'::float8)`,
+					Expected: []sql.Row{{"1.25", `"NaN"`, `"Infinity"`, `"-Infinity"`}},
+				},
+				{
+					Query:    `SELECT to_json(1e20::float8), to_json(1e-7::float8)`,
+					Expected: []sql.Row{{"1e+20", "1e-07"}},
+				},
+				{
+					Query:    `SELECT to_json(true)`,
+					Expected: []sql.Row{{"true"}},
+				},
+				{
+					Query:    `SELECT to_json(DATE '2024-02-29')`,
+					Expected: []sql.Row{{`"2024-02-29"`}},
+				},
+				{
+					Query:    `SELECT to_json(TIMESTAMP '2024-02-29 12:34:56.123456')`,
+					Expected: []sql.Row{{`"2024-02-29T12:34:56.123456"`}},
+				},
+				{
+					Query:    `SELECT to_json(TIMESTAMPTZ '2024-02-29 12:34:56.123456+05:30')`,
+					Expected: []sql.Row{{`"2024-02-29T07:04:56.123456+00:00"`}},
+				},
+				{
+					Query:    `SELECT to_json(DATE '0001-01-01 BC'), to_json(TIMESTAMP '0001-01-01 12:34:56.123456 BC'), to_json(TIMESTAMPTZ '0001-01-01 12:34:56.123456+00 BC')`,
+					Expected: []sql.Row{{`"0001-01-01 BC"`, `"0001-01-01T12:34:56.123456 BC"`, `"0001-01-01T12:34:56.123456+00:00 BC"`}},
+				},
+				{
+					Query:    `SELECT to_json('550e8400-e29b-41d4-a716-446655440000'::uuid)`,
+					Expected: []sql.Row{{`"550e8400-e29b-41d4-a716-446655440000"`}},
+				},
+				{
+					Query:    `SELECT to_json(23::oid), to_json('pg_class'::regclass), to_json('42'::xid)`,
+					Expected: []sql.Row{{`"23"`, `"pg_class"`, `"42"`}},
+				},
+				{
+					Query:    `SELECT to_json(7::to_json_int_domain), to_json(23::to_json_oid_domain)`,
+					Expected: []sql.Row{{"7", `"23"`}},
+				},
+				{
+					Query:    `SELECT to_json(ARRAY[1, NULL, 3]::to_json_int_array_domain)`,
+					Expected: []sql.Row{{`[1,null,3]`}},
+				},
+				{
+					Query:    `SELECT to_json((ROW(7, 'named')::to_json_named_record)::to_json_named_record_domain)`,
+					Expected: []sql.Row{{`{"id":7,"label":"named"}`}},
+				},
+				{
+					Query:    `SELECT to_json('{"b": 2, "a":1}'::json), to_json('{"b": 2, "a":1}'::jsonb)`,
+					Expected: []sql.Row{{`{"b": 2, "a":1}`, `{"a": 1, "b": 2}`}},
+				},
+				{
+					Query:    `SELECT to_json('{"b": 2, "a":1}'::to_json_json_domain)`,
+					Expected: []sql.Row{{`{"b": 2, "a":1}`}},
+				},
+				{
+					Query:    `SELECT to_json(E'\\x00ff'::bytea), to_json(INTERVAL '1 day 02:03:04.5')`,
+					Expected: []sql.Row{{`"\\x00ff"`, `"1 day 02:03:04.5"`}},
+				},
+				{
+					Query:    `SELECT to_json(ARRAY[1, NULL, 3]::int4[])`,
+					Expected: []sql.Row{{`[1,null,3]`}},
+				},
+				{
+					Query:    `SELECT to_json(ROW(1, 'x'::text, NULL::bool))`,
+					Expected: []sql.Row{{`{"f1":1,"f2":"x","f3":null}`}},
+				},
+				{
+					Query:    `SELECT to_json(t) FROM to_json_test t`,
+					Expected: []sql.Row{{`{"id":7,"label":"named"}`}},
+				},
+				{
+					Query:    `SELECT to_json(NULL::text)`,
+					Expected: []sql.Row{{nil}},
+				},
+			},
+		},
+		{
 			Name: "row_to_json anonymous row",
 			Assertions: []ScriptTestAssertion{
 				{
@@ -1937,8 +2050,16 @@ func TestArrayFunctions(t *testing.T) {
 					Expected: []sql.Row{{"[1.5,2.5]"}},
 				},
 				{
+					Query:    `SELECT array_to_json(ARRAY[1e20::float8, 1e-7::float8])`,
+					Expected: []sql.Row{{"[1e+20,1e-07]"}},
+				},
+				{
 					Query:    `SELECT array_to_json(ARRAY[true, false])`,
 					Expected: []sql.Row{{"[true,false]"}},
+				},
+				{
+					Query:    `SELECT array_to_json(ARRAY[DATE '2024-02-29', DATE '2025-01-01'])`,
+					Expected: []sql.Row{{`["2024-02-29","2025-01-01"]`}},
 				},
 				{
 					Query:    `SELECT array_to_json(ARRAY['a', 'b', 'c'])`,
@@ -1949,7 +2070,7 @@ func TestArrayFunctions(t *testing.T) {
 					Expected: []sql.Row{{"[1,null,3]"}},
 				},
 				{
-					Skip:     true, // TODO: multidimensional array literals are not yet supported
+					Skip:     true, // TODO: https://github.com/dolthub/doltgresql/issues/3183
 					Query:    `SELECT array_to_json('{{1,2},{3,4}}'::int[])`,
 					Expected: []sql.Row{{"[[1,2],[3,4]]"}},
 				},


### PR DESCRIPTION
Implements PostgreSQL-compatible `to_json(anyelement)` support.

Uses PostgreSQL type output semantics across scalar, domain, array, composite, JSON, temporal, numeric, and extended types, while aligning `array_to_json` and `row_to_json` conversion behavior.

Part of #3099