### PR TITLE
Implement hashtext

### DIFF
--- a/server/functions/hashtext.go
+++ b/server/functions/hashtext.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+import (
+	"encoding/binary"
+	"math/bits"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// initHashText registers the functions to the catalog.
+func initHashText() {
+	framework.RegisterFunction(hashtext_text)
+}
+
+// hashtext_text represents the PostgreSQL function of the same name, taking the same parameters.
+var hashtext_text = framework.Function1{
+	Name:       "hashtext",
+	Return:     pgtypes.Int32,
+	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Text},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val any) (any, error) {
+		input, err := framework.UnwrapString(ctx, val)
+		if err != nil {
+			return nil, err
+		}
+		return int32(postgresHashBytes([]byte(input))), nil
+	},
+}
+
+// postgresHashBytes implements PostgreSQL's 32-bit hash_bytes routine on a byte slice. PostgreSQL uses this hash for
+// deterministic-collation text values; DoltgreSQL currently supports deterministic collations only.
+func postgresHashBytes(data []byte) uint32 {
+	a := uint32(0x9e3779b9 + len(data) + 3923095)
+	b := a
+	c := a
+
+	remaining := data
+	for len(remaining) >= 12 {
+		a += binary.LittleEndian.Uint32(remaining[0:4])
+		b += binary.LittleEndian.Uint32(remaining[4:8])
+		c += binary.LittleEndian.Uint32(remaining[8:12])
+		a, b, c = postgresHashMix(a, b, c)
+		remaining = remaining[12:]
+	}
+
+	switch len(remaining) {
+	case 11:
+		c += uint32(remaining[10]) << 24
+		fallthrough
+	case 10:
+		c += uint32(remaining[9]) << 16
+		fallthrough
+	case 9:
+		c += uint32(remaining[8]) << 8
+		fallthrough
+	case 8:
+		b += uint32(remaining[7]) << 24
+		fallthrough
+	case 7:
+		b += uint32(remaining[6]) << 16
+		fallthrough
+	case 6:
+		b += uint32(remaining[5]) << 8
+		fallthrough
+	case 5:
+		b += uint32(remaining[4])
+		fallthrough
+	case 4:
+		a += uint32(remaining[3]) << 24
+		fallthrough
+	case 3:
+		a += uint32(remaining[2]) << 16
+		fallthrough
+	case 2:
+		a += uint32(remaining[1]) << 8
+		fallthrough
+	case 1:
+		a += uint32(remaining[0])
+	}
+
+	_, _, c = postgresHashFinal(a, b, c)
+	return c
+}
+
+func postgresHashMix(a, b, c uint32) (uint32, uint32, uint32) {
+	a -= c
+	a ^= bits.RotateLeft32(c, 4)
+	c += b
+	b -= a
+	b ^= bits.RotateLeft32(a, 6)
+	a += c
+	c -= b
+	c ^= bits.RotateLeft32(b, 8)
+	b += a
+	a -= c
+	a ^= bits.RotateLeft32(c, 16)
+	c += b
+	b -= a
+	b ^= bits.RotateLeft32(a, 19)
+	a += c
+	c -= b
+	c ^= bits.RotateLeft32(b, 4)
+	b += a
+	return a, b, c
+}
+
+func postgresHashFinal(a, b, c uint32) (uint32, uint32, uint32) {
+	c ^= b
+	c -= bits.RotateLeft32(b, 14)
+	a ^= c
+	a -= bits.RotateLeft32(c, 11)
+	b ^= a
+	b -= bits.RotateLeft32(a, 25)
+	c ^= b
+	c -= bits.RotateLeft32(b, 16)
+	a ^= c
+	a -= bits.RotateLeft32(c, 4)
+	b ^= a
+	b -= bits.RotateLeft32(a, 14)
+	c ^= b
+	c -= bits.RotateLeft32(b, 24)
+	return a, b, c
+}

--- a/server/functions/init.go
+++ b/server/functions/init.go
@@ -125,6 +125,7 @@ func Init() {
 	initGetdatabaseencoding()
 	initHasDatabasePrivilege()
 	initHasSchemaPrivilege()
+	initHashText()
 	initInitcap()
 	initLcm()
 	initLeft()

--- a/testing/go/hashtext_test.go
+++ b/testing/go/hashtext_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _go
+
+import (
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+func TestHashText(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "hashtext",
+			SetUpScript: []string{
+				`CREATE TABLE hashtext_values (id INT PRIMARY KEY, value TEXT);`,
+				`INSERT INTO hashtext_values VALUES (1, repeat('x', 20000));`,
+				`CREATE TABLE hashtext_lengths (length INT PRIMARY KEY);`,
+				`INSERT INTO hashtext_lengths VALUES (0), (1), (2), (3), (4), (5), (6), (7), (8), (9), (10), ` +
+					`(11), (12), (13), (23), (24), (25);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `SELECT length, hashtext(repeat('x', length)) FROM hashtext_lengths ORDER BY length;`,
+					Expected: []sql.Row{
+						{int32(0), int32(-1477818771)},
+						{int32(1), int32(1074944137)},
+						{int32(2), int32(-1086392228)},
+						{int32(3), int32(-1992236649)},
+						{int32(4), int32(-1379736791)},
+						{int32(5), int32(-370454118)},
+						{int32(6), int32(1489915569)},
+						{int32(7), int32(-66683019)},
+						{int32(8), int32(-2126973000)},
+						{int32(9), int32(1651296771)},
+						{int32(10), int32(755764456)},
+						{int32(11), int32(-1494243903)},
+						{int32(12), int32(631527812)},
+						{int32(13), int32(28686851)},
+						{int32(23), int32(597544042)},
+						{int32(24), int32(1380215333)},
+						{int32(25), int32(733930510)},
+					},
+				},
+				{
+					Query:    `SELECT hashtext('');`,
+					Expected: []sql.Row{{int32(-1477818771)}},
+				},
+				{
+					Query:    `SELECT hashtext('abc');`,
+					Expected: []sql.Row{{int32(-785388649)}},
+				},
+				{
+					Query:    `SELECT hashtext('12345678901'), hashtext('123456789012'), hashtext('1234567890123');`,
+					Expected: []sql.Row{{int32(1650060602), int32(-2102057603), int32(437480032)}},
+				},
+				{
+					Query:    `SELECT octet_length('12345678901é'), hashtext('12345678901é');`,
+					Expected: []sql.Row{{int32(13), int32(-295778157)}},
+				},
+				{
+					Query:    `SELECT hashtext('café'), hashtext('日本');`,
+					Expected: []sql.Row{{int32(103771354), int32(-1851216170)}},
+				},
+				{
+					Query:    `SELECT hashtext(repeat('x', 1000));`,
+					Expected: []sql.Row{{int32(-1157355676)}},
+				},
+				{
+					Query:    `SELECT hashtext(value) FROM hashtext_values WHERE id = 1;`,
+					Expected: []sql.Row{{int32(-1519670832)}},
+				},
+				{
+					Query:    `SELECT hashtext(NULL);`,
+					Expected: []sql.Row{{nil}},
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
Adds PostgreSQL-compatible `hashtext` using PostgreSQL's 32-bit `hash_bytes` algorithm, including signed `int4` results and storage-backed text values.

Adds regression coverage for all tail lengths, block boundaries, UTF-8 crossing a block boundary, long values, and NULL behavior.

Part of #3099.