### PR TITLE
Implement convert_to

### DIFF
--- a/server/functions/convert_to.go
+++ b/server/functions/convert_to.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+
+	"github.com/dolthub/doltgresql/postgres/parser/pgcode"
+	"github.com/dolthub/doltgresql/postgres/parser/pgerror"
+	"github.com/dolthub/doltgresql/server/functions/framework"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+const encodingSupportIssuesURL = "https://github.com/dolthub/doltgresql/issues"
+
+// initConvertTo registers the functions to the catalog.
+func initConvertTo() {
+	framework.RegisterFunction(convert_to_text_name)
+}
+
+// convert_to_text_name represents the PostgreSQL function of the same name, taking the same parameters.
+var convert_to_text_name = framework.Function2{
+	Name:       "convert_to",
+	Return:     pgtypes.Bytea,
+	Parameters: [2]*pgtypes.DoltgresType{pgtypes.Text, pgtypes.Name},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [3]*pgtypes.DoltgresType, val1, val2 any) (any, error) {
+		input, err := framework.UnwrapString(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		encodingName, err := framework.UnwrapString(ctx, val2)
+		if err != nil {
+			return nil, err
+		}
+
+		destination := lookupPostgresEncoding(encodingName)
+		if destination == nil {
+			return nil, pgerror.WithCandidateCode(
+				fmt.Errorf(`invalid destination encoding name "%s"`, encodingName), pgcode.InvalidParameterValue)
+		}
+		if destination.passThrough {
+			return []byte(input), nil
+		}
+		if destination.encoder == nil {
+			return nil, pgerror.WithCandidateCode(fmt.Errorf(
+				`destination encoding "%s" is recognized but not yet supported; request support at %s`,
+				destination.name, encodingSupportIssuesURL), pgcode.FeatureNotSupported)
+		}
+
+		converted, err := destination.encoder.NewEncoder().Bytes([]byte(input))
+		if err != nil {
+			return nil, pgerror.WithCandidateCode(untranslatableCharacterError(input, *destination),
+				pgcode.UntranslatableCharacter)
+		}
+		return converted, nil
+	},
+}
+
+// untranslatableCharacterError describes the first input character unsupported by destination.
+func untranslatableCharacterError(input string, destination postgresEncoding) error {
+	for _, r := range input {
+		encodedRune := string(r)
+		if _, err := destination.encoder.NewEncoder().String(encodedRune); err != nil {
+			bytes := []byte(encodedRune)
+			parts := make([]string, len(bytes))
+			for i, b := range bytes {
+				parts[i] = fmt.Sprintf("0x%02x", b)
+			}
+			return fmt.Errorf(`character with byte sequence %s in encoding "UTF8" has no equivalent in encoding "%s"`,
+				strings.Join(parts, " "), destination.name)
+		}
+	}
+	return fmt.Errorf(`character has no equivalent in encoding "%s"`, destination.name)
+}

--- a/server/functions/encoding.go
+++ b/server/functions/encoding.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+import (
+	"strings"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/encoding/korean"
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/encoding/traditionalchinese"
+)
+
+// postgresEncoding describes a PostgreSQL encoding name. An entry with neither passThrough nor encoder set is a valid
+// PostgreSQL encoding that DoltgreSQL recognizes but does not support as a conversion destination yet.
+type postgresEncoding struct {
+	name        string
+	id          int32
+	aliases     []string
+	encoder     encoding.Encoding
+	passThrough bool
+}
+
+// postgresEncodings is the shared source of truth for encoding-aware functions. Conversion support is intentionally
+// curated: UTF8/SQL_ASCII, ISO-8859/Latin, Windows and KOI8 single-byte encodings, and the commonly used Japanese,
+// Korean, and Chinese encodings available in x/text. The remaining PostgreSQL encodings stay registered so callers get
+// an actionable unsupported-feature error instead of being told that a valid encoding name is invalid.
+var postgresEncodings = []postgresEncoding{
+	{name: "SQL_ASCII", id: 0, aliases: []string{"SQLASCII"}, passThrough: true},
+	{name: "EUC_JP", id: 1, encoder: japanese.EUCJP},
+	{name: "EUC_CN", id: 2},
+	{name: "EUC_KR", id: 3, encoder: korean.EUCKR},
+	{name: "EUC_TW", id: 4},
+	{name: "EUC_JIS_2004", id: 5},
+	{name: "UTF8", id: 6, aliases: []string{"UNICODE"}, passThrough: true},
+	{name: "MULE_INTERNAL", id: 7},
+	{name: "LATIN1", id: 8, aliases: []string{"ISO_8859_1"}, encoder: charmap.ISO8859_1},
+	{name: "LATIN2", id: 9, aliases: []string{"ISO_8859_2"}, encoder: charmap.ISO8859_2},
+	{name: "LATIN3", id: 10, aliases: []string{"ISO_8859_3"}, encoder: charmap.ISO8859_3},
+	{name: "LATIN4", id: 11, aliases: []string{"ISO_8859_4"}, encoder: charmap.ISO8859_4},
+	{name: "LATIN5", id: 12, aliases: []string{"ISO_8859_9"}, encoder: charmap.ISO8859_9},
+	{name: "LATIN6", id: 13, aliases: []string{"ISO_8859_10"}, encoder: charmap.ISO8859_10},
+	{name: "LATIN7", id: 14, aliases: []string{"ISO_8859_13"}, encoder: charmap.ISO8859_13},
+	{name: "LATIN8", id: 15, aliases: []string{"ISO_8859_14"}, encoder: charmap.ISO8859_14},
+	{name: "LATIN9", id: 16, aliases: []string{"ISO_8859_15"}, encoder: charmap.ISO8859_15},
+	{name: "LATIN10", id: 17, aliases: []string{"ISO_8859_16"}, encoder: charmap.ISO8859_16},
+	{name: "WIN1256", id: 18, aliases: []string{"WINDOWS_1256"}, encoder: charmap.Windows1256},
+	{name: "WIN1258", id: 19, aliases: []string{"WINDOWS_1258"}, encoder: charmap.Windows1258},
+	{name: "WIN866", id: 20, aliases: []string{"ALT", "WINDOWS_866"}, encoder: charmap.CodePage866},
+	{name: "WIN874", id: 21, aliases: []string{"WINDOWS_874"}, encoder: charmap.Windows874},
+	{name: "KOI8R", id: 22, encoder: charmap.KOI8R},
+	{name: "WIN1251", id: 23, aliases: []string{"WIN", "WINDOWS_1251"}, encoder: charmap.Windows1251},
+	{name: "WIN1252", id: 24, aliases: []string{"WINDOWS_1252"}, encoder: charmap.Windows1252},
+	{name: "ISO_8859_5", id: 25, encoder: charmap.ISO8859_5},
+	{name: "ISO_8859_6", id: 26, encoder: charmap.ISO8859_6},
+	{name: "ISO_8859_7", id: 27, encoder: charmap.ISO8859_7},
+	{name: "ISO_8859_8", id: 28, encoder: charmap.ISO8859_8},
+	{name: "WIN1250", id: 29, aliases: []string{"WINDOWS_1250"}, encoder: charmap.Windows1250},
+	{name: "WIN1253", id: 30, aliases: []string{"WINDOWS_1253"}, encoder: charmap.Windows1253},
+	{name: "WIN1254", id: 31, aliases: []string{"WINDOWS_1254"}, encoder: charmap.Windows1254},
+	{name: "WIN1255", id: 32, aliases: []string{"WINDOWS_1255"}, encoder: charmap.Windows1255},
+	{name: "WIN1257", id: 33, aliases: []string{"WINDOWS_1257"}, encoder: charmap.Windows1257},
+	{name: "KOI8U", id: 34, encoder: charmap.KOI8U},
+	{name: "SJIS", id: 35, aliases: []string{"SHIFT_JIS"}, encoder: japanese.ShiftJIS},
+	{name: "BIG5", id: 36, encoder: traditionalchinese.Big5},
+	{name: "GBK", id: 37, encoder: simplifiedchinese.GBK},
+	{name: "UHC", id: 38, encoder: korean.EUCKR},
+	{name: "GB18030", id: 39, encoder: simplifiedchinese.GB18030},
+	{name: "JOHAB", id: 40},
+	{name: "SHIFT_JIS_2004", id: 41},
+}
+
+var postgresEncodingByName = func() map[string]*postgresEncoding {
+	encodings := make(map[string]*postgresEncoding, len(postgresEncodings)*2)
+	for i := range postgresEncodings {
+		definition := &postgresEncodings[i]
+		encodings[normalizeEncodingName(definition.name)] = definition
+		for _, alias := range definition.aliases {
+			encodings[normalizeEncodingName(alias)] = definition
+		}
+	}
+	return encodings
+}()
+
+// lookupPostgresEncoding returns the PostgreSQL encoding matching name or one of its aliases.
+func lookupPostgresEncoding(name string) *postgresEncoding {
+	return postgresEncodingByName[normalizeEncodingName(name)]
+}
+
+// normalizeEncodingName matches PostgreSQL's case-insensitive treatment of encoding names and aliases.
+func normalizeEncodingName(name string) string {
+	var sb strings.Builder
+	for _, r := range strings.ToLower(name) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}

--- a/server/functions/init.go
+++ b/server/functions/init.go
@@ -100,6 +100,7 @@ func Init() {
 	initChr()
 	initColDescription()
 	initConcat()
+	initConvertTo()
 	initCos()
 	initCosd()
 	initCosh()

--- a/server/functions/pg_char_to_encoding.go
+++ b/server/functions/pg_char_to_encoding.go
@@ -15,8 +15,6 @@
 package functions
 
 import (
-	"strings"
-
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -40,19 +38,10 @@ var pg_char_to_encoding_name = framework.Function1{
 		if err != nil {
 			return nil, err
 		}
-		// Encoding names are normalized by lowercasing and dropping any characters that are not ASCII letters or
-		// digits, matching Postgres (e.g. "UTF-8" matches "utf8").
-		var sb strings.Builder
-		for _, r := range strings.ToLower(valStr) {
-			if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
-				sb.WriteRune(r)
-			}
+		definition := lookupPostgresEncoding(valStr)
+		if definition == nil {
+			return int32(-1), nil
 		}
-		switch sb.String() {
-		case "utf8", "unicode":
-			return int32(6), nil
-		}
-		// TODO: only UTF8 is supported for now; Postgres returns -1 for unrecognized encoding names
-		return int32(-1), nil
+		return definition.id, nil
 	},
 }

--- a/testing/go/convert_to_test.go
+++ b/testing/go/convert_to_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _go
+
+import (
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+func TestConvertTo(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "convert_to",
+			SetUpScript: []string{
+				`CREATE TABLE supported_encodings (name TEXT PRIMARY KEY);`,
+				`INSERT INTO supported_encodings VALUES ` +
+					`('SQL_ASCII'),('SQLASCII'),('EUC_JP'),('EUC_KR'),('UTF8'),('utf-8'),('UNICODE'),` +
+					`('LATIN1'),('ISO_8859_1'),('LATIN2'),('ISO_8859_2'),('LATIN3'),('ISO_8859_3'),` +
+					`('LATIN4'),('ISO_8859_4'),('LATIN5'),('ISO_8859_9'),('LATIN6'),('ISO_8859_10'),` +
+					`('LATIN7'),('ISO_8859_13'),('LATIN8'),('ISO_8859_14'),('LATIN9'),('ISO_8859_15'),` +
+					`('LATIN10'),('ISO_8859_16'),('WIN1256'),('WIN1258'),('WIN866'),('ALT'),('WIN874'),` +
+					`('KOI8R'),('WIN1251'),('WIN'),('WIN1252'),('ISO_8859_5'),('ISO_8859_6'),('ISO_8859_7'),` +
+					`('ISO_8859_8'),('WIN1250'),('WIN1253'),('WIN1254'),('WIN1255'),('WIN1257'),('KOI8U'),` +
+					`('SJIS'),('SHIFT_JIS'),('BIG5'),('GBK'),('UHC'),('GB18030'),` +
+					`('WINDOWS-866'),('WINDOWS-874'),('WINDOWS-1250'),('WINDOWS-1251'),('WINDOWS-1252'),` +
+					`('WINDOWS-1253'),('WINDOWS-1254'),('WINDOWS-1255'),('WINDOWS-1256'),('WINDOWS-1257'),` +
+					`('WINDOWS-1258');`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `SELECT count(*), bool_and(pg_char_to_encoding(name) >= 0), ` +
+						`bool_and(encode(convert_to('x', name::name), 'hex') = '78') FROM supported_encodings;`,
+					Expected: []sql.Row{{int64(63), "t", "t"}},
+				},
+				{
+					Query:    `SELECT encode(convert_to('x', 'UTF8'), 'hex');`,
+					Expected: []sql.Row{{"78"}},
+				},
+				{
+					Query:    `SELECT encode(convert_to('café', 'utf-8'), 'hex');`,
+					Expected: []sql.Row{{"636166c3a9"}},
+				},
+				{
+					Query:    `SELECT encode(convert_to('日本', 'EUC_JP'), 'hex');`,
+					Expected: []sql.Row{{"c6fccbdc"}},
+				},
+				{
+					Query: `SELECT encode(convert_to('한', 'UHC'), 'hex'), encode(convert_to('Ж', 'ALT'), 'hex'), ` +
+						`encode(convert_to('Ж', 'WIN'), 'hex'), encode(convert_to('Ж', 'ISO_8859_5'), 'hex');`,
+					Expected: []sql.Row{{"c7d1", "86", "c6", "b6"}},
+				},
+				{
+					Query: `SELECT encode(convert_to('Ж', 'KOI8R'), 'hex'), encode(convert_to('日本', 'SJIS'), 'hex'), ` +
+						`encode(convert_to('한', 'EUC_KR'), 'hex'), encode(convert_to('한', 'UHC'), 'hex'), ` +
+						`encode(convert_to('中文', 'BIG5'), 'hex'), encode(convert_to('中文', 'GBK'), 'hex'), ` +
+						`encode(convert_to('😄', 'GB18030'), 'hex');`,
+					Expected: []sql.Row{{"f6", "93fa967b", "c7d1", "c7d1", "a4a4a4e5", "d6d0cec4", "9439fd30"}},
+				},
+				{
+					Query: `SELECT encode(convert_to('€', 'WIN1252'), 'hex'), ` +
+						`encode(convert_to('€', 'WINDOWS-1252'), 'hex'), encode(convert_to('Ж', 'WIN866'), 'hex'), ` +
+						`encode(convert_to('Ж', 'WINDOWS-866'), 'hex');`,
+					Expected: []sql.Row{{"80", "80", "86", "86"}},
+				},
+				{
+					Query: `SELECT encode(convert_to('café', 'LATIN1'), 'hex'), ` +
+						`encode(convert_to('café', 'ISO_8859_1'), 'hex'), encode(convert_to('日本', 'SJIS'), 'hex'), ` +
+						`encode(convert_to('日本', 'SHIFT_JIS'), 'hex');`,
+					Expected: []sql.Row{{"636166e9", "636166e9", "93fa967b", "93fa967b"}},
+				},
+				{
+					Query: `SELECT pg_char_to_encoding('ALT'), pg_char_to_encoding('WIN'), pg_char_to_encoding('UHC'), ` +
+						`pg_char_to_encoding('ISO_8859_5'), pg_char_to_encoding('EUC_CN');`,
+					Expected: []sql.Row{{int32(20), int32(23), int32(38), int32(25), int32(2)}},
+				},
+				{
+					Query: `SELECT pg_char_to_encoding('WINDOWS-866'), pg_char_to_encoding('WINDOWS-874'), ` +
+						`pg_char_to_encoding('WINDOWS-1250'), pg_char_to_encoding('WINDOWS-1251'), ` +
+						`pg_char_to_encoding('WINDOWS-1252'), pg_char_to_encoding('WINDOWS-1253'), ` +
+						`pg_char_to_encoding('WINDOWS-1254'), pg_char_to_encoding('WINDOWS-1255'), ` +
+						`pg_char_to_encoding('WINDOWS-1256'), pg_char_to_encoding('WINDOWS-1257'), ` +
+						`pg_char_to_encoding('WINDOWS-1258');`,
+					Expected: []sql.Row{{int32(20), int32(21), int32(29), int32(23), int32(24), int32(30),
+						int32(31), int32(32), int32(18), int32(33), int32(19)}},
+				},
+				{
+					Query:    `SELECT encode(convert_to('', 'UTF8'), 'hex');`,
+					Expected: []sql.Row{{""}},
+				},
+				{
+					Query:    `SELECT convert_to(NULL, 'UTF8'), convert_to('x', NULL);`,
+					Expected: []sql.Row{{nil, nil}},
+				},
+				{
+					Query:           `SELECT convert_to('€', 'LATIN1');`,
+					ExpectedErr:     `character with byte sequence 0xe2 0x82 0xac in encoding "UTF8" has no equivalent in encoding "LATIN1"`,
+					ExpectedErrCode: "22P05",
+				},
+				{
+					Query:           `SELECT convert_to('x', 'EUC_CN');`,
+					ExpectedErr:     `destination encoding "EUC_CN" is recognized but not yet supported; request support at https://github.com/dolthub/doltgresql/issues`,
+					ExpectedErrCode: "0A000",
+				},
+				{
+					Query:           `SELECT convert_to('x', 'bogus');`,
+					ExpectedErr:     `invalid destination encoding name "bogus"`,
+					ExpectedErrCode: "22023",
+				},
+			},
+		},
+	})
+}

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -2703,10 +2703,9 @@ func TestSystemCatalogInformationFunctions(t *testing.T) {
 					},
 				},
 				{
-					// TODO: only UTF8 is supported for now
 					Query: `SELECT pg_char_to_encoding('LATIN1');`,
 					Expected: []sql.Row{
-						{-1},
+						{8},
 					},
 				},
 			},


### PR DESCRIPTION
Adds PostgreSQL-compatible `convert_to` for a curated set of common encodings and aliases. Centralizes encoding names, IDs, aliases, and conversion support so `convert_to` and `pg_char_to_encoding` remain consistent.

Distinguishes invalid encoding names, recognized but unsupported encodings, and untranslatable characters with the appropriate SQLSTATEs and actionable errors.

Part of #3099.