### PR TITLE
Persist column defaults with schema-qualified type names in explicit casts.

### DIFF
--- a/core/init.go
+++ b/core/init.go
@@ -37,7 +37,7 @@ func Init() {
 	plpgsql.GetTypesCollectionFromContext = GetTypesCollectionFromContext
 	id.RegisterListener(sequenceIDListener{}, id.Section_Table)
 	typecollection.GetSqlTableFromContext = GetSqlTableFromContext
-	typecollection.GetSchemaName = GetSchemaName
+	typecollection.LookupSchemaName = LookupSchemaName
 	pgtypes.GetTypesCollectionFromContext = func(ctx *sql.Context, database string) (pgtypes.TypeCollection, error) {
 		return GetTypesCollectionFromContext(ctx, database)
 	}

--- a/core/schema.go
+++ b/core/schema.go
@@ -19,20 +19,55 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
-// GetCurrentSchema returns the current schema used by the context. Defaults to "public" if the context does not specify
-// a schema.
-func GetCurrentSchema(ctx *sql.Context) (string, error) {
+// LookupCurrentSchema returns the first schema on the search path that exists, reporting whether there was one.
+// Finding none is not an error here: only the caller knows whether it needs somewhere to create an object or is
+// resolving a name that may simply not exist.
+func LookupCurrentSchema(ctx *sql.Context) (string, bool, error) {
 	_, root, err := GetRootFromContext(ctx)
 	if err != nil {
-		return "", nil
+		return "", false, err
 	}
 	// The current database may not be backed by a Doltgres *RootValue (e.g. Dolt's synthetic dolt_cluster system
 	// database), in which case there's no search path to resolve against.
 	if root == nil {
-		return "public", nil
+		return "public", true, nil
 	}
+	schemaName, err := resolve.FirstExistingSchemaOnSearchPath(ctx, root)
+	if err != nil {
+		// Dolt reports "no schema on the search path exists" with an error phrased for its CREATE TABLE caller.
+		if sql.ErrDatabaseNoDatabaseSchemaSelectedCreate.Is(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return schemaName, true, nil
+}
 
-	return resolve.FirstExistingSchemaOnSearchPath(ctx, root)
+// LookupSchemaName is GetSchemaName for callers that treat a missing schema as "not found" rather than an error.
+func LookupSchemaName(ctx *sql.Context, db sql.Database, schemaName string) (string, bool, error) {
+	if schemaName == "" {
+		if schema, isSch := db.(sql.DatabaseSchema); isSch {
+			schemaName = schema.SchemaName()
+		}
+		if schemaName == "" {
+			return LookupCurrentSchema(ctx)
+		}
+	}
+	return schemaName, true, nil
+}
+
+// GetCurrentSchema returns the current schema used by the context. Defaults to "public" if the context does not specify
+// a schema. Returns sql.ErrDatabaseNoDatabaseSchemaSelectedCreate when no schema on the search path exists, which suits
+// callers creating an object; use LookupCurrentSchema to treat that as "not found" instead.
+func GetCurrentSchema(ctx *sql.Context) (string, error) {
+	schemaName, ok, err := LookupCurrentSchema(ctx)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", sql.ErrDatabaseNoDatabaseSchemaSelectedCreate.New()
+	}
+	return schemaName, nil
 }
 
 // GetSchemaName returns the schema name if there is any exist.
@@ -42,13 +77,12 @@ func GetCurrentSchema(ctx *sql.Context) (string, error) {
 // it tries retrieving the current schema used by the context.
 // Defaults to "public" if the context does not specify a schema.
 func GetSchemaName(ctx *sql.Context, db sql.Database, schemaName string) (string, error) {
-	if schemaName == "" {
-		if schema, isSch := db.(sql.DatabaseSchema); isSch {
-			schemaName = schema.SchemaName()
-		}
-		if schemaName == "" {
-			return GetCurrentSchema(ctx)
-		}
+	name, ok, err := LookupSchemaName(ctx, db, schemaName)
+	if err != nil {
+		return "", err
 	}
-	return schemaName, nil
+	if !ok {
+		return "", sql.ErrDatabaseNoDatabaseSchemaSelectedCreate.New()
+	}
+	return name, nil
 }

--- a/core/typecollection/typecollection.go
+++ b/core/typecollection/typecollection.go
@@ -526,8 +526,11 @@ func (pgs *TypeCollection) writeCache(ctx context.Context) (err error) {
 // getTable returns the SQL table that matches the given schema and table name. Returns a nil table if one is not found.
 // This is intended for use with tableToType.
 func (*TypeCollection) getTable(ctx *sql.Context, schema string, tblName string) (tbl sql.Table, actualSchema string, err error) {
-	actualSchema, err = GetSchemaName(ctx, nil, schema)
-	if err != nil {
+	// With no schema to search there is no matching table, which is a miss rather than a failure: callers can still
+	// resolve an unqualified name by other means.
+	// TODO: an unqualified name should be resolved against every schema on the search path, not just the first.
+	actualSchema, ok, err := LookupSchemaName(ctx, nil, schema)
+	if err != nil || !ok {
 		return nil, "", err
 	}
 	tbl, err = GetSqlTableFromContext(ctx, "", doltdb.TableName{
@@ -569,5 +572,5 @@ func (pgs *TypeCollection) tableToType(ctx *sql.Context, tbl sql.Table, schema s
 // GetSqlTableFromContext is a forward declaration to get around import cycles
 var GetSqlTableFromContext func(ctx *sql.Context, databaseName string, tableName doltdb.TableName) (sql.Table, error)
 
-// GetSchemaName is a forward declaration to get around import cycles
-var GetSchemaName func(ctx *sql.Context, db sql.Database, schemaName string) (string, error)
+// LookupSchemaName is a forward declaration to get around import cycles
+var LookupSchemaName func(ctx *sql.Context, db sql.Database, schemaName string) (string, bool, error)

--- a/core/typecollection/typecollection_test.go
+++ b/core/typecollection/typecollection_test.go
@@ -19,8 +19,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
 	"github.com/dolthub/dolt/go/store/hash"
 	"github.com/dolthub/dolt/go/store/prolly/tree"
+	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/doltgresql/core/id"
@@ -52,6 +54,48 @@ func TestMap_RemainsUsableAfterFlushFailure(t *testing.T) {
 	require.NotPanics(t, func() {
 		_, _ = coll.Map(ctx)
 	})
+}
+
+// TestGetTable_NoSchemaToSearch asserts that an unqualified lookup with no schema to search reports no matching table
+// rather than an error, leaving the caller free to resolve the name another way.
+func TestGetTable_NoSchemaToSearch(t *testing.T) {
+	defer withSchemaResolution(t, "", false, nil)()
+
+	coll := newTestTypeCollection(t, tree.NewTestNodeStore())
+	tbl, schema, err := coll.getTable(sql.NewEmptyContext(), "", "registration_status")
+	require.NoError(t, err)
+	require.Nil(t, tbl)
+	require.Empty(t, schema)
+}
+
+// TestGetTable_SchemaResolutionErrorPropagates asserts that a genuine schema resolution failure is still reported.
+func TestGetTable_SchemaResolutionErrorPropagates(t *testing.T) {
+	boom := errors.New("boom")
+	defer withSchemaResolution(t, "", false, boom)()
+
+	coll := newTestTypeCollection(t, tree.NewTestNodeStore())
+	_, _, err := coll.getTable(sql.NewEmptyContext(), "", "registration_status")
+	require.ErrorIs(t, err, boom)
+}
+
+// withSchemaResolution makes resolving an unqualified name yield the given result, returning a restore function. The
+// table hook fails the test if reached, since there is no schema to look a table up in.
+func withSchemaResolution(t *testing.T, schema string, ok bool, err error) func() {
+	t.Helper()
+	origLookupSchemaName, origGetSqlTable := LookupSchemaName, GetSqlTableFromContext
+	LookupSchemaName = func(ctx *sql.Context, db sql.Database, schemaName string) (string, bool, error) {
+		if schemaName == "" {
+			return schema, ok, err
+		}
+		return schemaName, true, nil
+	}
+	GetSqlTableFromContext = func(ctx *sql.Context, databaseName string, tableName doltdb.TableName) (sql.Table, error) {
+		t.Errorf("table lookup attempted with no schema to search: %s", tableName.String())
+		return nil, nil
+	}
+	return func() {
+		LookupSchemaName, GetSqlTableFromContext = origLookupSchemaName, origGetSqlTable
+	}
 }
 
 // newTestTypeCollection returns a TypeCollection backed by |ns| with an

--- a/server/expression/explicit_cast.go
+++ b/server/expression/explicit_cast.go
@@ -170,8 +170,9 @@ func (c *ExplicitCast) String() string {
 	} else {
 		sqlChild = c.sqlChild.String()
 	}
+	// Column defaults are persisted as this string and re-parsed later, so the type must be schema-qualified.
 	// type needs to be upper-case to match InputExpression in AliasExpr
-	return fmt.Sprintf("%s::%s", sqlChild, strings.ToUpper(c.castToType.String()))
+	return fmt.Sprintf("%s::%s", sqlChild, strings.ToUpper(c.castToType.SchemaQualifiedString()))
 }
 
 // Type implements the sql.Expression interface.

--- a/server/types/type.go
+++ b/server/types/type.go
@@ -1060,6 +1060,18 @@ func (t *DoltgresType) String() string {
 	return str
 }
 
+// SchemaQualifiedString returns String with a schema qualifier for types outside `pg_catalog`. Persisted expressions
+// are re-parsed under whatever search path is in effect later, which may not reach the type's schema, or may match its
+// bare name in more than one schema.
+func (t *DoltgresType) SchemaQualifiedString() string {
+	str := t.String()
+	schema := t.ID.SchemaName()
+	if schema == "" || schema == "pg_catalog" {
+		return str
+	}
+	return fmt.Sprintf("%s.%s", schema, str)
+}
+
 // SubscriptFuncName returns the name that would be displayed in pg_type for the `typsubscript` field.
 func (t *DoltgresType) SubscriptFuncName() string {
 	return globalFunctionRegistry.GetString(t.SubscriptFunc)

--- a/testing/go/schemas_test.go
+++ b/testing/go/schemas_test.go
@@ -191,6 +191,58 @@ var SchemaTests = []ScriptTest{
 		},
 	},
 	{
+		// pg_dump emits schema-qualified DDL under an empty search_path, so a type reference in a column default has
+		// to survive being persisted and re-parsed with no search path to resolve it against.
+		Name: "qualified type in a column default with an empty search path",
+		SetUpScript: []string{
+			"SELECT pg_catalog.set_config('search_path', '', false);",
+			"CREATE TYPE public.registration_status AS ENUM ('PENDING', 'APPROVED', 'REJECTED');",
+			`CREATE TABLE public.registration_request (
+				id int NOT NULL,
+				status public.registration_status DEFAULT 'PENDING'::public.registration_status NOT NULL
+			);`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "ALTER TABLE ONLY public.registration_request ADD CONSTRAINT registration_request_pkey PRIMARY KEY (id);",
+			},
+			{
+				Query: "INSERT INTO public.registration_request (id) VALUES (1);",
+			},
+			{
+				Query: "SELECT id, status FROM public.registration_request;",
+				Expected: []sql.Row{
+					{1, "PENDING"},
+				},
+			},
+		},
+	},
+	{
+		// The same round trip has to keep the schema straight when the bare type name is ambiguous.
+		Name: "qualified type in a column default when the type name is ambiguous",
+		SetUpScript: []string{
+			"CREATE SCHEMA schema1;",
+			"CREATE SCHEMA schema2;",
+			"CREATE TYPE schema1.status AS ENUM ('one');",
+			"CREATE TYPE schema2.status AS ENUM ('two');",
+			"CREATE TABLE public.t1 (id int NOT NULL, status schema2.status DEFAULT 'two'::schema2.status NOT NULL);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "ALTER TABLE ONLY public.t1 ADD CONSTRAINT t1_pkey PRIMARY KEY (id);",
+			},
+			{
+				Query: "INSERT INTO public.t1 (id) VALUES (1);",
+			},
+			{
+				Query: "SELECT id, status FROM public.t1;",
+				Expected: []sql.Row{
+					{1, "two"},
+				},
+			},
+		},
+	},
+	{
 		Name: "search path returns user table before public table",
 		SetUpScript: []string{
 			"create schema postgres",


### PR DESCRIPTION
Storing the name without the schema makes for ambiguous lookups in the future and causes errors in inserts and alter tables.