### PR TITLE
Add octet_length, length and bit_length for bytea

### DIFF
--- a/integration-tests/go-sql-server-driver/large_values_test.go
+++ b/integration-tests/go-sql-server-driver/large_values_test.go
@@ -15,8 +15,6 @@
 package main
 
 import (
-	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -176,10 +174,10 @@ func TestLargeOutOfBandValues(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, numRows, count)
 
-			// All rows must have the correct byte length. Doltgres panics on
-			// octet_length() over large out-of-band text values, so the length
-			// is verified client-side.
-			count = countTextRowsOfLen(t, conn, ctx, "SELECT txt FROM large_text", textSize)
+			// All rows must have the correct byte length.
+			err = conn.QueryRowContext(ctx,
+				"SELECT COUNT(*) FROM large_text WHERE octet_length(txt) = $1", textSize).Scan(&count)
+			require.NoError(t, err)
 			require.Equal(t, numRows, count, "every row should retain the full text length")
 
 			// Spot-check a few rows for exact content.
@@ -240,21 +238,11 @@ func TestLargeOutOfBandValues(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, numRows, count)
 
-			// Doltgres has no server-side byte-length function for bytea
-			// (octet_length/length/encode are unavailable), so verify every
-			// row's blob length on the client side instead.
-			lenRows, err := conn.QueryContext(ctx, "SELECT data FROM large_blob")
+			// All rows must have the correct byte length.
+			err = conn.QueryRowContext(ctx,
+				"SELECT COUNT(*) FROM large_blob WHERE octet_length(data) = $1", blobSize).Scan(&count)
 			require.NoError(t, err)
-			count = 0
-			for lenRows.Next() {
-				var d []byte
-				require.NoError(t, lenRows.Scan(&d))
-				require.Equal(t, blobSize, len(d), "every row should retain the full blob length")
-				count++
-			}
-			require.NoError(t, lenRows.Err())
-			lenRows.Close()
-			require.Equal(t, numRows, count)
+			require.Equal(t, numRows, count, "every row should retain the full blob length")
 
 			// Spot-check exact binary content for a few rows.
 			for _, id := range []int{0, numRows / 2, numRows - 1} {
@@ -403,23 +391,12 @@ func TestLargeOutOfBandValues(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, numRows, count)
 
-			// Verify lengths of all large columns. Doltgres has no bytea length
-			// function and panics on octet_length() over large out-of-band text,
-			// so the lengths are checked client-side.
-			lenRows, err := conn.QueryContext(ctx, "SELECT txt, bin_data, note FROM mixed_large")
+			// Verify lengths of all large columns.
+			err = conn.QueryRowContext(ctx,
+				"SELECT COUNT(*) FROM mixed_large WHERE octet_length(txt) = $1 "+
+					"AND octet_length(bin_data) = $2 AND octet_length(note) = 5000",
+				textSize, blobSize).Scan(&count)
 			require.NoError(t, err)
-			count = 0
-			for lenRows.Next() {
-				var txtv, notev string
-				var binv []byte
-				require.NoError(t, lenRows.Scan(&txtv, &binv, &notev))
-				require.Equal(t, textSize, len(txtv))
-				require.Equal(t, blobSize, len(binv))
-				require.Equal(t, 5000, len(notev))
-				count++
-			}
-			require.NoError(t, lenRows.Err())
-			lenRows.Close()
 			require.Equal(t, numRows, count, "all large column lengths must be preserved")
 
 			// Spot-check content integrity.
@@ -551,21 +528,10 @@ func TestLargeOutOfBandValues(t *testing.T) {
 		require.Equal(t, numWorkers*rowsPerWorker, count,
 			"all rows from all workers must be present")
 
-		// Doltgres has no bytea length function and panics on octet_length()
-		// over large out-of-band text, so verify sizes client-side.
-		lenRows, err := conn.QueryContext(ctx, "SELECT txt, data FROM large_concurrent")
+		err = conn.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM large_concurrent WHERE octet_length(txt) = $1 AND octet_length(data) = $2",
+			textSize, blobSize).Scan(&count)
 		require.NoError(t, err)
-		count = 0
-		for lenRows.Next() {
-			var txtv string
-			var datav []byte
-			require.NoError(t, lenRows.Scan(&txtv, &datav))
-			require.Equal(t, textSize, len(txtv))
-			require.Equal(t, blobSize, len(datav))
-			count++
-		}
-		require.NoError(t, lenRows.Err())
-		lenRows.Close()
 		require.Equal(t, numWorkers*rowsPerWorker, count,
 			"all large values must have the correct size")
 	})
@@ -797,12 +763,11 @@ func TestTypeDiversity(t *testing.T) {
 		require.Equal(t, len(vals), count)
 
 		// Verify the large TEXT value was preserved intact (200 KB of ASCII).
-		// Doltgres panics on octet_length() over large out-of-band text, so the
-		// length is checked client-side.
-		var longText string
-		err = conn.QueryRowContext(ctx, "SELECT col_longtext FROM string_types WHERE id = 3").Scan(&longText)
+		var longTextLen int
+		err = conn.QueryRowContext(ctx,
+			"SELECT octet_length(col_longtext) FROM string_types WHERE id = 3").Scan(&longTextLen)
 		require.NoError(t, err)
-		require.Equal(t, 200000, len(longText), "200 KB TEXT value must be stored and retrieved intact")
+		require.Equal(t, 200000, longTextLen, "200 KB TEXT value must be stored and retrieved intact")
 
 		// Verify the NULL row.
 		err = conn.QueryRowContext(ctx,
@@ -882,12 +847,12 @@ func TestTypeDiversity(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, len(vals), count)
 
-		// Verify the 500 KB bytea value survived. Doltgres has no server-side
-		// byte-length function for bytea, so check the length client-side.
-		var lb500 []byte
-		err = conn.QueryRowContext(ctx, "SELECT col_longblob FROM binary_types WHERE id = 2").Scan(&lb500)
+		// Verify the 500 KB bytea value survived.
+		var lb500Len int
+		err = conn.QueryRowContext(ctx,
+			"SELECT octet_length(col_longblob) FROM binary_types WHERE id = 2").Scan(&lb500Len)
 		require.NoError(t, err)
-		require.Equal(t, 500_000, len(lb500), "500 KB bytea value must be stored and retrieved intact")
+		require.Equal(t, 500_000, lb500Len, "500 KB bytea value must be stored and retrieved intact")
 
 		// Spot-check exact blob content.
 		var actualLB []byte
@@ -1352,20 +1317,10 @@ func TestWideTable(t *testing.T) {
 		require.Equal(t, numRows, count)
 
 		// Verify that the first and last text columns have the expected length.
-		// Doltgres panics on octet_length() over large out-of-band text, so the
-		// lengths are checked client-side.
-		lenRows, err := conn.QueryContext(ctx, "SELECT c0, c99 FROM wide_text")
+		err = conn.QueryRowContext(ctx,
+			fmt.Sprintf("SELECT COUNT(*) FROM wide_text WHERE octet_length(c0) = %d AND octet_length(c%d) = %d",
+				colDataSize, numCols-1, colDataSize)).Scan(&count)
 		require.NoError(t, err)
-		count = 0
-		for lenRows.Next() {
-			var c0v, c99v string
-			require.NoError(t, lenRows.Scan(&c0v, &c99v))
-			require.Equal(t, colDataSize, len(c0v))
-			require.Equal(t, colDataSize, len(c99v))
-			count++
-		}
-		require.NoError(t, lenRows.Err())
-		lenRows.Close()
 		require.Equal(t, numRows, count, "all TEXT cells must retain their content length")
 
 		// Spot-check exact content of a cell.
@@ -1444,20 +1399,10 @@ func TestWideTable(t *testing.T) {
 		require.Equal(t, numRows, count)
 
 		// Verify total data volume via the byte length of two boundary columns.
-		// Doltgres panics on octet_length() over large out-of-band text, so the
-		// lengths are checked client-side.
-		lenRows, err := conn.QueryContext(ctx, "SELECT c0, c199 FROM extreme_wide")
+		err = conn.QueryRowContext(ctx,
+			fmt.Sprintf("SELECT COUNT(*) FROM extreme_wide WHERE octet_length(c0) = %d AND octet_length(c%d) = %d",
+				colDataSize, numCols-1, colDataSize)).Scan(&count)
 		require.NoError(t, err)
-		count = 0
-		for lenRows.Next() {
-			var c0v, c199v string
-			require.NoError(t, lenRows.Scan(&c0v, &c199v))
-			require.Equal(t, colDataSize, len(c0v))
-			require.Equal(t, colDataSize, len(c199v))
-			count++
-		}
-		require.NoError(t, lenRows.Err())
-		lenRows.Close()
 		require.Equal(t, numRows, count,
 			"extremely wide rows must fully preserve all column data")
 
@@ -1484,23 +1429,4 @@ func TestWideTable(t *testing.T) {
 		require.Equal(t, makeTestText(checkRow*numCols+checkCol, colDataSize), cell,
 			"extreme wide row TEXT cell must be byte-perfect after GC")
 	})
-}
-
-// countTextRowsOfLen runs a single-column text query and returns the number of
-// rows whose value has exactly want bytes, asserting each row matches. Doltgres
-// currently panics on octet_length()/length() over large out-of-band text
-// values, so callers verify text byte-lengths client-side instead of in SQL.
-func countTextRowsOfLen(t *testing.T, conn *sql.Conn, ctx context.Context, query string, want int) int {
-	rows, err := conn.QueryContext(ctx, query)
-	require.NoError(t, err)
-	defer rows.Close()
-	n := 0
-	for rows.Next() {
-		var s string
-		require.NoError(t, rows.Scan(&s))
-		require.Equal(t, want, len(s))
-		n++
-	}
-	require.NoError(t, rows.Err())
-	return n
 }

--- a/server/functions/bit_length.go
+++ b/server/functions/bit_length.go
@@ -15,8 +15,6 @@
 package functions
 
 import (
-	"math"
-
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -26,6 +24,7 @@ import (
 // initBitLength registers the functions to the catalog.
 func initBitLength() {
 	framework.RegisterFunction(bit_length_text)
+	framework.RegisterFunction(bit_length_bytea)
 	framework.RegisterFunction(bit_length_bit)
 }
 
@@ -35,12 +34,19 @@ var bit_length_text = framework.Function1{
 	Return:     pgtypes.Int32,
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Text},
 	Strict:     true,
-	Callable: func(ctx *sql.Context, t [2]*pgtypes.DoltgresType, val1 any) (any, error) {
-		result, err := octet_length_text.Callable(ctx, t, val1)
-		if err != nil {
-			return nil, err
-		}
-		return result.(int32) * 8, nil
+	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
+		return valueBitLength(ctx, val1)
+	},
+}
+
+// bit_length_bytea represents the PostgreSQL function of the same name, taking the same parameters.
+var bit_length_bytea = framework.Function1{
+	Name:       "bit_length",
+	Return:     pgtypes.Int32,
+	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Bytea},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
+		return valueBitLength(ctx, val1)
 	},
 }
 
@@ -55,14 +61,15 @@ var bit_length_bit = framework.Function1{
 		if err != nil {
 			return nil, err
 		}
-		return bitStringLength(uint64(len(val1str)))
+		return lengthToInt32(int64(len(val1str)))
 	},
 }
 
-// bitStringLength converts a bit string's length to the int4 returned by PostgreSQL's bit string length functions.
-func bitStringLength(length uint64) (int32, error) {
-	if length > math.MaxInt32 {
-		return 0, pgtypes.ErrOutOfRange.New("integer")
+// valueBitLength returns the number of bits in a string- or bytes-typed value, which is its byte length times eight.
+func valueBitLength(ctx *sql.Context, val any) (int32, error) {
+	length, err := framework.UnwrapByteLength(ctx, val)
+	if err != nil {
+		return 0, err
 	}
-	return int32(length), nil
+	return lengthToInt32(length * 8)
 }

--- a/server/functions/framework/unwrap.go
+++ b/server/functions/framework/unwrap.go
@@ -46,3 +46,27 @@ func UnwrapBytes(ctx *sql.Context, val any) ([]byte, error) {
 	}
 	return data, nil
 }
+
+// UnwrapByteLength returns the length in bytes of a string- or bytes-typed function argument. Large values may arrive
+// as a wrapper (e.g. *val.ByteArray) whose contents are stored out-of-band; when such a wrapper already knows its
+// exact byte length, that length is used rather than loading the full value into memory.
+func UnwrapByteLength(ctx *sql.Context, val any) (int64, error) {
+	if wrapper, ok := val.(sql.AnyWrapper); ok {
+		if wrapper.IsExactLength() {
+			return wrapper.MaxByteLength(), nil
+		}
+		unwrapped, err := wrapper.UnwrapAny(ctx)
+		if err != nil {
+			return 0, err
+		}
+		val = unwrapped
+	}
+	switch val := val.(type) {
+	case string:
+		return int64(len(val)), nil
+	case []byte:
+		return int64(len(val)), nil
+	default:
+		return 0, errors.Errorf("expected string or []byte value, got %T", val)
+	}
+}

--- a/server/functions/length.go
+++ b/server/functions/length.go
@@ -24,6 +24,7 @@ import (
 // initLength registers the functions to the catalog.
 func initLength() {
 	framework.RegisterFunction(length_text)
+	framework.RegisterFunction(length_bytea)
 	framework.RegisterFunction(length_bit)
 }
 
@@ -42,6 +43,22 @@ var length_text = framework.Function1{
 	},
 }
 
+// length_bytea represents the PostgreSQL function of the same name, taking the same parameters. Unlike length(text),
+// which counts characters, length(bytea) counts bytes.
+var length_bytea = framework.Function1{
+	Name:       "length",
+	Return:     pgtypes.Int32,
+	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Bytea},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
+		length, err := framework.UnwrapByteLength(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		return lengthToInt32(length)
+	},
+}
+
 // length_bit represents the PostgreSQL function of the same name, taking the same parameters.
 var length_bit = framework.Function1{
 	Name:       "length",
@@ -53,6 +70,6 @@ var length_bit = framework.Function1{
 		if err != nil {
 			return nil, err
 		}
-		return bitStringLength(uint64(len(val1str)))
+		return lengthToInt32(int64(len(val1str)))
 	},
 }

--- a/server/functions/octet_length.go
+++ b/server/functions/octet_length.go
@@ -15,6 +15,8 @@
 package functions
 
 import (
+	"math"
+
 	"github.com/dolthub/go-mysql-server/sql"
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
@@ -24,6 +26,7 @@ import (
 // initOctetLength registers the functions to the catalog.
 func initOctetLength() {
 	framework.RegisterFunction(octet_length_text)
+	framework.RegisterFunction(octet_length_bytea)
 }
 
 // octet_length_text represents the PostgreSQL function of the same name, taking the same parameters.
@@ -33,10 +36,33 @@ var octet_length_text = framework.Function1{
 	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Text},
 	Strict:     true,
 	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
-		str, err := framework.UnwrapString(ctx, val1)
+		length, err := framework.UnwrapByteLength(ctx, val1)
 		if err != nil {
 			return nil, err
 		}
-		return int32(len(str)), nil
+		return lengthToInt32(length)
 	},
+}
+
+// octet_length_bytea represents the PostgreSQL function of the same name, taking the same parameters.
+var octet_length_bytea = framework.Function1{
+	Name:       "octet_length",
+	Return:     pgtypes.Int32,
+	Parameters: [1]*pgtypes.DoltgresType{pgtypes.Bytea},
+	Strict:     true,
+	Callable: func(ctx *sql.Context, _ [2]*pgtypes.DoltgresType, val1 any) (any, error) {
+		length, err := framework.UnwrapByteLength(ctx, val1)
+		if err != nil {
+			return nil, err
+		}
+		return lengthToInt32(length)
+	},
+}
+
+// lengthToInt32 converts a length to the int4 returned by PostgreSQL's length functions, erroring if it does not fit.
+func lengthToInt32(length int64) (int32, error) {
+	if length > math.MaxInt32 {
+		return 0, pgtypes.ErrOutOfRange.New("integer")
+	}
+	return int32(length), nil
 }

--- a/server/functions/octet_length_test.go
+++ b/server/functions/octet_length_test.go
@@ -23,12 +23,12 @@ import (
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
-func TestBitStringLength(t *testing.T) {
-	result, err := bitStringLength(math.MaxInt32)
+func TestLengthToInt32(t *testing.T) {
+	result, err := lengthToInt32(math.MaxInt32)
 	require.NoError(t, err)
 	require.Equal(t, int32(math.MaxInt32), result)
 
-	result, err = bitStringLength(math.MaxInt32 + 1)
+	result, err = lengthToInt32(math.MaxInt32 + 1)
 	require.Zero(t, result)
 	require.Error(t, err)
 	require.True(t, pgtypes.ErrOutOfRange.Is(err))

--- a/testing/go/adaptive_encoding_test.go
+++ b/testing/go/adaptive_encoding_test.go
@@ -295,8 +295,8 @@ func TestStringFunctionsOnOutOfBandValues(t *testing.T) {
 							Expected: []sql.Row{{bigStringMd5}},
 						},
 						{
-							Query:    "select octet_length(body) from t_big;",
-							Expected: []sql.Row{{int32(20000)}},
+							Query:    "select octet_length(body), bit_length(body) from t_big;",
+							Expected: []sql.Row{{int32(20000), int32(160000)}},
 						},
 						{
 							Query:    "select initcap(left(body, 3)) from t_big;",
@@ -342,6 +342,10 @@ func TestByteaFunctionsOnOutOfBandValues(t *testing.T) {
 				{
 					Query:    "select body from t_bytes;",
 					Expected: []sql.Row{{bigBytes}},
+				},
+				{
+					Query:    "select octet_length(body), length(body), bit_length(body) from t_bytes;",
+					Expected: []sql.Row{{int32(20000), int32(20000), int32(160000)}},
 				},
 				{
 					Query:    "select length(encode(body, 'hex')) from t_bytes;",

--- a/testing/go/bytea_length_test.go
+++ b/testing/go/bytea_length_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _go
+
+import (
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+func TestByteaLengthFunctions(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "octet_length, length and bit_length for bytea",
+			SetUpScript: []string{
+				"CREATE TABLE byteas (id int primary key, v bytea);",
+				`INSERT INTO byteas VALUES (1, '\x00010203'), (2, ''), (3, NULL);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT octet_length('x'::bytea), length('x'::bytea), bit_length('x'::bytea);`,
+					Expected: []sql.Row{{int32(1), int32(1), int32(8)}},
+				},
+				{
+					Query:    `SELECT octet_length('\x00010203'::bytea), length('\x00010203'::bytea), bit_length('\x00010203'::bytea);`,
+					Expected: []sql.Row{{int32(4), int32(4), int32(32)}},
+				},
+				{
+					// Unlike length(text), which counts characters, length(bytea) counts bytes.
+					Query:    `SELECT length('héllo'::bytea), length('héllo'::text), octet_length('héllo'::text);`,
+					Expected: []sql.Row{{int32(6), int32(5), int32(6)}},
+				},
+				{
+					Query:    `SELECT octet_length(''::bytea), length(''::bytea), bit_length(''::bytea);`,
+					Expected: []sql.Row{{int32(0), int32(0), int32(0)}},
+				},
+				{
+					Query:    `SELECT octet_length(NULL::bytea), length(NULL::bytea), bit_length(NULL::bytea);`,
+					Expected: []sql.Row{{nil, nil, nil}},
+				},
+				{
+					// The bytea overloads must not make an untyped literal argument ambiguous.
+					Query:    `SELECT octet_length('abc'), length('abc'), bit_length('abc');`,
+					Expected: []sql.Row{{int32(3), int32(3), int32(24)}},
+				},
+				{
+					Query: "SELECT id, octet_length(v), length(v), bit_length(v) FROM byteas ORDER BY id;",
+					Expected: []sql.Row{
+						{int32(1), int32(4), int32(4), int32(32)},
+						{int32(2), int32(0), int32(0), int32(0)},
+						{int32(3), nil, nil, nil},
+					},
+				},
+			},
+		},
+		{
+			Name: "octet_length in a bytea CHECK constraint",
+			SetUpScript: []string{
+				"CREATE TABLE artifacts (id int primary key, artifact bytea NOT NULL, CONSTRAINT artifact_not_empty CHECK (octet_length(artifact) > 0));",
+				`INSERT INTO artifacts VALUES (1, '\x0001');`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    "SELECT id, octet_length(artifact) FROM artifacts;",
+					Expected: []sql.Row{{int32(1), int32(2)}},
+				},
+				{
+					Query:       `INSERT INTO artifacts VALUES (2, '');`,
+					ExpectedErr: "violated",
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
Postgres has octet_length(bytea), length(bytea) and bit_length(bytea); Doltgres implemented only the text and bit string overloads.

All three return the byte count (times eight for bit_length), obtained through a new framework.UnwrapByteLength helper that takes the length from an out-of-band wrapper when the wrapper knows it exactly, and only materializes the value otherwise. octet_length(text) now uses the same helper. bitStringLength is replaced by the shared lengthToInt32.

Some large-value integration tests worked around the missing functions by checking lengths client-side; those checks now run in SQL.