### PR TITLE
Generalize array constructor casts to vector types

### DIFF
--- a/server/expression/array.go
+++ b/server/expression/array.go
@@ -103,11 +103,11 @@ func (array *Array) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 	return values, nil
 }
 
-// evalOidvectorCast evaluates a direct ARRAY[...] constructor as an oidvector. PostgreSQL permits this coercion for
-// constructors whose elements coerce to oid, but does not expose a general array-to-oidvector cast.
-func (array *Array) evalOidvectorCast(ctx *sql.Context, row sql.Row) (any, error) {
+// evalVectorCast evaluates a direct ARRAY[...] constructor as a PostgreSQL vector type. PostgreSQL coerces the
+// constructor's elements to the vector's element type, but does not expose a general array-to-vector cast.
+func (array *Array) evalVectorCast(ctx *sql.Context, row sql.Row, targetType *pgtypes.DoltgresType) (any, error) {
 	if len(array.children) == 0 {
-		return nil, errors.New("array is not a valid oidvector")
+		return nil, errors.Errorf("array is not a valid %s", targetType.Name())
 	}
 
 	castsColl, err := core.GetCastsCollectionFromContext(ctx, "")
@@ -116,29 +116,30 @@ func (array *Array) evalOidvectorCast(ctx *sql.Context, row sql.Row) (any, error
 	}
 
 	result := make([]any, len(array.children))
+	elementType := targetType.ArrayBaseType()
 	for i, child := range array.children {
 		value, err := child.Eval(ctx, row)
 		if err != nil {
 			return nil, err
 		}
 		if value == nil {
-			return nil, errors.New("array is not a valid oidvector")
+			return nil, errors.Errorf("array is not a valid %s", targetType.Name())
 		}
 		if _, nested := value.([]any); nested {
-			return nil, errors.New("array is not a valid oidvector")
+			return nil, errors.Errorf("array is not a valid %s", targetType.Name())
 		}
 		sourceType, ok := child.Type(ctx).(*pgtypes.DoltgresType)
 		if !ok {
-			return nil, errors.New("array is not a valid oidvector")
+			return nil, errors.Errorf("array is not a valid %s", targetType.Name())
 		}
-		cast, err := castsColl.GetImplicitCast(ctx, sourceType, pgtypes.Oid)
+		cast, err := castsColl.GetExplicitCast(ctx, sourceType, elementType)
 		if err != nil {
 			return nil, err
 		}
 		if !cast.ID.IsValid() {
-			return nil, errors.New("array is not a valid oidvector")
+			return nil, errors.Errorf("cannot cast type %s to %s", sourceType.Name(), elementType.Name())
 		}
-		result[i], err = cast.Eval(ctx, value, sourceType, pgtypes.Oid)
+		result[i], err = cast.Eval(ctx, value, sourceType, elementType)
 		if err != nil {
 			return nil, err
 		}

--- a/server/expression/explicit_cast.go
+++ b/server/expression/explicit_cast.go
@@ -75,8 +75,13 @@ func (c *ExplicitCast) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 	if !c.castToType.IsResolvedType() {
 		return nil, errors.Errorf("cannot call ExplicitCast.Eval with unresolved cast to type: %s", c.castToType.String())
 	}
-	if array, ok := c.sqlChild.(*Array); ok && c.castToType.ID == pgtypes.Oidvector.ID {
-		return array.evalOidvectorCast(ctx, row)
+	baseCastToType := checkForDomainType(c.castToType)
+	if array, ok := c.sqlChild.(*Array); ok && baseCastToType.IsVectorType() {
+		castResult, err := array.evalVectorCast(ctx, row, baseCastToType)
+		if err != nil {
+			return nil, err
+		}
+		return c.applyDomainConstraints(ctx, castResult)
 	}
 
 	val, err := c.sqlChild.Eval(ctx, row)
@@ -95,7 +100,6 @@ func (c *ExplicitCast) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 		sourceType = gmsCast.DoltgresType(ctx)
 	}
 
-	baseCastToType := checkForDomainType(c.castToType)
 	castsColl, err := core.GetCastsCollectionFromContext(ctx, "")
 	if err != nil {
 		return nil, err
@@ -111,11 +115,8 @@ func (c *ExplicitCast) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 		)
 	}
 	if val == nil {
-		if c.castToType.TypType == pgtypes.TypeType_Domain && !c.domainNullable {
-			return nil, pgtypes.ErrDomainDoesNotAllowNullValues.New(c.castToType.Name())
-		}
 		if !cast.Function.IsValid() {
-			return nil, nil
+			return c.applyDomainConstraints(ctx, nil)
 		}
 	}
 	castResult, err := cast.Eval(ctx, val, sourceType, c.castToType)
@@ -133,18 +134,26 @@ func (c *ExplicitCast) Eval(ctx *sql.Context, row sql.Row) (any, error) {
 		}
 	}
 
-	if c.castToType.TypType == pgtypes.TypeType_Domain {
-		for _, check := range c.domainChecks {
-			res, err := sql.EvaluateCondition(ctx, check.Expr, sql.Row{castResult})
-			if err != nil {
-				return nil, err
-			}
-			if sql.IsFalse(res) {
-				return nil, pgtypes.ErrDomainValueViolatesCheckConstraint.New(c.castToType.Name(), check.Name)
-			}
+	return c.applyDomainConstraints(ctx, castResult)
+}
+
+// applyDomainConstraints enforces the NOT NULL and CHECK constraints attached to a domain cast.
+func (c *ExplicitCast) applyDomainConstraints(ctx *sql.Context, castResult any) (any, error) {
+	if c.castToType.TypType != pgtypes.TypeType_Domain {
+		return castResult, nil
+	}
+	if castResult == nil && !c.domainNullable {
+		return nil, pgtypes.ErrDomainDoesNotAllowNullValues.New(c.castToType.Name())
+	}
+	for _, check := range c.domainChecks {
+		res, err := sql.EvaluateCondition(ctx, check.Expr, sql.Row{castResult})
+		if err != nil {
+			return nil, err
+		}
+		if sql.IsFalse(res) {
+			return nil, pgtypes.ErrDomainValueViolatesCheckConstraint.New(c.castToType.Name(), check.Name)
 		}
 	}
-
 	return castResult, nil
 }
 

--- a/server/types/type.go
+++ b/server/types/type.go
@@ -787,6 +787,11 @@ func (t *DoltgresType) IsArrayCategory() bool {
 	return t.TypCategory == TypeCategory_ArrayTypes
 }
 
+// IsVectorType returns whether the type is one of PostgreSQL's legacy array-compatible vector types.
+func (t *DoltgresType) IsVectorType() bool {
+	return t.ID == Int16vector.ID || t.ID == Oidvector.ID
+}
+
 // IsCompositeType returns true if the type is a composite type, such as an anonymous record, or a
 // user-created composite type.
 func (t *DoltgresType) IsCompositeType() bool {

--- a/testing/go/types_test.go
+++ b/testing/go/types_test.go
@@ -2829,8 +2829,50 @@ var typesTests = []ScriptTest{
 		SetUpScript: []string{
 			"CREATE TABLE t_int2vector (id INTEGER primary key, v1 int2vector);",
 			"INSERT INTO t_int2vector VALUES (1, '1 2 3'), (2, '6 7 8 9');",
+			"CREATE TABLE t_int2_array (v int2[]);",
+			"INSERT INTO t_int2_array VALUES (ARRAY[1::int2]);",
 		},
 		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT ARRAY[1, 2]::int2vector;",
+				Expected: []sql.Row{{"1 2"}},
+			},
+			{
+				Query:    "SELECT ARRAY[1::bigint, 2::bigint]::int2vector;",
+				Expected: []sql.Row{{"1 2"}},
+			},
+			{
+				Query:    "SELECT ARRAY[1.0::numeric, 2.0::numeric]::int2vector;",
+				Expected: []sql.Row{{"1 2"}},
+			},
+			{
+				Query:       "SELECT ARRAY[1, NULL]::int2vector;",
+				ExpectedErr: "array is not a valid int2vector",
+			},
+			{
+				Query:       "SELECT ARRAY[ARRAY[1]]::int2vector;",
+				ExpectedErr: "array is not a valid int2vector",
+			},
+			{
+				Query:       "SELECT NULL::int2[]::int2vector;",
+				ExpectedErr: "cast from `smallint[]` to `int2vector` does not exist",
+			},
+			{
+				Query:       "SELECT ARRAY[]::int2[]::int2vector;",
+				ExpectedErr: "cast from `smallint[]` to `int2vector` does not exist",
+			},
+			{
+				Query:       "SELECT (ARRAY[1::int2]::int2[])::int2vector;",
+				ExpectedErr: "cast from `smallint[]` to `int2vector` does not exist",
+			},
+			{
+				Query:       "SELECT v::int2vector FROM t_int2_array;",
+				ExpectedErr: "cast from `smallint[]` to `int2vector` does not exist",
+			},
+			{
+				Query:       "SELECT (ARRAY[1::int2] || ARRAY[2::int2])::int2vector;",
+				ExpectedErr: "cast from `smallint[]` to `int2vector` does not exist",
+			},
 			{
 				Query: "SELECT * FROM t_int2vector ORDER BY id;",
 				Expected: []sql.Row{
@@ -2866,6 +2908,40 @@ var typesTests = []ScriptTest{
 				Skip:     true,
 				Query:    `SELECT unnest(unnest(v1)) FROM t_int2vector ORDER BY id;`,
 				Expected: []sql.Row{{1}, {2}, {3}, {4}},
+			},
+		},
+	},
+	{
+		Name: "Domains over vector types",
+		SetUpScript: []string{
+			"CREATE DOMAIN two_int2vector AS int2vector CHECK (array_length(VALUE, 1) = 2);",
+			"CREATE DOMAIN nonnull_oidvector AS oidvector NOT NULL CHECK (array_length(VALUE, 1) <= 2);",
+			"CREATE DOMAIN null_rejecting_int2vector AS int2vector CHECK (VALUE IS NOT NULL);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT ARRAY[1, 2]::two_int2vector;",
+				Expected: []sql.Row{{"1 2"}},
+			},
+			{
+				Query:       "SELECT ARRAY[1]::two_int2vector;",
+				ExpectedErr: `constraint "two_int2vector_check"`,
+			},
+			{
+				Query:    "SELECT ARRAY[23::oid, 25::oid]::nonnull_oidvector;",
+				Expected: []sql.Row{{"23 25"}},
+			},
+			{
+				Query:       "SELECT ARRAY[23::oid, 25::oid, 26::oid]::nonnull_oidvector;",
+				ExpectedErr: `constraint "nonnull_oidvector_check"`,
+			},
+			{
+				Query:       "SELECT NULL::nonnull_oidvector;",
+				ExpectedErr: "domain nonnull_oidvector does not allow null values",
+			},
+			{
+				Query:       "SELECT NULL::null_rejecting_int2vector;",
+				ExpectedErr: `constraint "null_rejecting_int2vector_check"`,
 			},
 		},
 	},


### PR DESCRIPTION
Generalizes PostgreSQL-compatible direct `ARRAY[...]` constructor casts across `oidvector` and `int2vector`, using each vector’s element type and explicit cast context.

Preserves PostgreSQL’s rejection of general array-expression-to-vector casts and applies domain constraints after vector construction.

Follow-up to #3177