### PR TITLE
Reject DISTINCT window aggregates

### DIFF
--- a/server/functions/framework/compiled_aggregate_function.go
+++ b/server/functions/framework/compiled_aggregate_function.go
@@ -98,6 +98,12 @@ func (c *CompiledAggregateFunction) WithChildren(ctx *sql.Context, children ...s
 
 	// We have to re-resolve here, since the change in children may require it (e.g. we have more type info than we did)
 	nc := newCompiledAggregateFunctionInternal(ctx, c.Name, children[:numArgs], c.overloads, c.fnOverloads)
+	nc.distinctWindow = c.distinctWindow
+	if nc.distinctWindow != nil {
+		if err := nc.distinctWindowError(); err != nil {
+			nc.stashedErr = err
+		}
+	}
 	// Preserve the aggregate/window identity assigned by the planbuilder: a later analyzer pass that
 	// rebuilds this expression via WithChildren (e.g. a generic bottom-up transform) must not silently
 	// lose the WithId/WithWindow state that was already bound onto c.

--- a/server/functions/framework/compiled_function.go
+++ b/server/functions/framework/compiled_function.go
@@ -28,6 +28,8 @@ import (
 	"github.com/dolthub/doltgresql/core/casts"
 	"github.com/dolthub/doltgresql/core/id"
 	procedures2 "github.com/dolthub/doltgresql/core/procedures"
+	"github.com/dolthub/doltgresql/postgres/parser/pgcode"
+	"github.com/dolthub/doltgresql/postgres/parser/pgerror"
 	"github.com/dolthub/doltgresql/server/extensions"
 	"github.com/dolthub/doltgresql/server/plpgsql"
 	pgtypes "github.com/dolthub/doltgresql/server/types"
@@ -45,16 +47,23 @@ type Function interface {
 
 // CompiledFunction is an expression that represents a fully-analyzed PostgreSQL function.
 type CompiledFunction struct {
-	Name          string
-	Arguments     []sql.Expression
-	IsOperator    bool
-	overloads     *Overloads
-	fnOverloads   []Overload
-	overload      overloadMatch
-	originalTypes []*pgtypes.DoltgresType
-	callResolved  []*pgtypes.DoltgresType
-	runner        sql.StatementRunner
-	stashedErr    error
+	Name           string
+	Arguments      []sql.Expression
+	IsOperator     bool
+	overloads      *Overloads
+	fnOverloads    []Overload
+	overload       overloadMatch
+	originalTypes  []*pgtypes.DoltgresType
+	callResolved   []*pgtypes.DoltgresType
+	runner         sql.StatementRunner
+	stashedErr     error
+	distinctWindow *distinctWindowCall
+}
+
+// distinctWindowCall preserves the parsed function identity until overload resolution completes.
+type distinctWindowCall struct {
+	schema string
+	name   string
 }
 
 var _ sql.FunctionExpression = (*CompiledFunction)(nil)
@@ -62,6 +71,31 @@ var _ sql.NonDeterministicExpression = (*CompiledFunction)(nil)
 var _ procedures.InterpreterExpr = (*CompiledFunction)(nil)
 var _ sql.RowIterExpression = (*CompiledFunction)(nil)
 var _ sql.ExtendedTableFunction = (*CompiledFunction)(nil)
+var _ sql.DistinctWindowFunctionValidator = (*CompiledFunction)(nil)
+
+// ValidateDistinctWindow returns PostgreSQL's error for DISTINCT after overload resolution identifies the function class.
+func (c *CompiledFunction) ValidateDistinctWindow(schema, name string) error {
+	c.distinctWindow = &distinctWindowCall{schema: schema, name: name}
+	return c.distinctWindowError()
+}
+
+// distinctWindowError classifies DISTINCT window usage from the selected overload.
+func (c *CompiledFunction) distinctWindowError() error {
+	if !c.overload.Valid() {
+		return nil
+	}
+	functionName := c.distinctWindow.name
+	if c.distinctWindow.schema != "" {
+		functionName = c.distinctWindow.schema + "." + c.distinctWindow.name
+	}
+	switch c.overload.Function().(type) {
+	case AggregateFunctionInterface, WindowFunctionInterface:
+		return pgerror.New(pgcode.FeatureNotSupported, "DISTINCT is not implemented for window functions")
+	default:
+		return pgerror.Newf(pgcode.WrongObjectType,
+			"DISTINCT specified, but %s is not an aggregate function", functionName)
+	}
+}
 
 // NewCompiledFunction returns a newly compiled function.
 func NewCompiledFunction(ctx *sql.Context, name string, args []sql.Expression, functions *Overloads, isOperator bool) *CompiledFunction {
@@ -725,7 +759,14 @@ func (c *CompiledFunction) WithChildren(ctx *sql.Context, children ...sql.Expres
 	}
 
 	// We have to re-resolve here, since the change in children may require it (e.g. we have more type info than we did)
-	return newCompiledFunctionInternal(ctx, c.Name, children, c.overloads, c.fnOverloads, c.IsOperator, c.runner), nil
+	nc := newCompiledFunctionInternal(ctx, c.Name, children, c.overloads, c.fnOverloads, c.IsOperator, c.runner)
+	nc.distinctWindow = c.distinctWindow
+	if nc.distinctWindow != nil {
+		if err := nc.distinctWindowError(); err != nil {
+			nc.stashedErr = err
+		}
+	}
+	return nc, nil
 }
 
 // SetStatementRunner implements the interface analyzer.Interpreter.

--- a/server/functions/framework/compiled_window_function.go
+++ b/server/functions/framework/compiled_window_function.go
@@ -92,6 +92,12 @@ func (c *CompiledWindowFunction) WithChildren(ctx *sql.Context, children ...sql.
 
 	// We have to re-resolve here, since the change in children may require it (e.g. we have more type info than we did)
 	nc := newCompiledWindowFunctionInternal(ctx, c.Name, children[:numArgs], c.overloads, c.fnOverloads)
+	nc.distinctWindow = c.distinctWindow
+	if nc.distinctWindow != nil {
+		if err := nc.distinctWindowError(); err != nil {
+			nc.stashedErr = err
+		}
+	}
 	// Preserve the identity assigned by the planbuilder: a later analyzer pass that rebuilds this
 	// expression via WithChildren (e.g. a generic bottom-up transform) must not silently lose the
 	// WithId/WithWindow state that was already bound onto c.

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -139,6 +139,10 @@ func TestAggregateFunctions(t *testing.T) {
 				`CREATE TABLE json_agg_stored (id int4 primary key, amount numeric(40,20), payload json)`,
 				`INSERT INTO json_agg_stored VALUES (1, 12345678901234567890.12345678901234567890, '{"kind":"stored"}')`,
 				`CREATE DOMAIN json_agg_positive_int AS int4 CHECK (VALUE > 0)`,
+				`CREATE FUNCTION json_agg_window_step(state int4, value int4) RETURNS int4 LANGUAGE SQL IMMUTABLE AS 'SELECT state + value'`,
+				`CREATE AGGREGATE json_agg_window_custom (int4) (SFUNC = json_agg_window_step, STYPE = int4, INITCOND = '0')`,
+				`CREATE SCHEMA json_agg_collision`,
+				`CREATE FUNCTION json_agg_collision.json_agg(value int4) RETURNS int4 LANGUAGE SQL IMMUTABLE AS 'SELECT value'`,
 			},
 			Assertions: []ScriptTestAssertion{
 				{
@@ -246,6 +250,36 @@ func TestAggregateFunctions(t *testing.T) {
 				{
 					Query:    `SELECT json_agg(DISTINCT v) FROM (VALUES (1),(1),(NULL),(NULL)) AS t(v);`,
 					Expected: []sql.Row{{`[1, null]`}},
+				},
+				{
+					Query:           `SELECT json_agg(DISTINCT v) OVER (PARTITION BY p ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM (VALUES ('a',1,1),('a',2,2),('a',3,2),('b',1,NULL),('b',2,2),('b',3,2)) AS t(p,id,v);`,
+					ExpectedErr:     `DISTINCT is not implemented for window functions`,
+					ExpectedErrCode: "0A000",
+				},
+				{
+					Query:           `SELECT json_agg(DISTINCT v) OVER (ORDER BY id ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) FROM (VALUES (1,1),(2,NULL)) AS t(id,v);`,
+					ExpectedErr:     `DISTINCT is not implemented for window functions`,
+					ExpectedErrCode: "0A000",
+				},
+				{
+					Query:           `SELECT sum(DISTINCT v) OVER () FROM (VALUES (1),(1),(NULL)) AS t(v);`,
+					ExpectedErr:     `DISTINCT is not implemented for window functions`,
+					ExpectedErrCode: "0A000",
+				},
+				{
+					Query:           `SELECT abs(DISTINCT v) OVER () FROM (VALUES (-1)) AS t(v);`,
+					ExpectedErr:     `DISTINCT specified, but abs is not an aggregate function`,
+					ExpectedErrCode: "42809",
+				},
+				{
+					Query:           `SELECT json_agg_window_custom(DISTINCT v) OVER () FROM (VALUES (1),(1)) AS t(v);`,
+					ExpectedErr:     `DISTINCT is not implemented for window functions`,
+					ExpectedErrCode: "0A000",
+				},
+				{
+					Query:           `SELECT json_agg_collision.json_agg(DISTINCT v) OVER () FROM (VALUES (1)) AS t(v);`,
+					ExpectedErr:     `DISTINCT specified, but json_agg_collision.json_agg is not an aggregate function`,
+					ExpectedErrCode: "42809",
 				},
 			},
 		},


### PR DESCRIPTION
Match PostgreSQL by rejecting DISTINCT window aggregates with SQLSTATE 0A000 after resolving the exact function overload, instead of silently ignoring DISTINCT. Preserve PostgreSQL scalar-function diagnostics, including user-defined and schema-qualified name collisions.

Depends on: [go-mysql-server #3732](https://github.com/dolthub/go-mysql-server/pull/3732)