### PR TITLE
Preserve the comparison operator when serializing ANY/SOME/ALL

### DIFF
--- a/server/expression/any.go
+++ b/server/expression/any.go
@@ -355,17 +355,26 @@ func (a *AnyExpr) WithResolvedChildren(ctx context.Context, children []any) (any
 	return a.WithChildren(ctx.(*sql.Context), left, right)
 }
 
-// String implements the fmt.Stringer interface.
+// operatorString returns the comparison operator as it should appear in serialized output. The parser spells
+// not-equals as `!=`, so we round-trip through the operator framework to get Postgres' canonical spelling (`<>`),
+// falling back to the operator as written for anything the framework doesn't recognize.
+func (a *AnyExpr) operatorString() string {
+	if op, err := framework.GetOperatorFromString(a.subOperator); err == nil {
+		return op.String()
+	}
+	return a.subOperator
+}
+
 func (a *AnyExpr) String() string {
 	if a.leftExpr == nil || a.rightExpr == nil {
-		return fmt.Sprintf("? %s (?)", a.name)
+		return fmt.Sprintf("? %s %s (?)", a.operatorString(), a.name)
 	}
-	return fmt.Sprintf("%s = %s (%s)", a.leftExpr, a.name, a.rightExpr)
+	return fmt.Sprintf("%s %s %s (%s)", a.leftExpr, a.operatorString(), a.name, a.rightExpr)
 }
 
 // DebugString implements the Expression interface.
 func (a *AnyExpr) DebugString(ctx *sql.Context) string {
-	return fmt.Sprintf("%s %s (%s)", sql.DebugString(ctx, a.leftExpr), a.name, sql.DebugString(ctx, a.rightExpr))
+	return fmt.Sprintf("%s %s %s (%s)", sql.DebugString(ctx, a.leftExpr), a.operatorString(), a.name, sql.DebugString(ctx, a.rightExpr))
 }
 
 // anySubqueryWithChildren resolves the comparison functions for a plan.Subquery.

--- a/testing/go/all_quantifier_test.go
+++ b/testing/go/all_quantifier_test.go
@@ -308,3 +308,69 @@ WHERE  nsp.oid = 2200::OID;`,
 		},
 	},
 }
+
+// TestAnyAllSerialization verifies that the serialized form of an ANY/SOME/ALL expression preserves the comparison
+// operator the user wrote. Check constraints are stored as this serialized text and re-parsed on every write, so
+// hardcoding `=` silently rewrote the constraint.
+func TestAnyAllSerialization(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			// Note: the `<name> CHECK <expr> ENFORCED` shape of these results is a separate pg_get_constraintdef
+			// defect (Postgres renders `CHECK (<expr>)`); what matters here is the comparison operator inside.
+			Name: "ANY/ALL check constraint round trip",
+			SetUpScript: []string{
+				`CREATE TABLE t_all (id int, v text, CONSTRAINT ck_all CHECK (v <> ALL (ARRAY['no','nope'])));`,
+				`CREATE TABLE t_any (id int, v text, CONSTRAINT ck_any CHECK (v <> ANY (ARRAY['no','nope'])));`,
+				`CREATE TABLE t_some (id int, v int, CONSTRAINT ck_some CHECK (v > SOME (ARRAY[1,2])));`,
+				`CREATE TABLE t_eq (id int, v text, CONSTRAINT ck_eq CHECK (v = ANY (ARRAY['yes','yep'])));`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT pg_get_constraintdef(oid) FROM pg_catalog.pg_constraint WHERE conname = 'ck_all';`,
+					Expected: []sql.Row{{`ck_all CHECK "v" <> ALL (ARRAY['no', 'nope']) ENFORCED`}},
+				},
+				{
+					Query:    `SELECT pg_get_constraintdef(oid) FROM pg_catalog.pg_constraint WHERE conname = 'ck_any';`,
+					Expected: []sql.Row{{`ck_any CHECK "v" <> ANY (ARRAY['no', 'nope']) ENFORCED`}},
+				},
+				{
+					Query:    `SELECT pg_get_constraintdef(oid) FROM pg_catalog.pg_constraint WHERE conname = 'ck_some';`,
+					Expected: []sql.Row{{`ck_some CHECK "v" > SOME (ARRAY[1, 2]) ENFORCED`}},
+				},
+				{
+					Query:    `SELECT pg_get_constraintdef(oid) FROM pg_catalog.pg_constraint WHERE conname = 'ck_eq';`,
+					Expected: []sql.Row{{`ck_eq CHECK "v" = ANY (ARRAY['yes', 'yep']) ENFORCED`}},
+				},
+				{
+					// The stored constraint is re-parsed on every write, so a row the constraint permits must insert.
+					Query:    `INSERT INTO t_all VALUES (1, 'ok');`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:       `INSERT INTO t_all VALUES (2, 'no');`,
+					ExpectedErr: "Check constraint",
+				},
+				{
+					Query:    `INSERT INTO t_any VALUES (1, 'no');`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `INSERT INTO t_some VALUES (1, 2);`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:       `INSERT INTO t_some VALUES (2, 1);`,
+					ExpectedErr: "Check constraint",
+				},
+				{
+					Query:    `INSERT INTO t_eq VALUES (1, 'yes');`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:       `INSERT INTO t_eq VALUES (2, 'nope');`,
+					ExpectedErr: "Check constraint",
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
AnyExpr.String() hardcoded `=` instead of using the operator the user wrote. Check constraints are persisted as this serialized text and re-parsed on every write, so `v <> ALL (ARRAY[...])` was stored and then enforced as `v = ALL (ARRAY[...])` — inverting the constraint so it rejected every row. `<> ANY` was corrupted the same way.

String() (both the resolved and unresolved branches) and DebugString now render the operator, canonicalized through the operator framework so the parser's `!=` is written as Postgres' `<>`.