### PR TITLE
Support a RECORD variable as the INTO target of a plpgsql statement

### DIFF
--- a/server/functions/framework/interpreted_function.go
+++ b/server/functions/framework/interpreted_function.go
@@ -267,9 +267,14 @@ func (InterpretedFunction) ApplyBindings(ctx *sql.Context, stack plpgsql.Interpr
 	}
 	newStmt = stmt
 	for i, bindingName := range bindings {
-		variable := stack.GetVariable(bindingName)
+		variable, err := stack.GetVariableWithError(bindingName)
+		if err != nil {
+			// Only a name that matches no variable at all leaves the caller free to try something else; a
+			// bad field on a variable that does exist is a real error that has to surface.
+			return newStmt, !plpgsql.ErrVariableNotFound.Is(err), err
+		}
 		if variable.Type == nil {
-			return newStmt, false, fmt.Errorf("variable `%s` could not be found", bindingName)
+			return newStmt, false, plpgsql.ErrVariableNotFound.New(bindingName)
 		}
 		var formattedVar string
 		if *variable.Value != nil {

--- a/server/plpgsql/interpreter_logic.go
+++ b/server/plpgsql/interpreter_logic.go
@@ -236,6 +236,23 @@ func call(ctx *sql.Context, iFunc InterpretedFunction, stack InterpreterStack) (
 					return nil, err
 				}
 			}
+		case OpCode_ExecuteInto:
+			// The target is a RECORD, which takes on the shape of the query's result columns.
+			schema, rows, err := iFunc.QueryMultiReturn(ctx, stack, operation.PrimaryData, operation.SecondaryData)
+			if err != nil {
+				return nil, err
+			}
+			// Without STRICT, Postgres keeps the first row and discards the rest, and leaves every field NULL
+			// when there are no rows at all.
+			var row sql.Row
+			if len(rows) > 0 {
+				row = rows[0]
+			}
+			if err = stack.UpdateRecord(operation.Target, schema, row); err != nil {
+				return nil, err
+			}
+		case OpCode_DeclareRecord:
+			stack.NewRecord(operation.Target, nil, nil)
 		case OpCode_Get:
 			// TODO: implement
 		case OpCode_Goto:

--- a/server/plpgsql/interpreter_operation.go
+++ b/server/plpgsql/interpreter_operation.go
@@ -21,27 +21,29 @@ type OpCode uint16
 const (
 	// New OpCode values MUST be added to the END of this list!
 	// Function OpCodes are persisted to disk, so these values MUST be stable across Doltgres versions.
-	OpCode_Alias        OpCode = 0  // https://www.postgresql.org/docs/15/plpgsql-declarations.html#PLPGSQL-DECLARATION-ALIAS
-	OpCode_Assign       OpCode = 1  // https://www.postgresql.org/docs/15/plpgsql-statements.html#PLPGSQL-STATEMENTS-ASSIGNMENT
-	OpCode_Case         OpCode = 2  // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-CONDITIONALS
-	OpCode_Declare      OpCode = 3  // https://www.postgresql.org/docs/15/plpgsql-declarations.html
-	OpCode_DeleteInto   OpCode = 4  // https://www.postgresql.org/docs/15/plpgsql-statements.html
-	OpCode_Exception    OpCode = 5  // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-ERROR-TRAPPING
-	OpCode_Execute      OpCode = 6  // Executing a standard SQL statement (expects no rows returned unless Target is specified)
-	OpCode_Get          OpCode = 7  // https://www.postgresql.org/docs/15/plpgsql-statements.html#PLPGSQL-STATEMENTS-DIAGNOSTICS
-	OpCode_Goto         OpCode = 8  // All control-flow structures can be represented using Goto
-	OpCode_If           OpCode = 9  // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-CONDITIONALS
-	OpCode_InsertInto   OpCode = 10 // https://www.postgresql.org/docs/15/plpgsql-statements.html
-	OpCode_Perform      OpCode = 11 // https://www.postgresql.org/docs/15/plpgsql-statements.html
-	OpCode_Raise        OpCode = 12 // https://www.postgresql.org/docs/15/plpgsql-errors-and-messages.html
-	OpCode_Return       OpCode = 13 // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-STATEMENTS-RETURNING
-	OpCode_ScopeBegin   OpCode = 14 // This is used for scope control, specific to Doltgres
-	OpCode_ScopeEnd     OpCode = 15 // This is used for scope control, specific to Doltgres
-	OpCode_SelectInto   OpCode = 16 // https://www.postgresql.org/docs/15/plpgsql-statements.html
-	OpCode_UpdateInto   OpCode = 17 // https://www.postgresql.org/docs/15/plpgsql-statements.html
-	OpCode_ReturnQuery  OpCode = 18 // https://www.postgresql.org/docs/current/plpgsql-control-structures.html#PLPGSQL-STATEMENTS-RETURNING-RETURN-NEXT
-	OpCode_ForQueryInit OpCode = 19 // Initialize a cursor for FOR record IN query LOOP
-	OpCode_ForQueryNext OpCode = 20 // Advance cursor and assign next row to record, or jump to exit
+	OpCode_Alias         OpCode = 0  // https://www.postgresql.org/docs/15/plpgsql-declarations.html#PLPGSQL-DECLARATION-ALIAS
+	OpCode_Assign        OpCode = 1  // https://www.postgresql.org/docs/15/plpgsql-statements.html#PLPGSQL-STATEMENTS-ASSIGNMENT
+	OpCode_Case          OpCode = 2  // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-CONDITIONALS
+	OpCode_Declare       OpCode = 3  // https://www.postgresql.org/docs/15/plpgsql-declarations.html
+	OpCode_DeleteInto    OpCode = 4  // https://www.postgresql.org/docs/15/plpgsql-statements.html
+	OpCode_Exception     OpCode = 5  // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-ERROR-TRAPPING
+	OpCode_Execute       OpCode = 6  // Executing a standard SQL statement (expects no rows returned unless Target is specified)
+	OpCode_Get           OpCode = 7  // https://www.postgresql.org/docs/15/plpgsql-statements.html#PLPGSQL-STATEMENTS-DIAGNOSTICS
+	OpCode_Goto          OpCode = 8  // All control-flow structures can be represented using Goto
+	OpCode_If            OpCode = 9  // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-CONDITIONALS
+	OpCode_InsertInto    OpCode = 10 // https://www.postgresql.org/docs/15/plpgsql-statements.html
+	OpCode_Perform       OpCode = 11 // https://www.postgresql.org/docs/15/plpgsql-statements.html
+	OpCode_Raise         OpCode = 12 // https://www.postgresql.org/docs/15/plpgsql-errors-and-messages.html
+	OpCode_Return        OpCode = 13 // https://www.postgresql.org/docs/15/plpgsql-control-structures.html#PLPGSQL-STATEMENTS-RETURNING
+	OpCode_ScopeBegin    OpCode = 14 // This is used for scope control, specific to Doltgres
+	OpCode_ScopeEnd      OpCode = 15 // This is used for scope control, specific to Doltgres
+	OpCode_SelectInto    OpCode = 16 // https://www.postgresql.org/docs/15/plpgsql-statements.html
+	OpCode_UpdateInto    OpCode = 17 // https://www.postgresql.org/docs/15/plpgsql-statements.html
+	OpCode_ReturnQuery   OpCode = 18 // https://www.postgresql.org/docs/current/plpgsql-control-structures.html#PLPGSQL-STATEMENTS-RETURNING-RETURN-NEXT
+	OpCode_ForQueryInit  OpCode = 19 // Initialize a cursor for FOR record IN query LOOP
+	OpCode_ForQueryNext  OpCode = 20 // Advance cursor and assign next row to record, or jump to exit
+	OpCode_DeclareRecord OpCode = 21 // Declares a RECORD variable, which has no shape until it is assigned
+	OpCode_ExecuteInto   OpCode = 22 // Executing a SQL statement whose first result row is assigned to a RECORD
 	// New OpCode values MUST be added to the END of this list!
 	// Function OpCodes are persisted to disk, so these values MUST be stable across Doltgres versions.
 )

--- a/server/plpgsql/interpreter_stack.go
+++ b/server/plpgsql/interpreter_stack.go
@@ -19,10 +19,21 @@ import (
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"gopkg.in/src-d/go-errors.v1"
 
 	pgtypes "github.com/dolthub/doltgresql/server/types"
 	"github.com/dolthub/doltgresql/utils"
 )
+
+// ErrRecordNotAssigned is returned when a field is read from a RECORD variable that has not been assigned yet,
+// and therefore has no shape to read a field from.
+var ErrRecordNotAssigned = errors.NewKind(`record "%s" is not assigned yet`)
+
+// ErrRecordHasNoField is returned when a field is read from a RECORD variable that has no such field.
+var ErrRecordHasNoField = errors.NewKind(`record "%s" has no field "%s"`)
+
+// ErrVariableNotFound is returned when a referenced variable does not exist on the stack.
+var ErrVariableNotFound = errors.NewKind("variable `%s` could not be found")
 
 // cursorState holds the result set for a FOR record IN query LOOP cursor.
 type cursorState struct {
@@ -38,6 +49,9 @@ type interpreterVariable struct {
 	Record sql.Schema // TODO: all records carry their type information alongside the value, so this is redundant
 	Type   *pgtypes.DoltgresType
 	Value  any
+	// IsRecord marks a variable declared as RECORD (or a trigger's NEW/OLD). Such a variable has no shape
+	// until something is assigned to it, at which point Record and Value are set together.
+	IsRecord bool
 }
 
 // InterpreterVariableReference is a reference to a variable that lives on the stack. If the type is not null, then it
@@ -107,15 +121,26 @@ func (is *InterpreterStack) GetCurrentLabel() string {
 	return ""
 }
 
-// GetVariable traverses the stack (starting from the top) to find a variable with a matching name. Returns nil if no
-// variable was found.
+// GetVariable traverses the stack (starting from the top) to find a variable with a matching name. Returns a
+// reference with a nil type if no variable was found. Use GetVariableWithError when the reason for the failure
+// matters.
 func (is *InterpreterStack) GetVariable(name string) InterpreterVariableReference {
+	ref, _ := is.GetVariableWithError(name)
+	return ref
+}
+
+// GetVariableWithError behaves like GetVariable, but explains why the reference could not be resolved rather
+// than returning an empty reference.
+func (is *InterpreterStack) GetVariableWithError(name string) (InterpreterVariableReference, error) {
 	// TODO: handle nested record access
+	fullName := name
 	fieldName := ""
 	if strings.Count(name, ".") == 1 {
 		splitName := strings.Split(name, ".")
 		name = splitName[0]
-		fieldName = splitName[1]
+		// A field may be written as a quoted identifier (`blocker."id"`), which reaches us with its quotes
+		// still attached. Field lookup is case-insensitive here, so the quotes are all that need removing.
+		fieldName = strings.Trim(splitName[1], `"`)
 	}
 	for i := 0; i < is.stack.Len(); i++ {
 		if iv, ok := is.stack.PeekDepth(i).variables[name]; ok {
@@ -123,36 +148,54 @@ func (is *InterpreterStack) GetVariable(name string) InterpreterVariableReferenc
 				return InterpreterVariableReference{
 					Type:  iv.Type,
 					Value: &iv.Value,
-				}
+				}, nil
 			} else if len(iv.Record) > 0 {
-				fieldIdx := iv.Record.IndexOf(fieldName, iv.Record[0].Source)
+				fieldIdx := recordFieldIndex(iv.Record, fieldName)
 				if fieldIdx == -1 {
-					// TODO: implement this as a proper error for missing record field rather than the generic "variable not found"
-					return InterpreterVariableReference{}
+					return InterpreterVariableReference{}, ErrRecordHasNoField.New(name, fieldName)
+				}
+				fieldType, ok := iv.Record[fieldIdx].Type.(*pgtypes.DoltgresType)
+				if !ok {
+					return InterpreterVariableReference{}, fmt.Errorf(
+						"field `%s` of record `%s` does not have a Postgres type", fieldName, name)
 				}
 				return InterpreterVariableReference{
-					Type:  iv.Record[fieldIdx].Type.(*pgtypes.DoltgresType),
+					Type:  fieldType,
 					Value: &(iv.Value.(sql.Row)[fieldIdx]),
-				}
-			} else if iv.Type.IsCompositeType() {
+				}, nil
+			} else if iv.IsRecord {
+				// A record that has never been assigned has no shape, so there is no field to read.
+				return InterpreterVariableReference{}, ErrRecordNotAssigned.New(name)
+			} else if iv.Type != nil && iv.Type.IsCompositeType() {
 				for fieldIdx := range iv.Type.CompositeAttrs {
 					if iv.Type.CompositeAttrs[fieldIdx].Name == fieldName {
 						vals := iv.Value.([]pgtypes.RecordValue)
 						return InterpreterVariableReference{
 							Type:  vals[fieldIdx].Type.(*pgtypes.DoltgresType),
 							Value: &(vals[fieldIdx].Value),
-						}
+						}, nil
 					}
 				}
-				// The field could not be found
-				return InterpreterVariableReference{}
+				return InterpreterVariableReference{}, ErrRecordHasNoField.New(name, fieldName)
 			} else {
-				// Can't access fields on an empty record
-				return InterpreterVariableReference{}
+				return InterpreterVariableReference{}, fmt.Errorf(
+					"could not identify column `%s` in variable `%s`", fieldName, name)
 			}
 		}
 	}
-	return InterpreterVariableReference{}
+	return InterpreterVariableReference{}, ErrVariableNotFound.New(fullName)
+}
+
+// recordFieldIndex returns the index of the field named |fieldName| within |sch|, or -1 if there is no such
+// field. Unlike sql.Schema.IndexOf, the column's source is ignored, since a record's shape comes from the
+// output columns of whatever query was assigned to it and those may originate in different tables.
+func recordFieldIndex(sch sql.Schema, fieldName string) int {
+	for i, col := range sch {
+		if strings.EqualFold(col.Name, fieldName) {
+			return i
+		}
+	}
+	return -1
 }
 
 // ListVariables returns a map with the names of all variables. The attached slice represents field names for records.
@@ -174,19 +217,30 @@ func (is *InterpreterStack) ListVariables() map[string][]string {
 }
 
 // NewRecord creates a new record in the current scope. If a record with the same name exists in a previous scope, then
-// that record will be shadowed until the current scope exits.
+// that record will be shadowed until the current scope exits. A nil |sch| declares a record that has no shape yet,
+// which is what a `DECLARE r RECORD` produces until something is assigned to it. When |sch| is non-nil but |val| is
+// nil, the record has a shape whose every field is NULL, which is what a trigger's OLD record is on an INSERT.
 func (is *InterpreterStack) NewRecord(name string, sch sql.Schema, val sql.Row) {
-	// TODO: this is currently implemented only for the specific record types used in triggers: OLD and NEW
-	var newVal sql.Row
-	if val != nil {
-		newVal = make(sql.Row, len(val))
-		copy(newVal, val)
-	}
 	is.stack.Peek().variables[name] = &interpreterVariable{
-		Record: sch,
-		Type:   pgtypes.Trigger, // TODO: we need to implement the RECORD pseudotype and replace the TRIGGER type here
-		Value:  newVal,
+		Record:   sch,
+		Type:     pgtypes.Trigger, // TODO: we need to implement the RECORD pseudotype and replace the TRIGGER type here
+		Value:    copyRecordRow(sch, val),
+		IsRecord: true,
 	}
+}
+
+// copyRecordRow returns a copy of |val| for storage in a record. A nil |val| becomes an all-NULL row matching
+// |sch|, so that every field of a record with a known shape is addressable.
+func copyRecordRow(sch sql.Schema, val sql.Row) sql.Row {
+	if val == nil {
+		if len(sch) == 0 {
+			return nil
+		}
+		return make(sql.Row, len(sch))
+	}
+	newVal := make(sql.Row, len(val))
+	copy(newVal, val)
+	return newVal
 }
 
 // NewVariable creates a new variable in the current scope. If a variable with the same name exists in a previous scope,
@@ -313,14 +367,42 @@ func (is *InterpreterStack) CloseCursor(name string) {
 	delete(is.cursors, name)
 }
 
-// UpdateRecord finds the named variable and sets its schema and row value.
+// UpdateRecord finds the named variable and sets its schema and row value. A nil |val| gives the record the
+// shape of |schema| with every field NULL, which is what PostgreSQL does when an INTO query matches no rows.
 func (is *InterpreterStack) UpdateRecord(name string, schema sql.Schema, val sql.Row) error {
+	normalizedSchema, err := normalizeRecordSchema(schema)
+	if err != nil {
+		return err
+	}
 	for i := 0; i < is.stack.Len(); i++ {
 		if iv, ok := is.stack.PeekDepth(i).variables[name]; ok {
-			iv.Record = schema
-			iv.Value = val
+			iv.Record = normalizedSchema
+			iv.Value = copyRecordRow(normalizedSchema, val)
+			iv.IsRecord = true
 			return nil
 		}
 	}
 	return fmt.Errorf("record variable `%s` could not be found", name)
+}
+
+// normalizeRecordSchema returns |schema| with every column type converted to a DoltgresType. Query results can
+// carry plain GMS types (an aggregate such as `count(*)`, for example), but a record's fields are read back as
+// Doltgres values, so the types have to be converted before the schema is stored.
+func normalizeRecordSchema(schema sql.Schema) (sql.Schema, error) {
+	normalized := make(sql.Schema, len(schema))
+	for i, col := range schema {
+		if _, ok := col.Type.(*pgtypes.DoltgresType); ok {
+			normalized[i] = col
+			continue
+		}
+		// TODO: this only converts the type, not the value. See the same TODO in convertRowsToRecords.
+		doltgresType, err := pgtypes.FromGmsTypeToDoltgresType(col.Type)
+		if err != nil {
+			return nil, err
+		}
+		newCol := *col
+		newCol.Type = doltgresType
+		normalized[i] = &newCol
+	}
+	return normalized, nil
 }

--- a/server/plpgsql/json.go
+++ b/server/plpgsql/json.go
@@ -323,22 +323,18 @@ func (stmt *plpgSQL_stmt_assign) Convert() (Assignment, error) {
 // Convert converts the JSON statement into its output form.
 func (stmt *plpgSQL_stmt_call) Convert() (ExecuteSQL, error) {
 	var target string
+	var targetIsRecord bool
 	if !stmt.IsCall {
-		if stmt.Target.Row != nil {
-			names := make([]string, len(stmt.Target.Row.Fields))
-			for i, rowField := range stmt.Target.Row.Fields {
-				names[i] = rowField.Name
-			}
-			target = strings.Join(names, ",")
-		} else if stmt.Target.Variable != nil {
-			target = stmt.Target.Variable.RefName
-		} else {
-			return ExecuteSQL{}, errors.Errorf("unhandled datum type: %T", stmt.Target)
+		var err error
+		target, targetIsRecord, err = intoTarget(stmt.Target)
+		if err != nil {
+			return ExecuteSQL{}, err
 		}
 	}
 	return ExecuteSQL{
-		Statement: stmt.Expression.Expression.Query,
-		Target:    target,
+		Statement:      stmt.Expression.Expression.Query,
+		Target:         target,
+		TargetIsRecord: targetIsRecord,
 	}, nil
 }
 
@@ -437,48 +433,62 @@ func (stmt *plpgSQL_stmt_dynexecute) Convert() (DynamicExecute, error) {
 		params = append(params, param.Expr.Query)
 	}
 	var target string
+	var targetIsRecord bool
 	if stmt.Into {
-		switch {
-		case stmt.Target.Row != nil:
-			names := make([]string, len(stmt.Target.Row.Fields))
-			for i, rowField := range stmt.Target.Row.Fields {
-				names[i] = rowField.Name
-			}
-			target = strings.Join(names, ",")
-		case stmt.Target.Variable != nil:
-			target = stmt.Target.Variable.RefName
-		default:
-			return DynamicExecute{}, errors.Errorf("unhandled datum type: %T", stmt.Target)
+		var err error
+		target, targetIsRecord, err = intoTarget(stmt.Target)
+		if err != nil {
+			return DynamicExecute{}, err
 		}
 	}
 	query := strings.TrimSuffix(strings.TrimPrefix(stmt.Query.Expression.Query, "'"), "'")
 	return DynamicExecute{
-		Query:  query,
-		Params: params,
-		Target: target,
+		Query:          query,
+		Params:         params,
+		Target:         target,
+		TargetIsRecord: targetIsRecord,
 	}, nil
 }
 
 // Convert converts the JSON statement into its output form.
 func (stmt *plpgSQL_stmt_execsql) Convert() (ExecuteSQL, error) {
 	var target string
+	var targetIsRecord bool
 	if stmt.Into {
-		if stmt.Target.Row != nil {
-			names := make([]string, len(stmt.Target.Row.Fields))
-			for i, rowField := range stmt.Target.Row.Fields {
-				names[i] = rowField.Name
-			}
-			target = strings.Join(names, ",")
-		} else if stmt.Target.Variable != nil {
-			target = stmt.Target.Variable.RefName
-		} else {
-			return ExecuteSQL{}, errors.Errorf("unhandled datum type: %T", stmt.Target)
+		var err error
+		target, targetIsRecord, err = intoTarget(stmt.Target)
+		if err != nil {
+			return ExecuteSQL{}, err
 		}
 	}
 	return ExecuteSQL{
-		Statement: stmt.SQLStmt.Expr.Query,
-		Target:    target,
+		Statement:      stmt.SQLStmt.Expr.Query,
+		Target:         target,
+		TargetIsRecord: targetIsRecord,
 	}, nil
+}
+
+// intoTarget returns the name of the variable that an INTO clause writes to. A row target (which is what
+// PL/pgSQL builds for a list of scalar variables, or for a variable declared as %ROWTYPE) is returned as a
+// comma-separated list of its field names. A record target is returned by name, with |isRecord| set, since
+// a record takes on the shape of whatever is assigned to it rather than having one of its own.
+func intoTarget(target datum) (name string, isRecord bool, err error) {
+	switch {
+	case target.Row != nil:
+		names := make([]string, len(target.Row.Fields))
+		for i, rowField := range target.Row.Fields {
+			names[i] = rowField.Name
+		}
+		return strings.Join(names, ","), false, nil
+	case target.Variable != nil:
+		return target.Variable.RefName, false, nil
+	case target.Record != nil:
+		return target.Record.RefName, true, nil
+	default:
+		// The datum struct is a union of pointers, so printing its type here would only ever say
+		// "plpgsql.datum". Name the arms we do handle instead.
+		return "", false, errors.New("unhandled INTO target: expected a record, row, or variable")
+	}
 }
 
 // Convert converts the JSON statement into its output form.

--- a/server/plpgsql/json_convert.go
+++ b/server/plpgsql/json_convert.go
@@ -69,7 +69,20 @@ func jsonConvert(jsonBlock plpgSQL_block) (Block, error) {
 				Default:     v.Variable.Default.Var.Query,
 			})
 		default:
-			return Block{}, errors.Errorf("unhandled datum type: %T", v)
+			// The datum struct is a union of pointers, so printing its type here would only ever say
+			// "plpgsql.datum". Name the arms we do handle instead.
+			return Block{}, errors.New("unhandled declared variable: expected a record, record field, row, or variable")
+		}
+	}
+	// The NEW and OLD records of a trigger appear in the datum list like any other record, but they are
+	// supplied by the trigger invocation rather than declared by the function, so they must not be
+	// redeclared (which would shadow the supplied values with an empty record).
+	for _, triggerRecordNumber := range []int32{jsonBlock.NewVariableNumber, jsonBlock.OldVariableNumber} {
+		if triggerRecordNumber == 0 {
+			continue
+		}
+		if idx := triggerRecordNumber + offset; idx >= 0 && int(idx) < len(block.Records) {
+			block.Records[idx].IsTriggerRecord = true
 		}
 	}
 	var err error

--- a/server/plpgsql/statements.go
+++ b/server/plpgsql/statements.go
@@ -84,6 +84,11 @@ func (stmt Block) OperationSize() int32 {
 			total++
 		}
 	}
+	for _, record := range stmt.Records {
+		if record.IsDeclared() {
+			total++
+		}
+	}
 	for _, innerStmt := range stmt.Body {
 		total += innerStmt.OperationSize()
 	}
@@ -125,11 +130,19 @@ func (stmt Block) AppendOperations(ops *[]InterpreterOperation, stack *Interpret
 		stack.NewVariableWithValue(variable.Name, nil, val)
 	}
 	for _, record := range stmt.Records {
+		// The schema here only exists so that field references such as `r.id` are recognized as variable
+		// references while the body is compiled. The real schema is not known until the record is assigned.
 		var fakeSch sql.Schema
 		for _, fieldName := range record.Fields {
 			fakeSch = append(fakeSch, &sql.Column{Name: fieldName})
 		}
 		stack.NewRecord(record.Name, fakeSch, nil)
+		if record.IsDeclared() {
+			*ops = append(*ops, InterpreterOperation{
+				OpCode: OpCode_DeclareRecord,
+				Target: record.Name,
+			})
+		}
 	}
 	for _, innerStmt := range stmt.Body {
 		if err := innerStmt.AppendOperations(ops, stack); err != nil {
@@ -147,6 +160,9 @@ func (stmt Block) AppendOperations(ops *[]InterpreterOperation, stack *Interpret
 type ExecuteSQL struct {
 	Statement string
 	Target    string
+	// TargetIsRecord states that Target names a single RECORD variable that receives the entire result row,
+	// rather than a comma-separated list of scalar variables that each receive one column.
+	TargetIsRecord bool
 }
 
 var _ Statement = ExecuteSQL{}
@@ -163,7 +179,7 @@ func (stmt ExecuteSQL) AppendOperations(ops *[]InterpreterOperation, stack *Inte
 		return err
 	}
 	*ops = append(*ops, InterpreterOperation{
-		OpCode:        OpCode_Execute,
+		OpCode:        executeOpCode(stmt.TargetIsRecord),
 		PrimaryData:   statementStr,
 		SecondaryData: referencedVariables,
 		Target:        stmt.Target,
@@ -176,6 +192,9 @@ type DynamicExecute struct {
 	Query  string
 	Params []string
 	Target string
+	// TargetIsRecord states that Target names a single RECORD variable that receives the entire result row,
+	// rather than a comma-separated list of scalar variables that each receive one column.
+	TargetIsRecord bool
 }
 
 var _ Statement = DynamicExecute{}
@@ -188,12 +207,21 @@ func (DynamicExecute) OperationSize() int32 {
 // AppendOperations implements the interface Statement.
 func (stmt DynamicExecute) AppendOperations(ops *[]InterpreterOperation, stack *InterpreterStack) error {
 	*ops = append(*ops, InterpreterOperation{
-		OpCode:        OpCode_Execute,
+		OpCode:        executeOpCode(stmt.TargetIsRecord),
 		PrimaryData:   stmt.Query,
 		SecondaryData: stmt.Params,
 		Target:        stmt.Target,
 	})
 	return nil
+}
+
+// executeOpCode returns the opcode used to run a SQL statement whose results are written into the given
+// kind of INTO target.
+func executeOpCode(targetIsRecord bool) OpCode {
+	if targetIsRecord {
+		return OpCode_ExecuteInto
+	}
+	return OpCode_Execute
 }
 
 // ForQueryInit executes a SQL query and stores the result set in a named cursor on the stack.
@@ -382,6 +410,15 @@ func (r Raise) AppendOperations(ops *[]InterpreterOperation, _ *InterpreterStack
 type Record struct {
 	Name   string
 	Fields []string
+	// IsTriggerRecord is true for the NEW and OLD records of a trigger function. Those are created by the
+	// trigger invocation rather than by the function body, so they are not declared when the block is entered.
+	IsTriggerRecord bool
+}
+
+// IsDeclared returns whether entering the record's block should declare it. Trigger records are supplied by
+// the trigger invocation, and PL/pgSQL leaves a record's name empty when it is only referenced internally.
+func (record Record) IsDeclared() bool {
+	return !record.IsTriggerRecord && len(record.Name) > 0
 }
 
 // ReturnQuery represents a RETURN QUERY statement.

--- a/testing/go/plpgsql_record_test.go
+++ b/testing/go/plpgsql_record_test.go
@@ -1,0 +1,328 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _go
+
+import (
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// TestPlpgsqlRecordInto covers using a variable declared as RECORD as the INTO target of a
+// SQL statement (SELECT/INSERT ... RETURNING/EXECUTE). All expectations were verified against
+// PostgreSQL 16.
+func TestPlpgsqlRecordInto(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "SELECT INTO a RECORD variable",
+			SetUpScript: []string{
+				`CREATE TABLE k (id int, name text, amt numeric);`,
+				`INSERT INTO k VALUES (1, 'a', 10.5), (2, 'b', 20.25);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					// The record target is never read, so only the conversion has to succeed.
+					Query: `CREATE FUNCTION f_repro() RETURNS int LANGUAGE plpgsql AS $$
+DECLARE r RECORD;
+BEGIN SELECT id INTO r FROM k LIMIT 1; RETURN 1; END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT f_repro();`,
+					Expected: []sql.Row{{1}},
+				},
+				{
+					Query: `CREATE FUNCTION f_field_text(p int) RETURNS text LANGUAGE plpgsql AS $$
+DECLARE r RECORD;
+BEGIN
+	SELECT id, name INTO r FROM k WHERE id = p;
+	RETURN r.name;
+END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT f_field_text(2);`,
+					Expected: []sql.Row{{"b"}},
+				},
+				{
+					Query: `CREATE FUNCTION f_field_int(p int) RETURNS int LANGUAGE plpgsql AS $$
+DECLARE r RECORD;
+BEGIN
+	SELECT id, name INTO r FROM k WHERE id = p;
+	RETURN r.id;
+END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT f_field_int(2);`,
+					Expected: []sql.Row{{2}},
+				},
+				{
+					// SELECT * INTO a RECORD picks up every column of the table.
+					Query: `CREATE FUNCTION f_star() RETURNS numeric LANGUAGE plpgsql AS $$
+DECLARE r RECORD;
+BEGIN
+	SELECT * INTO r FROM k WHERE id = 1;
+	RETURN r.amt;
+END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT f_star();`,
+					Expected: []sql.Row{{Numeric("10.5")}},
+				},
+				{
+					// Field names come from the query's output column names, not from any table.
+					Query: `CREATE FUNCTION f_agg() RETURNS bigint LANGUAGE plpgsql AS $$
+DECLARE r RECORD;
+BEGIN
+	SELECT count(*) AS c INTO r FROM k;
+	RETURN r.c;
+END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT f_agg();`,
+					Expected: []sql.Row{{2}},
+				},
+				{
+					// When the query matches no rows, every field of the record is NULL.
+					Query: `CREATE FUNCTION f_nomatch() RETURNS boolean LANGUAGE plpgsql AS $$
+DECLARE r RECORD;
+BEGIN
+	SELECT id, name INTO r FROM k WHERE id = 999;
+	RETURN r.id IS NULL;
+END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT f_nomatch();`,
+					Expected: []sql.Row{{"t"}},
+				},
+				{
+					// A RECORD takes the shape of whatever was last assigned to it.
+					Query: `CREATE FUNCTION f_reshape() RETURNS text LANGUAGE plpgsql AS $$
+DECLARE r RECORD;
+BEGIN
+	SELECT id, name INTO r FROM k WHERE id = 1;
+	SELECT name AS other INTO r FROM k WHERE id = 2;
+	RETURN r.other;
+END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT f_reshape();`,
+					Expected: []sql.Row{{"b"}},
+				},
+			},
+		},
+		{
+			Name: "INSERT RETURNING INTO a RECORD variable",
+			SetUpScript: []string{
+				`CREATE TABLE k (id int, name text);`,
+				`INSERT INTO k VALUES (1, 'a');`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `CREATE FUNCTION f_insert_returning() RETURNS text LANGUAGE plpgsql AS $$
+DECLARE r RECORD;
+BEGIN
+	INSERT INTO k VALUES (3, 'c') RETURNING id, name INTO r;
+	RETURN r.name;
+END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT f_insert_returning();`,
+					Expected: []sql.Row{{"c"}},
+				},
+				{
+					Query:    `SELECT id, name FROM k ORDER BY id;`,
+					Expected: []sql.Row{{1, "a"}, {3, "c"}},
+				},
+			},
+		},
+		{
+			Name: "EXECUTE INTO a RECORD variable",
+			SetUpScript: []string{
+				`CREATE TABLE k (id int, name text);`,
+				`INSERT INTO k VALUES (1, 'a'), (2, 'b');`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `CREATE FUNCTION f_exec() RETURNS text LANGUAGE plpgsql AS $$
+DECLARE r RECORD;
+BEGIN
+	EXECUTE 'SELECT id, name FROM k WHERE id = 2' INTO r;
+	RETURN r.name;
+END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT f_exec();`,
+					Expected: []sql.Row{{"b"}},
+				},
+			},
+		},
+		{
+			Name: "trigger function using SELECT INTO a RECORD variable",
+			SetUpScript: []string{
+				`CREATE TABLE t (id int primary key, v int);`,
+				`CREATE FUNCTION trg_guard() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE blocker RECORD;
+BEGIN
+	SELECT id, v INTO blocker FROM t WHERE v > NEW.v LIMIT 1;
+	IF blocker.id IS NOT NULL THEN
+		RAISE EXCEPTION 'blocked by row %', blocker.id;
+	END IF;
+	RETURN NEW;
+END; $$;`,
+				`CREATE TRIGGER trg BEFORE INSERT ON t FOR EACH ROW EXECUTE FUNCTION trg_guard();`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `INSERT INTO t VALUES (1, 10);`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:       `INSERT INTO t VALUES (2, 5);`,
+					ExpectedErr: `blocked by row 1`,
+				},
+				{
+					Query:    `SELECT id, v FROM t ORDER BY id;`,
+					Expected: []sql.Row{{1, 10}},
+				},
+			},
+		},
+		{
+			Name: "RECORD fields written as quoted identifiers",
+			SetUpScript: []string{
+				`CREATE TABLE k3 ("id" int, "book_date" date);`,
+				`INSERT INTO k3 VALUES (7, '2026-01-02'), (9, '2026-03-04');`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `CREATE FUNCTION f_quoted() RETURNS int LANGUAGE plpgsql AS $$
+DECLARE blocker RECORD;
+BEGIN
+	SELECT b."id", b."book_date" INTO blocker FROM k3 b ORDER BY b."book_date" LIMIT 1;
+	IF blocker."id" IS NOT NULL THEN
+		RETURN blocker."id";
+	END IF;
+	RETURN -1;
+END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT f_quoted();`,
+					Expected: []sql.Row{{7}},
+				},
+				{
+					// A record field read through RAISE resolves the same way as one read through a query.
+					Query: `CREATE FUNCTION f_raise() RETURNS void LANGUAGE plpgsql AS $$
+DECLARE r RECORD;
+BEGIN
+	SELECT "id" INTO r FROM k3 ORDER BY "id" LIMIT 1;
+	RAISE EXCEPTION 'saw %', r."id";
+END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:       `SELECT f_raise();`,
+					ExpectedErr: `saw 7`,
+				},
+			},
+		},
+		{
+			Name: "FOR..IN..SELECT over a RECORD variable",
+			SetUpScript: []string{
+				`CREATE TABLE k4 (id int, name text);`,
+				`INSERT INTO k4 VALUES (1, 'a'), (2, 'b'), (3, 'c');`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					// The existing FOR..IN..SELECT coverage loops over an empty result, so the record is never
+					// actually assigned. This reads fields off it on every iteration.
+					Query: `CREATE FUNCTION f_forloop() RETURNS text LANGUAGE plpgsql AS $$
+DECLARE r RECORD; acc text := '';
+BEGIN
+	FOR r IN SELECT id, name FROM k4 ORDER BY id LOOP
+		acc := acc || r.id || r.name;
+	END LOOP;
+	RETURN acc;
+END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT f_forloop();`,
+					Expected: []sql.Row{{"1a2b3c"}},
+				},
+			},
+		},
+		{
+			Name: "SELECT INTO a RECORD from a derived table",
+			Assertions: []ScriptTestAssertion{
+				{
+					// The record's shape comes from the query's output columns, which here belong to no table.
+					Query: `CREATE FUNCTION f_derived() RETURNS numeric LANGUAGE plpgsql AS $$
+DECLARE fig RECORD;
+BEGIN
+	SELECT * INTO fig FROM (SELECT 12.5::numeric AS computed_balance, 3::bigint AS line_count) f;
+	RETURN fig.computed_balance;
+END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT f_derived();`,
+					Expected: []sql.Row{{Numeric("12.5")}},
+				},
+			},
+		},
+		{
+			Name: "errors accessing RECORD fields",
+			SetUpScript: []string{
+				`CREATE TABLE k (id int, name text);`,
+				`INSERT INTO k VALUES (1, 'a');`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `CREATE FUNCTION f_badfield() RETURNS text LANGUAGE plpgsql AS $$
+DECLARE r RECORD;
+BEGIN
+	SELECT id INTO r FROM k WHERE id = 1;
+	RETURN r.nope;
+END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:       `SELECT f_badfield();`,
+					ExpectedErr: `record "r" has no field "nope"`,
+				},
+				{
+					Query: `CREATE FUNCTION f_unassigned() RETURNS text LANGUAGE plpgsql AS $$
+DECLARE r RECORD;
+BEGIN
+	RETURN r.id;
+END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:       `SELECT f_unassigned();`,
+					ExpectedErr: `record "r" is not assigned yet`,
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
`SELECT ... INTO r` where `r` is declared `RECORD` failed at CREATE FUNCTION time with `unhandled datum type: plpgsql.datum`: the INTO target arrives as a `PLpgSQL_rec`, and the three conversion sites (`SELECT`, `EXECUTE`, `CALL`) accepted only `PLpgSQL_row` and `PLpgSQL_var`.

Unlike a row target, a record has no shape of its own — it takes the shape of whatever is assigned to it — so it cannot be expressed as the existing comma-separated list of scalar variables. Two opcodes are added for it:

  - `OpCode_DeclareRecord` declares a shapeless record when its block is entered. Records previously existed only on the compile-time stack, so a record was never actually present at runtime; the one existing FOR..IN..SELECT test loops over an empty result and so never assigned one.
  - `OpCode_ExecuteInto` runs a statement and assigns its first result row, with the query's output columns as the record's schema. As in Postgres without STRICT, extra rows are discarded and no rows at all leaves every field NULL.

Record field lookup gains three fixes this exposed: fields are matched by name rather than by name plus the first column's source (a record's columns can come from different tables), quoted field references such as `blocker."id"` have their quotes stripped, and non-Doltgres result types (from an aggregate such as `count(*)`) are converted when the schema is stored.

Reading a field now reports what Postgres reports — `record "r" has no field "x"` and `record "r" is not assigned yet` — instead of the generic "variable could not be found", and the two `unhandled datum type: %T` messages, which could only ever print `plpgsql.datum`, now name the arms they handle.