### PR TITLE
Expand table-returning functions into columns in a FROM clause

### DIFF
--- a/server/functions/framework/compiled_function.go
+++ b/server/functions/framework/compiled_function.go
@@ -185,12 +185,35 @@ func (c *CompiledFunction) Description() string {
 	return fmt.Sprintf("The PostgreSQL function `%s`", c.Name)
 }
 
-// OutParametersSchema implements the interface sql.ExtendedTableFunction.
+// OutParametersSchema implements the interface sql.ExtendedTableFunction. It returns the columns this function
+// produces when it is invoked in a FROM clause, which is one column per OUT parameter, or one column per field of the
+// return type for a function declared RETURNS TABLE(...) or RETURNS SETOF <composite>.
 func (c *CompiledFunction) OutParametersSchema() sql.Schema {
 	if !c.overload.Valid() {
 		return nil
 	}
-	return c.overload.Function().GetOutParameters()
+	if outParams := c.overload.Function().GetOutParameters(); len(outParams) > 0 {
+		return outParams
+	}
+	return compositeReturnSchema(c.overload.Function().GetReturn())
+}
+
+// compositeReturnSchema returns one column per field of |returnType| when it is a composite type. A function declared
+// RETURNS TABLE(...) stores its result columns as the fields of an anonymous composite type, and one declared
+// RETURNS SETOF <composite> names an existing one, so in both cases those fields are the function's result columns in
+// a FROM clause. Returns nil for every other return type.
+func compositeReturnSchema(returnType *pgtypes.DoltgresType) sql.Schema {
+	if returnType == nil || returnType.TypCategory != pgtypes.TypeCategory_CompositeTypes || len(returnType.CompositeAttrs) == 0 {
+		return nil
+	}
+	schema := make(sql.Schema, len(returnType.CompositeAttrs))
+	for i, attr := range returnType.CompositeAttrs {
+		schema[i] = &sql.Column{
+			Name: attr.Name,
+			Type: attr.Type,
+		}
+	}
+	return schema
 }
 
 // Unwrap implements the interface sql.ExtendedTableFunction.
@@ -199,7 +222,7 @@ func (c *CompiledFunction) Unwrap(v any) sql.Row {
 		return sql.Row{v}
 	}
 	if rv, ok := v.([]pgtypes.RecordValue); ok {
-		if len(rv) == len(c.overload.Function().GetOutParameters()) {
+		if len(rv) == len(c.OutParametersSchema()) {
 			var r sql.Row
 			for _, val := range rv {
 				r = append(r, val.Value)
@@ -384,8 +407,27 @@ func (c *CompiledFunction) func2FastPath(ctx *sql.Context, f Function2, row sql.
 	return res, true, nil
 }
 
-// Eval implements the interface sql.Expression.
+// Eval implements the interface sql.Expression. A set-returning function returns a sql.RowIter here, with one column
+// per result column, which is the shape a FROM clause consumes. EvalRowIter returns the SELECT-list shape instead,
+// where a multi-column result is collapsed into a single record value per row.
 func (c *CompiledFunction) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	res, err := c.evalRaw(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+	rowIter, ok := res.(sql.RowIter)
+	if !ok {
+		return res, nil
+	}
+	if outParams := c.OutParametersSchema(); len(outParams) > 0 {
+		return &recordExpandingRowIter{child: rowIter, outParams: outParams}, nil
+	}
+	return rowIter, nil
+}
+
+// evalRaw invokes the resolved overload, leaving the result in whatever form the function itself produced. A
+// set-returning function with a multi-column result produces one record value per row here.
+func (c *CompiledFunction) evalRaw(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	// If we have a stashed error, then we should return that now. Errors are stashed when they're supposed to be
 	// returned during the call to Eval. This helps to ensure consistency with how errors are returned in Postgres.
 	if c.stashedErr != nil {
@@ -517,11 +559,17 @@ func (c *CompiledFunction) callFunction(ctx *sql.Context, args []any) (interface
 
 // EvalRowIter implements sql.RowIterExpression
 func (c *CompiledFunction) EvalRowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error) {
-	eval, err := c.Eval(ctx, r)
+	eval, err := c.evalRaw(ctx, r)
 	if err != nil {
 		return nil, err
 	}
-	return rowIterForSRF(c.Name, eval, c.OutParametersSchema())
+	// Only real OUT parameters collapse here. A composite return type already produces one record value per row,
+	// which is the shape a SELECT list wants.
+	var outParams sql.Schema
+	if c.overload.Valid() {
+		outParams = c.overload.Function().GetOutParameters()
+	}
+	return rowIterForSRF(c.Name, eval, outParams)
 }
 
 // rowIterForSRF converts the value returned by a set-returning function into the sql.RowIter used to expand it in a
@@ -576,6 +624,87 @@ func (r *recordCollapsingRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 
 // Close implements the interface sql.RowIter.
 func (r *recordCollapsingRowIter) Close(ctx *sql.Context) error {
+	return r.child.Close(ctx)
+}
+
+// recordExpandingRowIter wraps the row iterator of a set-returning function whose result has multiple columns,
+// expanding the single record value in each row back into one column per result column. This is the shape a FROM
+// clause consumes, as opposed to the record value a SELECT list sees.
+type recordExpandingRowIter struct {
+	child     sql.RowIter
+	outParams sql.Schema
+	casts     []casts.Cast
+}
+
+var _ sql.RowIter = (*recordExpandingRowIter)(nil)
+
+// Next implements the interface sql.RowIter.
+func (r *recordExpandingRowIter) Next(ctx *sql.Context) (sql.Row, error) {
+	row, err := r.child.Next(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(row) != 1 {
+		return row, nil
+	}
+	record, ok := row[0].([]pgtypes.RecordValue)
+	if !ok || len(record) != len(r.outParams) {
+		// The function's body produced a result that doesn't line up with the columns it declares, so there is
+		// nothing to expand it into. Leave the row alone rather than reporting an error the SELECT-list form of the
+		// same call doesn't report.
+		return row, nil
+	}
+	if r.casts == nil {
+		// A function's result rows all come from one query, so they share a set of field types and the casts only
+		// have to be resolved once.
+		if r.casts, err = r.resolveCasts(ctx, record); err != nil {
+			return nil, err
+		}
+	}
+	expanded := make(sql.Row, len(record))
+	for i, field := range record {
+		expanded[i] = field.Value
+		if field.Value == nil || !r.casts[i].ID.IsValid() {
+			continue
+		}
+		sourceType, sourceOk := field.Type.(*pgtypes.DoltgresType)
+		targetType, targetOk := r.outParams[i].Type.(*pgtypes.DoltgresType)
+		if !sourceOk || !targetOk {
+			continue
+		}
+		if expanded[i], err = r.casts[i].Eval(ctx, field.Value, sourceType, targetType); err != nil {
+			return nil, err
+		}
+	}
+	return expanded, nil
+}
+
+// resolveCasts returns the cast needed to bring each field of |record| to the type of the result column it fills. A
+// function body isn't required to produce the exact types the function declares (`RETURNS TABLE(n int)` over a body
+// selecting a bigint, say), and the FROM clause reads these values as the declared types, so each field is assignment
+// cast the way Postgres coerces a function's result. Fields that already have the declared type get an invalid cast,
+// which the caller skips.
+func (r *recordExpandingRowIter) resolveCasts(ctx *sql.Context, record []pgtypes.RecordValue) ([]casts.Cast, error) {
+	castsColl, err := core.GetCastsCollectionFromContext(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	resolved := make([]casts.Cast, len(record))
+	for i, field := range record {
+		sourceType, sourceOk := field.Type.(*pgtypes.DoltgresType)
+		targetType, targetOk := r.outParams[i].Type.(*pgtypes.DoltgresType)
+		if !sourceOk || !targetOk || sourceType.ID == targetType.ID {
+			continue
+		}
+		if resolved[i], err = castsColl.GetAssignmentCast(ctx, sourceType, targetType); err != nil {
+			return nil, err
+		}
+	}
+	return resolved, nil
+}
+
+// Close implements the interface sql.RowIter.
+func (r *recordExpandingRowIter) Close(ctx *sql.Context) error {
 	return r.child.Close(ctx)
 }
 

--- a/server/plpgsql/interpreter_logic.go
+++ b/server/plpgsql/interpreter_logic.go
@@ -322,9 +322,16 @@ func call(ctx *sql.Context, iFunc InterpretedFunction, stack InterpreterStack) (
 			if len(stack.ReturnQueryResults()) > 0 {
 				records := stack.ReturnQueryResults()
 
+				// A function that declares a single, non-composite result column returns that column's value
+				// directly rather than a one-field record.
+				returnsRecord := iFunc.GetReturn().TypCategory == pgtypes.TypeCategory_CompositeTypes
 				rows := make([]sql.Row, len(records))
 				for i, record := range records {
-					rows[i] = sql.Row{record}
+					if !returnsRecord && len(record) == 1 {
+						rows[i] = sql.Row{record[0].Value}
+					} else {
+						rows[i] = sql.Row{record}
+					}
 				}
 
 				return sql.RowsToRowIter(rows...), nil

--- a/testing/go/create_function_plpgsql_test.go
+++ b/testing/go/create_function_plpgsql_test.go
@@ -1776,5 +1776,81 @@ $$ LANGUAGE plpgsql;`,
 				},
 			},
 		},
+		{
+			Name: "RETURNS TABLE in a FROM clause",
+			SetUpScript: []string{
+				`CREATE FUNCTION figures() RETURNS TABLE(shape TEXT, sides INT)
+					LANGUAGE plpgsql
+					AS $$
+					BEGIN
+						RETURN QUERY SELECT 'triangle', 3;
+						RETURN QUERY SELECT 'square', 4;
+					END;
+					$$;`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:            "SELECT * FROM figures();",
+					ExpectedColNames: []string{"shape", "sides"},
+					Expected:         []sql.Row{{"triangle", 3}, {"square", 4}},
+				},
+				{
+					Query:            "SELECT shape FROM figures() WHERE sides = 4;",
+					ExpectedColNames: []string{"shape"},
+					Expected:         []sql.Row{{"square"}},
+				},
+				{
+					// In a SELECT list the same call produces one record value per row
+					Query:    "SELECT figures();",
+					Expected: []sql.Row{{"(triangle,3)"}, {"(square,4)"}},
+				},
+			},
+		},
+		{
+			Name: "RETURNS TABLE with a single column in a FROM clause",
+			SetUpScript: []string{
+				`CREATE FUNCTION shapes() RETURNS TABLE(shape TEXT)
+					LANGUAGE plpgsql
+					AS $$
+					BEGIN
+						RETURN QUERY SELECT 'triangle';
+						RETURN QUERY SELECT 'square';
+					END;
+					$$;`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:            "SELECT * FROM shapes();",
+					ExpectedColNames: []string{"shape"},
+					Expected:         []sql.Row{{"triangle"}, {"square"}},
+				},
+				{
+					Query:    "SELECT shapes();",
+					Expected: []sql.Row{{"(triangle)"}, {"(square)"}},
+				},
+			},
+		},
+		{
+			Name: "RETURNS SETOF a scalar type",
+			SetUpScript: []string{
+				`CREATE FUNCTION sides() RETURNS SETOF INT
+					LANGUAGE plpgsql
+					AS $$
+					BEGIN
+						RETURN QUERY SELECT 3 UNION ALL SELECT 4;
+					END;
+					$$;`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    "SELECT * FROM sides();",
+					Expected: []sql.Row{{3}, {4}},
+				},
+				{
+					Query:    "SELECT sides();",
+					Expected: []sql.Row{{3}, {4}},
+				},
+			},
+		},
 	})
 }

--- a/testing/go/create_function_sql_test.go
+++ b/testing/go/create_function_sql_test.go
@@ -473,5 +473,82 @@ func TestCreateFunctionsLanguageSQL(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "table function in FROM returning a table",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `CREATE FUNCTION figures() RETURNS TABLE(shape TEXT, sides INT) LANGUAGE SQL AS $$ SELECT 'triangle', 3 UNION ALL SELECT 'square', 4 $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT * FROM figures();`,
+					Expected: []sql.Row{{"triangle", 3}, {"square", 4}},
+				},
+				{
+					Query:    `SELECT shape, sides FROM figures();`,
+					Expected: []sql.Row{{"triangle", 3}, {"square", 4}},
+				},
+				{
+					Query:    `SELECT shape FROM figures() WHERE sides = 4;`,
+					Expected: []sql.Row{{"square"}},
+				},
+				{
+					Query:    `SELECT * FROM public.figures();`,
+					Expected: []sql.Row{{"triangle", 3}, {"square", 4}},
+				},
+				{
+					Query:    `SELECT * FROM figures() AS f(name, edges);`,
+					Expected: []sql.Row{{"triangle", 3}, {"square", 4}},
+				},
+				{
+					// In a SELECT list the same call produces one record value per row
+					Query:    `SELECT figures();`,
+					Expected: []sql.Row{{"(triangle,3)"}, {"(square,4)"}},
+				},
+			},
+		},
+		{
+			Name: "table function in FROM returning SETOF a table type",
+			SetUpScript: []string{
+				`CREATE TABLE shapes (shape TEXT, sides INT);`,
+				`INSERT INTO shapes VALUES ('triangle', 3), ('square', 4);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `CREATE FUNCTION with_sides(n INT) RETURNS SETOF shapes LANGUAGE SQL AS $$ SELECT * FROM shapes WHERE sides >= n $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT * FROM with_sides(4);`,
+					Expected: []sql.Row{{"square", 4}},
+				},
+				{
+					Query:    `SELECT s.shape FROM shapes s JOIN with_sides(3) w ON s.shape = w.shape ORDER BY s.shape;`,
+					Expected: []sql.Row{{"square"}, {"triangle"}},
+				},
+				{
+					Query:    `SELECT with_sides(4);`,
+					Expected: []sql.Row{{"(square,4)"}},
+				},
+			},
+		},
+		{
+			Name:        "table function in FROM returning a composite type",
+			SetUpScript: []string{`CREATE TYPE figure AS (shape TEXT, sides INT);`},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `CREATE FUNCTION a_figure() RETURNS figure LANGUAGE SQL AS $$ SELECT ROW('triangle', 3)::figure $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT * FROM a_figure();`,
+					Expected: []sql.Row{{"triangle", 3}},
+				},
+				{
+					Query:    `SELECT a_figure();`,
+					Expected: []sql.Row{{"(triangle,3)"}},
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
A function called in a FROM clause is already rewritten into a vitess.TableFuncExpr and resolved through GMS's TableFunctionWrapper, which asks sql.ExtendedTableFunction for the function's result columns. CompiledFunction answered that question with the function's OUT parameters only, so a function declared RETURNS TABLE(...) or RETURNS SETOF <composite> - which stores its result columns as the fields of a composite return type rather than as OUT parameters - reported a single column, and `SELECT * FROM figures()` returned one record value per row instead of one column per field.

OutParametersSchema now falls back to the fields of a composite return type, and Eval expands each record value back into separate columns, assignment casting each field to the result type the function declares. The SELECT-list shape is unchanged: EvalRowIter keeps returning one record value per row, so it now calls the underlying overload directly rather than going through Eval.

Also fixes a PL/pgSQL function declared RETURNS SETOF <scalar>, whose RETURN QUERY results were buffered as one-field records and so failed to render in either a FROM clause or a SELECT list.