### PR TITLE
Fold plpgsql identifiers the way Postgres does

### DIFF
--- a/server/plpgsql/interpreter_logic.go
+++ b/server/plpgsql/interpreter_logic.go
@@ -76,14 +76,17 @@ func TriggerCall(ctx *sql.Context, iFunc InterpretedFunction, runner sql.Stateme
 	// Set up the initial state of the function
 	stack := NewInterpreterStack(runner)
 	// Add the special variables
-	stack.NewRecord("OLD", sch, oldRow)
-	stack.NewRecord("NEW", sch, newRow)
+	// These are declared under their folded names, the same as anything the function declares itself, so
+	// that a body may write them in any case (`NEW.x`, `new.x`) the way Postgres allows.
+	stack.NewRecord(TriggerOldRecordName, sch, oldRow)
+	stack.NewRecord(TriggerNewRecordName, sch, newRow)
 	for varName, val := range trigVars {
-		varType, ok := triggerSpecialVariables[varName]
+		normalized := NormalizeIdentifier(varName)
+		varType, ok := triggerSpecialVariables[normalized]
 		if !ok {
 			return nil, fmt.Errorf("unknown variable %s for trigger", varName)
 		}
-		stack.NewVariableWithValue(varName, varType, val)
+		stack.NewVariableWithValue(normalized, varType, val)
 	}
 	return call(ctx, iFunc, stack)
 }
@@ -342,10 +345,10 @@ func call(ctx *sql.Context, iFunc InterpretedFunction, stack InterpreterStack) (
 			if iFunc.GetReturn().ID == pgtypes.Trigger.ID && len(operation.SecondaryData) == 1 {
 				normalized := strings.ReplaceAll(strings.ToLower(operation.PrimaryData), " ", "")
 				if normalized == "select$1;" {
-					if strings.EqualFold(operation.SecondaryData[0], "new") {
-						return *stack.GetVariable("NEW").Value, nil
-					} else if strings.EqualFold(operation.SecondaryData[0], "old") {
-						return *stack.GetVariable("OLD").Value, nil
+					if strings.EqualFold(operation.SecondaryData[0], TriggerNewRecordName) {
+						return *stack.GetVariable(TriggerNewRecordName).Value, nil
+					} else if strings.EqualFold(operation.SecondaryData[0], TriggerOldRecordName) {
+						return *stack.GetVariable(TriggerOldRecordName).Value, nil
 					}
 				}
 			}
@@ -487,7 +490,13 @@ func evaluteNoticeMessage(ctx *sql.Context, iFunc InterpretedFunction,
 				}
 				currentParam := params[currentParamIdx]
 				currentParamIdx += 1
-				formattedVar, varFound, err := iFunc.ApplyBindings(ctx, stack, "$1", []string{currentParam}, false)
+				// RAISE carries its arguments as raw source text, so a reference among them still has to
+				// be folded before it will match the variable it names.
+				lookupName := currentParam
+				if normalized, isRef := NormalizeIdentifierPath(currentParam); isRef {
+					lookupName = normalized
+				}
+				formattedVar, varFound, err := iFunc.ApplyBindings(ctx, stack, "$1", []string{lookupName}, false)
 				if varFound {
 					if err != nil {
 						return "", err
@@ -515,17 +524,18 @@ func evaluteNoticeMessage(ctx *sql.Context, iFunc InterpretedFunction,
 // triggerSpecialVariables are the list of special variables for triggers.
 // https://www.postgresql.org/docs/15/plpgsql-trigger.html
 // TODO: NEW and OLD variables are handled separately using `InterpreterStack.NewRecord` function.
+// Keys are the folded form of each name, since that is what a reference to one normalizes to.
 var triggerSpecialVariables = map[string]*pgtypes.DoltgresType{
-	//"NEW":
-	//"OLD":
-	"TG_NAME":         pgtypes.Name,
-	"TG_WHEN":         pgtypes.Text,
-	"TG_LEVEL":        pgtypes.Text,
-	"TG_OP":           pgtypes.Text,
-	"TG_RELID":        pgtypes.Oid,
-	"TG_RELNAME":      pgtypes.Name,
-	"TG_TABLE_NAME":   pgtypes.Name,
-	"TG_TABLE_SCHEMA": pgtypes.Name,
-	"TG_NARGS":        pgtypes.Int32,
-	"TG_ARGV[]":       pgtypes.TextArray,
+	//"new":
+	//"old":
+	"tg_name":         pgtypes.Name,
+	"tg_when":         pgtypes.Text,
+	"tg_level":        pgtypes.Text,
+	"tg_op":           pgtypes.Text,
+	"tg_relid":        pgtypes.Oid,
+	"tg_relname":      pgtypes.Name,
+	"tg_table_name":   pgtypes.Name,
+	"tg_table_schema": pgtypes.Name,
+	"tg_nargs":        pgtypes.Int32,
+	"tg_argv[]":       pgtypes.TextArray,
 }

--- a/server/plpgsql/interpreter_stack.go
+++ b/server/plpgsql/interpreter_stack.go
@@ -35,6 +35,71 @@ var ErrRecordHasNoField = errors.NewKind(`record "%s" has no field "%s"`)
 // ErrVariableNotFound is returned when a referenced variable does not exist on the stack.
 var ErrVariableNotFound = errors.NewKind("variable `%s` could not be found")
 
+// NormalizeIdentifier folds a PL/pgSQL identifier the way Postgres does, so that the name a reference is
+// written with and the name a variable was declared with can be compared directly. An unquoted identifier
+// folds to lowercase; a quoted one keeps its case and loses its quotes, with a doubled quote inside standing
+// for a literal one. `MyVar` and `MYVAR` therefore name the same variable, and `"MyVar"` names a different
+// one. pg_query already stores declared names in this form, so normalizing every name we take from raw
+// source text is what puts both sides in the same alphabet.
+func NormalizeIdentifier(ident string) string {
+	if len(ident) >= 2 && strings.HasPrefix(ident, `"`) && strings.HasSuffix(ident, `"`) {
+		return strings.ReplaceAll(ident[1:len(ident)-1], `""`, `"`)
+	}
+	return strings.ToLower(ident)
+}
+
+// NormalizeIdentifierPath folds a bare reference of the form `name` or `name.field` and reports whether the
+// text was such a reference at all. Some statements, RAISE among them, carry their arguments as raw source
+// text rather than through the expression rewriter, and each one may be either a variable reference or an
+// expression to evaluate. Anything that is not a plain reference is left alone for the caller to evaluate.
+func NormalizeIdentifierPath(text string) (string, bool) {
+	text = strings.TrimSpace(text)
+	// GetVariable resolves at most one level of field access, so anything deeper is not a reference it
+	// could answer anyway.
+	base, field, hasField := strings.Cut(text, ".")
+	if !isIdentifier(base) || (hasField && !isIdentifier(field)) {
+		return "", false
+	}
+	// Only the base names a variable; the field is matched against the record's columns separately.
+	if hasField {
+		return NormalizeIdentifier(base) + "." + field, true
+	}
+	return NormalizeIdentifier(base), true
+}
+
+// isIdentifier reports whether |s| is a single SQL identifier, quoted or otherwise.
+func isIdentifier(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	if strings.HasPrefix(s, `"`) {
+		return len(s) >= 2 && strings.HasSuffix(s, `"`) && !strings.Contains(s[1:len(s)-1], `"`)
+	}
+	for i, r := range s {
+		switch {
+		case r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z'):
+		case i > 0 && (r == '$' || (r >= '0' && r <= '9')):
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// QuoteIdentifier renders |name| so that it survives NormalizeIdentifier unchanged. Use it when building SQL
+// that refers to a variable whose declared name is already known, since that name may hold capitals that an
+// unquoted mention would fold away.
+func QuoteIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+// TriggerNewRecordName and TriggerOldRecordName are the names a trigger invocation supplies its row records
+// under. They are the folded form of NEW and OLD, matching how pg_query names them in a parsed function.
+const (
+	TriggerNewRecordName = "new"
+	TriggerOldRecordName = "old"
+)
+
 // cursorState holds the result set for a FOR record IN query LOOP cursor.
 type cursorState struct {
 	Schema sql.Schema
@@ -198,8 +263,9 @@ func recordFieldIndex(sch sql.Schema, fieldName string) int {
 	return -1
 }
 
-// ListVariables returns a map with the names of all variables. The attached slice represents field names for records.
-// All names are lowercased.
+// ListVariables returns a map with the names of all variables. The attached slice represents field names for
+// records. Names are keyed exactly as they were declared, which is already the folded form, so a reference
+// matches by being folded the same way rather than by being compared case-insensitively.
 func (is *InterpreterStack) ListVariables() map[string][]string {
 	seen := make(map[string][]string)
 	for i := 0; i < is.stack.Len(); i++ {
@@ -210,7 +276,7 @@ func (is *InterpreterStack) ListVariables() map[string][]string {
 					fieldNames = append(fieldNames, strings.ToLower(col.Name))
 				}
 			}
-			seen[strings.ToLower(varName)] = fieldNames
+			seen[varName] = fieldNames
 		}
 	}
 	return seen

--- a/server/plpgsql/json.go
+++ b/server/plpgsql/json.go
@@ -314,7 +314,8 @@ func (stmt *plpgSQL_stmt_assign) Convert() (Assignment, error) {
 		return Assignment{}, errors.New("PL/pgSQL assignment cannot find `:=` sign")
 	}
 	return Assignment{
-		VariableName:  varName,
+		// The target is raw source text, so it has to be folded the same way a reference to it would be.
+		VariableName:  NormalizeIdentifier(varName),
 		Expression:    query,
 		VariableIndex: stmt.VariableNumber,
 	}, nil
@@ -365,12 +366,9 @@ func (stmt *plpgSQL_stmt_case) Convert() (block Block, err error) {
 			return Block{}, fmt.Errorf("case statement WHEN clause is nil")
 		}
 
-		// TODO: The generated expressions from pg_query_go uses double quotes
-		//       around the variable name, which is valid for Postgres, but
-		//       our engine doesn't currently resolve double-quoted strings to
-		//       variables, so for now, we just extract the double quotes.
+		// pg_query_go quotes the generated variable name, which is what keeps its capitals intact when
+		// the reference is folded, so the quotes are left in place.
 		expressionString := when.Expression.Expression.Query
-		expressionString = strings.ReplaceAll(expressionString, `"`, "")
 
 		convertedWhenBodyStatements, err := jsonConvertStatements(when.Body)
 		if err != nil {
@@ -430,7 +428,13 @@ func (stmt *plpgSQL_stmt_case) Convert() (block Block, err error) {
 func (stmt *plpgSQL_stmt_dynexecute) Convert() (DynamicExecute, error) {
 	var params []string
 	for _, param := range stmt.Params {
-		params = append(params, param.Expr.Query)
+		// USING arguments are raw source text, so a reference among them is folded the way one in an
+		// ordinary expression would be.
+		query := param.Expr.Query
+		if normalized, isRef := NormalizeIdentifierPath(query); isRef {
+			query = normalized
+		}
+		params = append(params, query)
 	}
 	var target string
 	var targetIsRecord bool
@@ -534,6 +538,10 @@ func (stmt *plpgSQL_stmt_fori) Convert() (block Block, err error) {
 		return Block{}, errors.New("for loop variable cannot be nil")
 	}
 	varName := stmt.Var.Variable.RefName
+	// The name is already in its declared form, so it is quoted where it goes into generated SQL rather
+	// than mentioned bare, which would fold away any capitals a quoted declaration gave it. Assignment
+	// targets take the plain name, since those are matched against the stack rather than parsed as SQL.
+	quotedVarName := QuoteIdentifier(varName)
 
 	// Extract bound and step expressions
 	lowerExpr := "1"
@@ -553,11 +561,11 @@ func (stmt *plpgSQL_stmt_fori) Convert() (block Block, err error) {
 	// In the JSON, Lower is always the starting value and Upper is the ending bound.
 	var condition, incrExpr string
 	if stmt.Reverse {
-		condition = fmt.Sprintf("%s >= (%s)", varName, upperExpr)
-		incrExpr = fmt.Sprintf("%s - (%s)", varName, stepExpr)
+		condition = fmt.Sprintf("%s >= (%s)", quotedVarName, upperExpr)
+		incrExpr = fmt.Sprintf("%s - (%s)", quotedVarName, stepExpr)
 	} else {
-		condition = fmt.Sprintf("%s <= (%s)", varName, upperExpr)
-		incrExpr = fmt.Sprintf("%s + (%s)", varName, stepExpr)
+		condition = fmt.Sprintf("%s <= (%s)", quotedVarName, upperExpr)
+		incrExpr = fmt.Sprintf("%s + (%s)", quotedVarName, stepExpr)
 	}
 
 	// Convert the loop body.
@@ -742,7 +750,13 @@ func (stmt *plpgSQL_stmt_perform) Convert() Perform {
 func (stmt *plpgSQL_stmt_raise) Convert() Raise {
 	var params []string
 	for _, param := range stmt.Params {
-		params = append(params, param.Expr.Query)
+		// USING arguments are raw source text, so a reference among them is folded the way one in an
+		// ordinary expression would be.
+		query := param.Expr.Query
+		if normalized, isRef := NormalizeIdentifierPath(query); isRef {
+			query = normalized
+		}
+		params = append(params, query)
 	}
 
 	options := make(map[string]string)

--- a/server/plpgsql/statements.go
+++ b/server/plpgsql/statements.go
@@ -16,7 +16,6 @@ package plpgsql
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
 
@@ -511,24 +510,29 @@ func substituteVariableReferences(expression string, stack *InterpreterStack) (n
 		isAfterDot := i > 0 && scanResult.Tokens[i-1].Token == '.'
 
 		if !isAfterDot {
-			if _, ok := varMap[strings.ToLower(substring)]; ok {
+			// A variable is named by whatever the reference folds to, not by how it happens to be spelled
+			// here, so the binding is recorded under the folded name.
+			normalized := NormalizeIdentifier(substring)
+			if _, ok := varMap[normalized]; ok {
+				bindingName := normalized
 				// If there's a '.', then we'll assume this is accessing a record's field (`NEW.val1` for example)
 				for i+2 < len(scanResult.Tokens) && scanResult.Tokens[i+1].Token == '.' {
 					nextFieldSubstring := expression[scanResult.Tokens[i+2].Start:scanResult.Tokens[i+2].End]
 					substring += "." + nextFieldSubstring
+					bindingName += "." + nextFieldSubstring
 					i += 2
 				}
 				// Variables cannot have a '(' after their name as that would classify them as functions, so we have to
 				// explicitly check for that. This is because variables and functions can share names, for example:
 				// SELECT COUNT(*) INTO count FROM table_name;
 				if i+1 >= len(scanResult.Tokens) || scanResult.Tokens[i+1].Token != '(' {
-					referencedVars = append(referencedVars, substring)
+					referencedVars = append(referencedVars, bindingName)
 					newExpression += fmt.Sprintf("$%d ", len(referencedVars))
 				} else {
 					newExpression += substring + " "
 				}
-			} else if _, ok := triggerSpecialVariables[substring]; ok {
-				referencedVars = append(referencedVars, substring)
+			} else if _, ok := triggerSpecialVariables[normalized]; ok {
+				referencedVars = append(referencedVars, normalized)
 				newExpression += fmt.Sprintf("$%d ", len(referencedVars))
 			} else {
 				newExpression += substring + " "

--- a/testing/go/plpgsql_identifiers_test.go
+++ b/testing/go/plpgsql_identifiers_test.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _go
+
+import (
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// TestPlpgsqlIdentifierCasing covers how a PL/pgSQL identifier is matched to the variable it names. An
+// unquoted identifier folds to lowercase and a quoted one keeps its case, at every site that names a
+// variable: a reference, an assignment target, an INTO target, a RAISE parameter, and a parameter name.
+// All expectations were verified against PostgreSQL 16.
+func TestPlpgsqlIdentifierCasing(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "references fold to the declared name",
+			SetUpScript: []string{
+				`CREATE TABLE k (id int, nm text);`,
+				`INSERT INTO k VALUES (1, 'a');`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `CREATE FUNCTION r1() RETURNS int LANGUAGE plpgsql AS $$
+DECLARE MyVar int := 1; BEGIN RETURN MYVAR; END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT r1();`,
+					Expected: []sql.Row{{1}},
+				},
+				{
+					// A quoted declaration keeps its case, and a quoted reference finds it.
+					Query: `CREATE FUNCTION r2() RETURNS int LANGUAGE plpgsql AS $$
+DECLARE "MyVar" int := 1; BEGIN RETURN "MyVar"; END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT r2();`,
+					Expected: []sql.Row{{1}},
+				},
+			},
+		},
+		{
+			Name: "assignment and INTO targets fold too",
+			SetUpScript: []string{
+				`CREATE TABLE k (id int, nm text);`,
+				`INSERT INTO k VALUES (1, 'a');`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `CREATE FUNCTION r3() RETURNS int LANGUAGE plpgsql AS $$
+DECLARE myvar int; BEGIN MyVar := 7; RETURN myvar; END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT r3();`,
+					Expected: []sql.Row{{7}},
+				},
+				{
+					Query: `CREATE FUNCTION r4() RETURNS int LANGUAGE plpgsql AS $$
+DECLARE "MyVar" int; BEGIN "MyVar" := 7; RETURN "MyVar"; END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT r4();`,
+					Expected: []sql.Row{{7}},
+				},
+				{
+					Query: `CREATE FUNCTION r7() RETURNS int LANGUAGE plpgsql AS $$
+DECLARE myvar int; BEGIN SELECT id INTO MyVar FROM k; RETURN myvar; END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT r7();`,
+					Expected: []sql.Row{{1}},
+				},
+			},
+		},
+		{
+			Name: "parameters and RAISE arguments fold too",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `CREATE FUNCTION r5(MyParam int) RETURNS int LANGUAGE plpgsql AS $$
+BEGIN RETURN MYPARAM; END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT r5(7);`,
+					Expected: []sql.Row{{7}},
+				},
+				{
+					Query: `CREATE FUNCTION r6("MyParam" int) RETURNS int LANGUAGE plpgsql AS $$
+BEGIN RETURN "MyParam"; END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT r6(7);`,
+					Expected: []sql.Row{{7}},
+				},
+				{
+					Query: `CREATE FUNCTION r8() RETURNS void LANGUAGE plpgsql AS $$
+DECLARE myvar int := 3; BEGIN RAISE EXCEPTION 'v=%', MyVar; END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:       `SELECT r8();`,
+					ExpectedErr: `v=3`,
+				},
+			},
+		},
+		{
+			Name: "a quoted name is a different identifier from an unquoted one",
+			Assertions: []ScriptTestAssertion{
+				{
+					// `MyVar` unquoted folds to `myvar`, so it names the outer variable rather than the
+					// quoted inner one.
+					Query: `CREATE FUNCTION s1() RETURNS text LANGUAGE plpgsql AS $$
+DECLARE myvar text := 'outer';
+BEGIN
+	DECLARE "MyVar" text := 'inner-quoted';
+	BEGIN
+		RETURN MyVar;
+	END;
+END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT s1();`,
+					Expected: []sql.Row{{"outer"}},
+				},
+				{
+					// With only a quoted declaration, an unquoted reference names nothing.
+					Query: `CREATE FUNCTION s2() RETURNS int LANGUAGE plpgsql AS $$
+DECLARE "MyVar" int := 1; BEGIN RETURN MyVar; END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:       `SELECT s2();`,
+					ExpectedErr: `myvar`,
+				},
+			},
+		},
+		{
+			Name: "FOR loop variables fold like any other name",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `CREATE FUNCTION l1() RETURNS int LANGUAGE plpgsql AS $$
+DECLARE acc int := 0; BEGIN FOR I IN 1..3 LOOP acc := acc + i; END LOOP; RETURN acc; END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT l1();`,
+					Expected: []sql.Row{{6}},
+				},
+				{
+					// A quoted loop variable keeps its capitals, so the generated loop condition has to
+					// name it in a way that survives folding.
+					Query: `CREATE FUNCTION l2() RETURNS int LANGUAGE plpgsql AS $$
+DECLARE acc int := 0; BEGIN FOR "I" IN 1..3 LOOP acc := acc + "I"; END LOOP; RETURN acc; END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `SELECT l2();`,
+					Expected: []sql.Row{{6}},
+				},
+				{
+					Query: `CREATE FUNCTION l3() RETURNS int LANGUAGE plpgsql AS $$
+DECLARE acc int := 0; BEGIN FOR "I" IN 1..3 LOOP acc := acc + i; END LOOP; RETURN acc; END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:       `SELECT l3();`,
+					ExpectedErr: `"i"`,
+				},
+			},
+		},
+		{
+			// TG_OP is left out deliberately: it is not populated for a trigger whose source node is
+			// wrapped, so it resolves to nothing regardless of how it is spelled.
+			Name: "trigger records fold like any other name",
+			SetUpScript: []string{
+				`CREATE TABLE t (id int primary key, v int);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: `CREATE FUNCTION g() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+	IF new.v < 0 THEN RAISE EXCEPTION 'negative %', new.v; END IF;
+	RETURN new;
+END; $$;`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `CREATE TRIGGER trg BEFORE INSERT ON t FOR EACH ROW EXECUTE FUNCTION g();`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    `INSERT INTO t VALUES (1, 5);`,
+					Expected: []sql.Row{},
+				},
+				{
+					Query:       `INSERT INTO t VALUES (2, -1);`,
+					ExpectedErr: `negative -1`,
+				},
+				{
+					Query:    `SELECT id FROM t;`,
+					Expected: []sql.Row{{1}},
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
Declarations were already folded but references used the source text as written.  `DECLARE MyVar` was unreachable as `MYVAR`, quoted declarations and references were poorly handled, and a trigger body could not write `new`/`old` in lowercase because TriggerCall had registered the identifiers as `NEW`/`OLD`.

Fold variable names at reference sites in the source text, including in expression references, assignment targets, RAISE arguments and EXECUTE USING arguments. Correspondingly register lowercase names for `NEW`/`OLD` and `TG_` variables.

We needed to add variable name quoting in the two places where the engine generates SQL that mentions a variable whose declared name we already hold: the integer FOR loop's condition and increment, and the CASE temporary.