### PR TITLE
Minor optimization for result row batching

### DIFF
--- a/server/doltgres_handler.go
+++ b/server/doltgres_handler.go
@@ -83,6 +83,39 @@ type Result struct {
 	Fields       []pgproto3.FieldDescription `json:"fields"`
 	Rows         []Row                       `json:"rows"`
 	RowsAffected uint64                      `json:"rows_affected"`
+	// availableRowValueCells is the unused tail of the current batch-owned metadata chunk.
+	availableRowValueCells [][]byte
+}
+
+// nextRowValues returns isolated, batch-owned column metadata for the next row.
+// It carves rows from geometrically grown chunks and caps speculative capacity
+// for wide rows. Returned row slices retain their chunks until the batch is done.
+func (r *Result) nextRowValues(columnCount int) [][]byte {
+	if columnCount <= 0 || len(r.Rows) >= rowsBatch {
+		return nil
+	}
+	if len(r.availableRowValueCells) < columnCount {
+		remainingRows := rowsBatch - len(r.Rows)
+		// Match the next chunk to the rows already covered, doubling total capacity.
+		chunkRows := len(r.Rows) + 1
+		// Consume the remainder when another geometric chunk would leave a small tail.
+		if chunkRows*2 > remainingRows {
+			chunkRows = remainingRows
+		}
+		// Always fit one row, even when its metadata exceeds the chunk budget.
+		maxChunkRows := maxRowValueChunkCells / columnCount
+		if maxChunkRows < 1 {
+			maxChunkRows = 1
+		}
+		if chunkRows > maxChunkRows {
+			chunkRows = maxChunkRows
+		}
+		r.availableRowValueCells = make([][]byte, chunkRows*columnCount)
+	}
+	// Clamp capacity so appending cannot overwrite the following row's metadata.
+	rowValues := r.availableRowValueCells[:columnCount:columnCount]
+	r.availableRowValueCells = r.availableRowValueCells[columnCount:]
+	return rowValues
 }
 
 // Row represents a single row value in bytes format.
@@ -92,7 +125,11 @@ type Row struct {
 	val [][]byte
 }
 
-const rowsBatch = 128
+const (
+	rowsBatch = 128
+	// maxRowValueChunkCells caps one arena allocation at about 96 KiB on 64-bit platforms.
+	maxRowValueChunkCells = 4096
+)
 
 // DoltgresHandler is a handler uses SQLe engine directly
 // running Doltgres specific queries.
@@ -400,21 +437,21 @@ func (h *DoltgresHandler) doQuery(ctx context.Context, c *mysql.Conn, query stri
 		if err != nil {
 			return err
 		}
-	} else if analyzer.FlagIsSet(qFlags, sql.QFlagMax1Row) {
-		resultFields, err := schemaToFieldDescriptions(sqlCtx, schema, formatCodes)
-		if err != nil {
-			return err
-		}
-		r, err = resultForMax1RowIter(sqlCtx, schema, rowIter, resultFields, formatCodes)
-		if err != nil {
-			return err
-		}
 	} else {
+		// Normalize wire format codes into one canonical per-column slice for result encoding.
+		formatCodes, err = extendFormatCodes(len(schema), formatCodes)
+		if err != nil {
+			return err
+		}
 		resultFields, err := schemaToFieldDescriptions(sqlCtx, schema, formatCodes)
 		if err != nil {
 			return err
 		}
-		r, processedAtLeastOneBatch, err = h.resultForDefaultIter(sqlCtx, schema, rowIter, callback, resultFields, formatCodes)
+		if analyzer.FlagIsSet(qFlags, sql.QFlagMax1Row) {
+			r, err = resultForMax1RowIter(sqlCtx, schema, rowIter, resultFields, formatCodes)
+		} else {
+			r, processedAtLeastOneBatch, err = h.resultForDefaultIter(sqlCtx, schema, rowIter, callback, resultFields, formatCodes)
+		}
 		if err != nil {
 			return err
 		}
@@ -726,7 +763,8 @@ func (h *DoltgresHandler) resultForDefaultIter(ctx *sql.Context, schema sql.Sche
 					continue
 				}
 
-				outputRow, rErr := rowToBytes(ctx, schema, row, formatCodes)
+				outputRow := res.nextRowValues(len(schema))
+				rErr := rowToBytesInto(ctx, schema, row, formatCodes, outputRow)
 				if rErr != nil {
 					return rErr
 				}
@@ -803,6 +841,27 @@ func rowToBytes(ctx *sql.Context, s sql.Schema, row sql.Row, formatCodes []int16
 		return nil, err
 	}
 	o := make([][]byte, len(row))
+	if err = rowToBytesInto(ctx, s, row, formatCodes, o); err != nil {
+		return nil, err
+	}
+	return o, nil
+}
+
+// rowToBytesInto encodes a row into caller-owned column metadata.
+func rowToBytesInto(ctx *sql.Context, s sql.Schema, row sql.Row, formatCodes []int16, o [][]byte) error {
+	if len(row) == 0 {
+		return nil
+	}
+	if len(s) == 0 {
+		return errors.Errorf("received empty schema")
+	}
+	if len(o) != len(row) {
+		return errors.Errorf("received output row of length %d for input row of length %d", len(o), len(row))
+	}
+	if len(formatCodes) != len(row) {
+		return errors.Errorf("received %d format codes for row of length %d", len(formatCodes), len(row))
+	}
+	var err error
 	for i, v := range row {
 		if v == nil {
 			o[i] = nil
@@ -811,26 +870,26 @@ func rowToBytes(ctx *sql.Context, s sql.Schema, row sql.Row, formatCodes []int16
 			case *pgtypes.DoltgresType:
 				o[i], err = d.CallSend(ctx, v)
 				if err != nil {
-					return nil, err
+					return err
 				}
 			default:
 				cast := pgexprs.NewGMSCast(expression.NewLiteral(v, d))
 				v, err = cast.Eval(ctx, nil)
 				if err != nil {
-					return nil, err
+					return err
 				}
 				o[i], err = cast.DoltgresType(ctx).CallSend(ctx, v)
 				if err != nil {
-					return nil, err
+					return err
 				}
 			}
 		} else {
 			val, err := s[i].Type.SQL(ctx, []byte{}, v) // We use []byte{} as there's a distinction between nil and empty
 			if err != nil {
-				return nil, err
+				return err
 			}
 			o[i] = val.ToBytes()
 		}
 	}
-	return o, nil
+	return nil
 }

--- a/testing/go/result_batch_test.go
+++ b/testing/go/result_batch_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _go
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/jackc/pgx/v5/pgproto3"
+)
+
+// TestResultBatchBoundaries exercises empty, partial, exact, and overflowing
+// wire-result batches. In addition to row ordering, the nullable and text
+// columns protect the lifetime of values retained until a batch is encoded.
+func TestResultBatchBoundaries(t *testing.T) {
+	const maxRows = 129
+	values := make([]string, maxRows)
+	for i := range values {
+		id := i + 1
+		textValue := fmt.Sprintf("'value-%03d'", id)
+		if id%17 == 0 {
+			textValue = "NULL"
+		}
+		values[i] = fmt.Sprintf("(%d, %s)", id, textValue)
+	}
+
+	assertions := make([]ScriptTestAssertion, 0, 5)
+	for _, rowCount := range []int{0, 1, 127, 128, 129} {
+		expected := make([]sql.Row, rowCount)
+		for i := range expected {
+			id := i + 1
+			var textValue any = fmt.Sprintf("value-%03d", id)
+			if id%17 == 0 {
+				textValue = nil
+			}
+			expected[i] = sql.Row{int32(id), textValue}
+		}
+		assertions = append(assertions, ScriptTestAssertion{
+			Query:    fmt.Sprintf("SELECT id, value FROM result_batch_test ORDER BY id LIMIT %d", rowCount),
+			Expected: expected,
+		})
+	}
+
+	RunScripts(t, []ScriptTest{{
+		Name: "result batch boundaries",
+		SetUpScript: []string{
+			"CREATE TABLE result_batch_test (id INT PRIMARY KEY, value TEXT)",
+			"INSERT INTO result_batch_test VALUES " + strings.Join(values, ","),
+		},
+		Assertions: assertions,
+	}})
+}
+
+// TestResultBatchMixedFormats verifies that mixed text, binary, and NULL values
+// remain correct when a result crosses the internal batch boundary.
+func TestResultBatchMixedFormats(t *testing.T) {
+	const rowCount = 129
+	values := make([]string, rowCount)
+	receive := make([]pgproto3.BackendMessage, 0, rowCount+4)
+	receive = append(receive, &pgproto3.ParseComplete{}, &pgproto3.BindComplete{})
+	for i := range values {
+		id := i + 1
+		textValue := fmt.Sprintf("'value-%03d'", id)
+		var wireText []byte
+		if id%17 == 0 || id == rowCount {
+			textValue = "NULL"
+		} else {
+			wireText = []byte(fmt.Sprintf("value-%03d", id))
+		}
+		values[i] = fmt.Sprintf("(%d, %s)", id, textValue)
+		wireID := make([]byte, 4)
+		binary.BigEndian.PutUint32(wireID, uint32(id))
+		receive = append(receive, &pgproto3.DataRow{Values: [][]byte{wireID, wireText}})
+	}
+	receive = append(receive,
+		&pgproto3.CommandComplete{CommandTag: []byte("SELECT 129")},
+		&pgproto3.ReadyForQuery{TxStatus: 'I'},
+	)
+
+	RunWireScripts(t, []WireScriptTest{{
+		Name: "mixed formats across result batch boundary",
+		SetUpScript: []string{
+			"CREATE TABLE result_batch_mixed_test (id INT PRIMARY KEY, value TEXT)",
+			"INSERT INTO result_batch_mixed_test VALUES " + strings.Join(values, ","),
+		},
+		Assertions: []WireScriptTestAssertion{{
+			Send: []pgproto3.FrontendMessage{
+				&pgproto3.Parse{Name: "result_batch_mixed", Query: "SELECT id, value FROM result_batch_mixed_test ORDER BY id"},
+				&pgproto3.Bind{PreparedStatement: "result_batch_mixed", ResultFormatCodes: []int16{1, 0}},
+				&pgproto3.Execute{},
+				&pgproto3.Sync{},
+			},
+			Receive: receive,
+		}},
+	}})
+}


### PR DESCRIPTION
Batch pgwire row metadata in result-owned chunks and normalize result format codes once per result set. This removes per-row metadata allocations without pooling or changing payload encoding. Covers text, binary, mixed-format, NULL, and short-final-batch results.

Local sysbench runs against an isolated 24-column dataset, median text-scan latency improved 2.9% (16.25 to 15.77 ms). Mixed-type and binary results were within run-to-run variation, so no latency improvement is claimed for those workloads, due to the increase latency for binary protocol format encoding.