### PR TITLE
Fix INSERT SELECT parameter type inference

### DIFF
--- a/server/analyzer/assign_insert_casts.go
+++ b/server/analyzer/assign_insert_casts.go
@@ -94,9 +94,13 @@ func AssignInsertCasts(ctx *sql.Context, a *analyzer.Analyzer, node sql.Node, sc
 		sourceSchema := insertInto.Source.Schema(ctx)
 		projections := make([]sql.Expression, len(sourceSchema))
 		for i, col := range sourceSchema {
-			fromColType, ok := col.Type.(*pgtypes.DoltgresType)
+			colType := col.Type
+			if colType == nil || colType == types.Null {
+				colType = pgtypes.Unknown
+			}
+			fromColType, ok := colType.(*pgtypes.DoltgresType)
 			if !ok {
-				return nil, transform.NewTree, errors.Errorf("INSERT: non-Doltgres type found in source: %s", fromColType.String())
+				return nil, transform.NewTree, errors.Errorf("INSERT: non-Doltgres type found in source: %s", colType.String())
 			}
 			toColType := destinationTypes[i]
 			getField := expression.NewGetField(i, fromColType, col.Name, true)

--- a/server/connection_data.go
+++ b/server/connection_data.go
@@ -201,6 +201,7 @@ func extractBindVarTypes(ctx *sql.Context, queryPlan sql.Node) ([]uint32, error)
 	switch queryPlan := queryPlan.(type) {
 	case *plan.InsertInto:
 		transform.InspectExpressionsWithNode(ctx, queryPlan.Source, extractBindVars)
+		bindInsertSelect(ctx, queryPlan, types)
 	}
 
 	// above finds types of bindvars in unordered form.
@@ -217,6 +218,34 @@ func extractBindVarTypes(ctx *sql.Context, queryPlan sql.Node) ([]uint32, error)
 		typesArr[idx-1] = t
 	}
 	return typesArr, err
+}
+
+// bindInsertSelect infers direct SELECT bind variables from their corresponding INSERT destination columns.
+func bindInsertSelect(ctx *sql.Context, insert *plan.InsertInto, types map[string]uint32) {
+	project, ok := insert.Source.(*plan.Project)
+	if !ok {
+		return
+	}
+	destinationTypes := make(map[string]sql.Type)
+	for _, col := range insert.Destination.Schema(ctx) {
+		destinationTypes[strings.ToLower(col.Name)] = col.Type
+	}
+	unknownOID := id.Cache().ToOID(pgtypes.Unknown.ID.AsId())
+	for i, projection := range project.Projections {
+		bindVar := pgexprs.UnwrapBindVar(projection)
+		if bindVar == nil || i >= len(insert.ColumnNames) || types[bindVar.Name] != unknownOID {
+			continue
+		}
+		destinationType, ok := destinationTypes[strings.ToLower(insert.ColumnNames[i])]
+		if !ok {
+			continue
+		}
+		if doltgresType, ok := destinationType.(*pgtypes.DoltgresType); ok {
+			types[bindVar.Name] = id.Cache().ToOID(doltgresType.ID.AsId())
+		} else if typOID, typeErr := VitessTypeToObjectID(destinationType); typeErr == nil {
+			types[bindVar.Name] = typOID
+		}
+	}
 }
 
 // VitessTypeToObjectID returns a type, as defined by Vitess, into a type as defined by Postgres.

--- a/testing/go/binding_test.go
+++ b/testing/go/binding_test.go
@@ -65,6 +65,42 @@ func TestBindingWithOidZero(t *testing.T) {
 	assert.Equal(t, "Alice", name)
 }
 
+// TestBindingInsertSelectWithOidZero verifies that INSERT target columns supply
+// types for otherwise untyped parameters in a SELECT source.
+func TestBindingInsertSelectWithOidZero(t *testing.T) {
+	ctx, connection, controller := CreateServer(t, "postgres")
+	defer func() {
+		connection.Close(ctx)
+		controller.Stop()
+		require.NoError(t, controller.WaitForStop())
+	}()
+	conn := connection.Default
+
+	_, err := connection.Exec(ctx, "CREATE TABLE t (id INT PRIMARY KEY, v BIGINT, label TEXT);")
+	require.NoError(t, err)
+
+	sql := "INSERT INTO t (id, v, label) SELECT $1, $2, $3"
+	description, err := conn.PgConn().Prepare(ctx, "insert_select", sql, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []uint32{pgtype.Int4OID, pgtype.Int8OID, pgtype.TextOID}, description.ParamOIDs)
+
+	args := [][]byte{[]byte("12"), []byte("9223372036854775806"), []byte("inserted")}
+	paramOIDs := []uint32{0, 0, 0}
+	paramFormats := []int16{0, 0, 0}
+	result := conn.PgConn().ExecParams(ctx,
+		sql,
+		args, paramOIDs, paramFormats, nil).Read()
+	require.NoError(t, result.Err)
+
+	var id int32
+	var value int64
+	var label string
+	require.NoError(t, conn.QueryRow(ctx, "SELECT id, v, label FROM t").Scan(&id, &value, &label))
+	assert.Equal(t, int32(12), id)
+	assert.Equal(t, int64(9223372036854775806), value)
+	assert.Equal(t, "inserted", label)
+}
+
 // TestBindingInt4ToBigintWithUntypedNull is a regression test for
 // https://github.com/dolthub/doltgresql/issues/2973: an int4-typed parameter bound to
 // a BIGINT column was silently corrupted whenever the same statement also had an untyped


### PR DESCRIPTION
Treat unresolved source types in `INSERT ... SELECT` as PostgreSQL `unknown`, allowing assignment casts to use the destination column type without dereferencing a nil `DoltgresType`.

Infer direct projected bind-variable OIDs from the INSERT destination for PostgreSQL-compatible Parse/Describe responses while preserving explicit client-supplied OIDs. Add extended-protocol regression coverage for inferred `int4`, `int8`, and `text` parameters and successful execution.

Fixes #3234