### PR TITLE
[no-release-notes] Fix SQLAlchemy pg_index expectation

### DIFF
--- a/testing/go/pgcatalog_test.go
+++ b/testing/go/pgcatalog_test.go
@@ -6603,7 +6603,7 @@ FROM pg_catalog.pg_index
 WHERE pg_catalog.pg_index.indrelid IN (select oid from pg_class where relname='t2')
   AND NOT pg_catalog.pg_index.indisprimary ORDER BY pg_catalog.pg_index.indrelid, cls_idx.relname`,
 					Expected: []sql.Row{
-						{1496157034, "t2_b_idx", "f", "f", "0", nil, "btree", nil, 0, "f", "{b}", "{f}"},
+						{1496157034, "t2_b_idx", "f", "f", "0", nil, "btree", nil, 1, "f", "{b}", "{f}"},
 					},
 				},
 			},


### PR DESCRIPTION
Updates the SQLAlchemy catalog expectation missed by #3150. A single-column index reports indnkeyatts = 1, matching the existing Doltgres catalog behavior and the exact query result from PostgreSQL 16.13.