### PR TITLE
Support targetless ON CONFLICT DO NOTHING

### DIFF
--- a/server/ast/insert.go
+++ b/server/ast/insert.go
@@ -42,10 +42,17 @@ func nodeInsert(ctx *Context, node *tree.Insert) (insert *vitess.Insert, err err
 	var ignore string
 	var onDuplicate vitess.OnDup
 	var onDuplicateWhere vitess.Expr
+	var conflictTarget vitess.Columns
 
 	if node.OnConflict != nil {
 		if isIgnore(node.OnConflict) {
 			ignore = vitess.IgnoreStr
+			if len(node.OnConflict.Columns) > 0 {
+				conflictTarget = make(vitess.Columns, len(node.OnConflict.Columns))
+				for i, column := range node.OnConflict.Columns {
+					conflictTarget[i] = vitess.NewColIdent(string(column))
+				}
+			}
 		} else if supportedOnConflictClause(node.OnConflict) {
 			// TODO: we are ignoring the column names, which are used to infer which index under conflict is to be checked
 			updateExprs, err := nodeUpdateExprs(ctx, node.OnConflict.Exprs)
@@ -120,6 +127,7 @@ func nodeInsert(ctx *Context, node *tree.Insert) (insert *vitess.Insert, err err
 		Returning:        returningExprs,
 		With:             with,
 		Columns:          columns,
+		ConflictTarget:   conflictTarget,
 		Rows:             rows,
 		OnDup:            onDuplicate,
 		OnDupValuesAlias: "excluded",

--- a/server/connection_handler.go
+++ b/server/connection_handler.go
@@ -1767,6 +1767,9 @@ func castSQLError(err error) *pgconn.PgError {
 	// TODO: should update the error message to match Postgres
 	var code pgcode.Code
 	switch {
+	// Class 42 — Syntax Error or Access Rule Violation
+	case sql.ErrInsertConflictTarget.Is(err):
+		code = pgcode.InvalidColumnReference
 	// Class 0A — Feature Not Supported
 	case sql.ErrUnsupportedFeature.Is(err), sql.ErrUnsupportedSyntax.Is(err):
 		code = pgcode.FeatureNotSupported

--- a/servercfg/config.go
+++ b/servercfg/config.go
@@ -45,6 +45,7 @@ func (*DoltgresConfig) Overrides() sql.EngineOverrides {
 		Builder: sql.BuilderOverrides{
 			ParseTableAsColumn:          expression.NewTableToComposite,
 			ScalarFunctionAliasAsColumn: true,
+			InsertIgnoreMode:            sql.InsertIgnoreModeDuplicateKeysOnly,
 			Parser:                      pgsql.NewPostgresParser(),
 		},
 		Hooks: sql.ExecutionHooks{

--- a/testing/go/enginetest/doltgres_engine_test.go
+++ b/testing/go/enginetest/doltgres_engine_test.go
@@ -260,8 +260,9 @@ func TestInsertInto(t *testing.T) {
 
 func TestInsertIgnoreInto(t *testing.T) {
 	h := newDoltgresServerHarness(t).WithSkippedQueries([]string{
-		"Test that INSERT IGNORE properly addresses data conversion", // postgres strict typing rejects MySQL coercions
-		"Insert Ignore works correctly with ON DUPLICATE UPDATE",     // postgres strict typing rejects MySQL coercions
+		"Test that INSERT IGNORE properly addresses data conversion", // PostgreSQL strict typing rejects MySQL coercions
+		"Test that INSERT IGNORE with Non nullable columns works",    // PostgreSQL does not ignore NOT NULL violations
+		"Insert Ignore works correctly with ON DUPLICATE UPDATE",     // PostgreSQL strict typing rejects MySQL coercions
 		"issue 8611: insert ignore on enum type column",              // enums not supported
 	})
 	defer h.Close()
@@ -1720,12 +1721,7 @@ func TestTimeQueries(t *testing.T) {
 }
 
 func TestUpdateIgnore(t *testing.T) {
-	h := newDoltgresServerHarness(t).WithSkippedQueries([]string{
-		"UPDATE IGNORE with primary keys and indexes", // ignore semantics are different
-		"UPDATE IGNORE with type conversions",         // postgres strict typing rejects MySQL coercions
-	})
-	defer h.Close()
-	enginetest.TestUpdateIgnore(t, h)
+	t.Skip("MySQL UPDATE IGNORE semantics are not applicable to PostgreSQL")
 }
 
 func TestUserPrivileges(t *testing.T) {

--- a/testing/go/enginetest/query_converter_test.go
+++ b/testing/go/enginetest/query_converter_test.go
@@ -134,7 +134,6 @@ func transformUpdate(stmt *sqlparser.Update) ([]string, bool) {
 			Select: selectClause,
 		},
 		OnConflict: &tree.OnConflict{
-			Columns:   tree.NameList{tree.Name("fake")}, // placeholder, see transformInsert
 			DoNothing: true,
 		},
 		Returning: &tree.NoReturningClause{},
@@ -264,7 +263,6 @@ func transformInsert(stmt *sqlparser.Insert) ([]string, bool) {
 		rows := rowsForInsert(stmt.Rows)
 
 		onConflict := tree.OnConflict{
-			Columns:   tree.NameList{tree.Name("fake")}, // column list ignored but must be present for valid syntax
 			DoNothing: true,
 		}
 
@@ -2397,19 +2395,19 @@ func TestUpdateIgnoreConversion(t *testing.T) {
 		{
 			input: "UPDATE IGNORE mytable SET i = 2 WHERE i = 1",
 			expected: []string{
-				"INSERT INTO mytable(i) SELECT 2 FROM mytable WHERE i = 1 ON CONFLICT (fake) DO NOTHING",
+				"INSERT INTO mytable(i) SELECT 2 FROM mytable WHERE i = 1 ON CONFLICT DO NOTHING",
 			},
 		},
 		{
 			input: "UPDATE IGNORE pkTable SET pk = pk + 1, val = val + 1",
 			expected: []string{
-				`INSERT INTO "pkTable"(pk, val) SELECT pk + 1, val + 1 FROM "pkTable" ON CONFLICT (fake) DO NOTHING`,
+				`INSERT INTO "pkTable"(pk, val) SELECT pk + 1, val + 1 FROM "pkTable" ON CONFLICT DO NOTHING`,
 			},
 		},
 		{
 			input: "UPDATE IGNORE t1 SET v1 = v1 + 5 WHERE pk > 3",
 			expected: []string{
-				"INSERT INTO t1(v1) SELECT v1 + 5 FROM t1 WHERE pk > 3 ON CONFLICT (fake) DO NOTHING",
+				"INSERT INTO t1(v1) SELECT v1 + 5 FROM t1 WHERE pk > 3 ON CONFLICT DO NOTHING",
 			},
 		},
 	}

--- a/testing/go/insert_test.go
+++ b/testing/go/insert_test.go
@@ -189,6 +189,157 @@ ON CONFLICT (id) do update set c1 = $4`,
 			},
 		},
 		{
+			Name: "on conflict do nothing only ignores uniqueness conflicts",
+			SetUpScript: []string{
+				"CREATE TABLE conflict_parent (id INT PRIMARY KEY)",
+				"CREATE TABLE conflict_child (id INT PRIMARY KEY, parent_id INT NOT NULL REFERENCES conflict_parent(id), positive INT CHECK (positive > 0))",
+				"CREATE TABLE self_referencing_child (id INT PRIMARY KEY, parent_id INT REFERENCES self_referencing_child(id))",
+				"CREATE TABLE secondary_unique_child (id INT PRIMARY KEY, unique_value INT UNIQUE, parent_id INT REFERENCES conflict_parent(id))",
+				"CREATE TABLE conflict_arbiter (id INT PRIMARY KEY, unique_value INT UNIQUE, a INT, b INT, UNIQUE (a, b))",
+				"CREATE TABLE invalid_conflict_target (id INT PRIMARY KEY, non_unique INT)",
+				"CREATE TABLE crossed_conflict (id INT PRIMARY KEY, unique_value INT UNIQUE)",
+				"CREATE TABLE crossed_keyless_conflict (a INT UNIQUE, b INT UNIQUE)",
+				"CREATE TABLE crossed_partial_conflict (a INT, b INT UNIQUE)",
+				"CREATE UNIQUE INDEX a_partial ON crossed_partial_conflict (a) WHERE b > 0",
+				"CREATE UNIQUE INDEX z_full ON crossed_partial_conflict (a)",
+				"INSERT INTO conflict_parent VALUES (1)",
+				"INSERT INTO conflict_child VALUES (1, 1, 1)",
+				"INSERT INTO secondary_unique_child VALUES (1, 10, 1)",
+				"INSERT INTO conflict_arbiter VALUES (1, 10, 20, 30)",
+				"INSERT INTO crossed_conflict VALUES (1, 10), (2, 20)",
+				"INSERT INTO crossed_keyless_conflict VALUES (1, 10), (2, 20)",
+				"INSERT INTO crossed_partial_conflict VALUES (1, 10), (2, 20)",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:           "INSERT INTO conflict_child VALUES (2, 999, 1) ON CONFLICT DO NOTHING",
+					ExpectedErr:     "Foreign key violation",
+					ExpectedErrCode: "23503",
+				},
+				{
+					Query:           "INSERT INTO conflict_child VALUES (2, 1, -1) ON CONFLICT DO NOTHING",
+					ExpectedErr:     "Check constraint",
+					ExpectedErrCode: "23514",
+				},
+				{
+					Query: "INSERT INTO conflict_child VALUES (1, 999, 1) ON CONFLICT DO NOTHING",
+				},
+				{
+					Query: "INSERT INTO secondary_unique_child VALUES (2, 10, 999) ON CONFLICT DO NOTHING",
+				},
+				{
+					Query: "SELECT * FROM secondary_unique_child ORDER BY id",
+					Expected: []sql.Row{
+						{1, 10, 1},
+					},
+				},
+				{
+					Query: "INSERT INTO conflict_arbiter VALUES (1, 11, 21, 31) ON CONFLICT (id) DO NOTHING",
+				},
+				{
+					Query:           "INSERT INTO conflict_arbiter VALUES (2, 10, 21, 31) ON CONFLICT (id) DO NOTHING",
+					ExpectedErr:     "duplicate unique key given",
+					ExpectedErrCode: "23505",
+				},
+				{
+					Query: "INSERT INTO conflict_arbiter VALUES (2, 11, 20, 30) ON CONFLICT (a, b) DO NOTHING",
+				},
+				{
+					Query: "INSERT INTO conflict_arbiter VALUES (2, 10, 21, 31) ON CONFLICT DO NOTHING",
+				},
+				{
+					Query: "SELECT * FROM conflict_arbiter ORDER BY id",
+					Expected: []sql.Row{
+						{1, 10, 20, 30},
+					},
+				},
+				{
+					Query:           "INSERT INTO invalid_conflict_target VALUES (1, 10) ON CONFLICT (non_unique) DO NOTHING",
+					ExpectedErr:     "there is no unique or exclusion constraint matching the ON CONFLICT specification",
+					ExpectedErrCode: "42P10",
+				},
+				{
+					Query:           "INSERT INTO invalid_conflict_target VALUES (1, 10) ON CONFLICT (missing) DO NOTHING",
+					ExpectedErr:     `column "missing" could not be found in any table in scope`,
+					ExpectedErrCode: "42703",
+				},
+				{
+					Query: "SELECT * FROM invalid_conflict_target",
+				},
+				{
+					Query: "INSERT INTO crossed_conflict VALUES (1, 20) ON CONFLICT (id) DO NOTHING",
+				},
+				{
+					Query: "INSERT INTO crossed_conflict VALUES (1, 20) ON CONFLICT (unique_value) DO NOTHING",
+				},
+				{
+					Query: "INSERT INTO crossed_conflict VALUES (3, 30), (3, 10) ON CONFLICT (id) DO NOTHING",
+				},
+				{
+					Query: "SELECT * FROM crossed_conflict ORDER BY id",
+					Expected: []sql.Row{
+						{1, 10},
+						{2, 20},
+						{3, 30},
+					},
+				},
+				{
+					Query: "INSERT INTO crossed_keyless_conflict VALUES (3, 30), (3, 10) ON CONFLICT (a) DO NOTHING",
+				},
+				{
+					Query: "SELECT * FROM crossed_keyless_conflict ORDER BY a",
+					Expected: []sql.Row{
+						{1, 10},
+						{2, 20},
+						{3, 30},
+					},
+				},
+				{
+					Query: "INSERT INTO crossed_partial_conflict VALUES (3, -1), (3, 10) ON CONFLICT (a) DO NOTHING",
+				},
+				{
+					Query: "SELECT * FROM crossed_partial_conflict ORDER BY a",
+					Expected: []sql.Row{
+						{1, 10},
+						{2, 20},
+						{3, -1},
+					},
+				},
+				{
+					Query: "INSERT INTO self_referencing_child VALUES (1, 1) ON CONFLICT DO NOTHING",
+				},
+				{
+					Query: "SELECT * FROM self_referencing_child",
+					Expected: []sql.Row{
+						{1, 1},
+					},
+				},
+				{
+					Query:    "INSERT INTO conflict_child VALUES (1, 1, 1), (2, 1, 1) ON CONFLICT DO NOTHING RETURNING id",
+					Expected: []sql.Row{{2}},
+				},
+				{
+					Query: "SELECT * FROM conflict_child ORDER BY id",
+					Expected: []sql.Row{
+						{1, 1, 1},
+						{2, 1, 1},
+					},
+				},
+				{
+					Query:           "INSERT INTO conflict_child VALUES (2, 1, 1), (3, 999, 1) ON CONFLICT DO NOTHING",
+					ExpectedErr:     "Foreign key violation",
+					ExpectedErrCode: "23503",
+				},
+				{
+					Query: "SELECT * FROM conflict_child ORDER BY id",
+					Expected: []sql.Row{
+						{1, 1, 1},
+						{2, 1, 1},
+					},
+				},
+			},
+		},
+		{
 			Name: "null and unspecified default values",
 			SetUpScript: []string{
 				"CREATE TABLE t (i INT DEFAULT NULL, j INT)",


### PR DESCRIPTION
Support PostgreSQL INSERT ... ON CONFLICT DO NOTHING without a conflict target. The execution path skips unique-key conflicts while continuing to report foreign-key, check, and NOT NULL violations, with regression coverage for multi-row and targeted cases.

Depends on:
- https://github.com/dolthub/vitess/pull/485
- https://github.com/dolthub/dolt/pull/11668
- https://github.com/dolthub/go-mysql-server/pull/3758

Fixes #3091