### PR TITLE
[no-release-notes] Automate Dolt dependency bump PRs

### DIFF
--- a/.github/workflows/bump-dependency.yaml
+++ b/.github/workflows/bump-dependency.yaml
@@ -4,6 +4,10 @@ on:
   repository_dispatch:
     types: [ bump-dependency ]
 
+concurrency:
+  group: bump-dependency-${{ github.event.client_payload.dependency }}
+  cancel-in-progress: false
+
 jobs:
   get-label:
     name: Get Label
@@ -88,6 +92,9 @@ jobs:
     needs: [get-label, stale-bump-prs]
     name: Open Bump PR
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       latest-pr: ${{ steps.latest-pr.outputs.pr_url }}
     steps:
@@ -99,54 +106,139 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Bump dependency
+        env:
+          DEPENDENCY: ${{ github.event.client_payload.dependency }}
+          HEAD_SHA: ${{ github.event.client_payload.head_commit_sha }}
         run: |
-          go get github.com/dolthub/${{ github.event.client_payload.dependency }}/go@${{ github.event.client_payload.head_commit_sha }}
+          set -euo pipefail
+          if [[ ! "$HEAD_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "Invalid dependency commit SHA"
+            exit 1
+          fi
+          go get "github.com/dolthub/${DEPENDENCY}/go@${HEAD_SHA}"
           go mod tidy
-      - name: Get short hash
-        id: short-sha
+      - name: Verify dependency version
+        env:
+          DEPENDENCY: ${{ github.event.client_payload.dependency }}
+          HEAD_SHA: ${{ github.event.client_payload.head_commit_sha }}
         run: |
-          commit=${{ github.event.client_payload.head_commit_sha }}
-          short=${commit:0:8}
-          echo "short=$short" >> $GITHUB_OUTPUT
-      - name: Get Assignee and Reviewer
-        id: get_reviewer
-        run: |
-          if [ "${{ github.event.client_payload.assignee }}" == "github-actions[bot]" ]
-          then
-            echo "assignee=zachmu" >> $GITHUB_OUTPUT
-          else
-            assignee="${{ github.event.client_payload.assignee }}"
-            echo "assignee=$assignee" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          module="github.com/dolthub/${DEPENDENCY}/go"
+          requested_version="$(go list -m -f '{{.Version}}' "${module}@${HEAD_SHA}")"
+          selected_version="$(go list -m -f '{{.Version}}' "${module}")"
+          if [ "$selected_version" != "$requested_version" ]; then
+            echo "Selected ${module}@${selected_version}; expected ${requested_version}"
+            exit 1
           fi
-  
-          if [ "${{ github.event.client_payload.assignee }}" == "zachmu" ]
-          then
-            echo "reviewer=Hydrocharged" >> $GITHUB_OUTPUT
-          else
-            echo "reviewer=zachmu" >> $GITHUB_OUTPUT
-          fi
-
       - name: Create and Push new branch
+        id: bump-commit
+        env:
+          HEAD_SHA: ${{ github.event.client_payload.head_commit_sha }}
         run: |
-          git config --global --add user.name "${{ steps.get_reviewer.outputs.assignee }}"
-          git config --global --add user.email "${{ github.event.client_payload.assignee_email }}"
-          branchname=${{ format('{0}-{1}', steps.get_reviewer.outputs.assignee, steps.short-sha.outputs.short) }}
-          git checkout -b "$branchname"
+          set -euo pipefail
+          branch="auto-bump-dolt-${HEAD_SHA:0:8}"
+          git config --global --add user.name "github-actions[bot]"
+          git config --global --add user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
           git add .
-          git commit -m "${{ format('[ga-bump-dep] Bump dependency in Doltgres by {0}', steps.get_reviewer.outputs.assignee) }}"
-          git push origin "$branchname"
+          git commit -m "[ga-bump-dep] Bump Dolt dependency in Doltgres"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          git push origin "$branch"
       - name: pull-request
         uses: repo-sync/pull-request@v2
         id: latest-pr
         with:
-          source_branch: ${{ format('{0}-{1}', steps.get_reviewer.outputs.assignee, steps.short-sha.outputs.short ) }}
+          source_branch: ${{ steps.bump-commit.outputs.branch }}
           destination_branch: "main"
-          github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN || secrets.REPO_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
-          pr_title: "[auto-bump] [no-release-notes] dependency by ${{ steps.get_reviewer.outputs.assignee }}"
+          github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN || secrets.REPO_ACCESS_TOKEN }}
+          pr_title: "[auto-bump] [no-release-notes] Dolt dependency"
           pr_template: ".github/markdown-templates/dep-bump.md"
-          pr_reviewer: ${{ steps.get_reviewer.outputs.reviewer }}
-          pr_assignee: ${{ github.event.client_payload.assignee }}
           pr_label: ${{ needs.get-label.outputs.label }}
+      - name: Validate and approve pull request
+        uses: actions/github-script@v7
+        env:
+          EXPECTED_BRANCH: ${{ steps.bump-commit.outputs.branch }}
+          EXPECTED_LABEL: ${{ needs.get-label.outputs.label }}
+          EXPECTED_SHA: ${{ steps.bump-commit.outputs.sha }}
+          PR_URL: ${{ steps.latest-pr.outputs.pr_url }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { EXPECTED_BRANCH, EXPECTED_LABEL, EXPECTED_SHA, PR_URL } = process.env;
+            const match = PR_URL.match(/\/pull\/(\d+)$/);
+            if (!match) throw new Error(`Unable to determine pull request number from ${PR_URL}`);
+
+            const pull_number = Number(match[1]);
+            const { owner, repo } = context.repo;
+            const { data: pull } = await github.rest.pulls.get({ owner, repo, pull_number });
+
+            if (pull.state !== "open") throw new Error("Pull request is not open");
+            if (pull.base.ref !== "main") throw new Error(`Unexpected base branch: ${pull.base.ref}`);
+            if (pull.head.repo?.full_name !== `${owner}/${repo}`) throw new Error("Pull request head is from a fork");
+            if (pull.head.ref !== EXPECTED_BRANCH) throw new Error(`Unexpected head branch: ${pull.head.ref}`);
+            if (pull.head.sha !== EXPECTED_SHA) throw new Error(`Unexpected head SHA: ${pull.head.sha}`);
+            if (!pull.labels.some(({ name }) => name === EXPECTED_LABEL)) {
+              throw new Error(`Pull request is missing expected label: ${EXPECTED_LABEL}`);
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number,
+              per_page: 100,
+            });
+            const allowed = new Set(["go.mod", "go.sum"]);
+            const unexpected = files.filter(({ filename }) => !allowed.has(filename));
+            if (!files.some(({ filename }) => filename === "go.mod")) {
+              throw new Error("Dependency bump did not change go.mod");
+            }
+            if (unexpected.length > 0) {
+              throw new Error(`Unexpected changed files: ${unexpected.map(({ filename }) => filename).join(", ")}`);
+            }
+
+            await github.rest.pulls.createReview({
+              owner,
+              repo,
+              pull_number,
+              commit_id: EXPECTED_SHA,
+              event: "APPROVE",
+              body: "Automated approval: validated dependency-only update.",
+            });
+      - name: Disable auto-merge on superseded pull requests
+        if: ${{ needs.stale-bump-prs.outputs.stale-pulls != '' }}
+        uses: actions/github-script@v7
+        env:
+          STALE_PULLS: ${{ needs.stale-bump-prs.outputs.stale-pulls }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pulls = JSON.parse(process.env.STALE_PULLS);
+
+            for (const { number, keepAlive } of pulls) {
+              if (keepAlive) continue;
+              const { data: pull } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: number,
+              });
+              if (!pull.auto_merge) continue;
+
+              await github.graphql(`
+                mutation($pullRequestId: ID!) {
+                  disablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId}) {
+                    pullRequest { number }
+                  }
+                }
+              `, { pullRequestId: pull.node_id });
+            }
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.bump-commit.outputs.sha }}
+          PR_URL: ${{ steps.latest-pr.outputs.pr_url }}
+        run: gh pr merge "$PR_URL" --auto --squash --match-head-commit "$HEAD_SHA"
 
   comment-on-stale-prs:
     needs: [open-bump-pr, stale-bump-prs]


### PR DESCRIPTION
Automates the existing Dolt dependency-bump PR lifecycle:

- Serializes bump runs and removes unused human assignee/reviewer handling.
- Validates the dispatched commit and confirms Go selected the requested Dolt version.
- Creates a deterministic bot-authored branch with a PAT-backed PR creator distinct from the approver.
- Verifies the exact PR head, base, label, repository, and `go.mod`/`go.sum`-only file set before approving that commit with `GITHUB_TOKEN`.
- Disables auto-merge on superseded bumps, then enables squash auto-merge on the validated replacement so required CI remains the merge gate.

Requires the repository Actions policy to allow `GITHUB_TOKEN` pull-request approvals.