### PR TITLE
Support wrapped create tables in CTAS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dolthub/dolt/go v0.40.5-0.20260909123323-1db5c3a346eb
 	github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.20.1-0.20260909105556-71a5b2098e95
+	github.com/dolthub/go-mysql-server v0.20.1-0.20260909191122-dd708156e10b
 	github.com/dolthub/pg_query_go/v6 v6.0.0-20251215122834-fb20be4254d1
 	github.com/dolthub/sqllogictest/go v0.0.0-20260624223518-788480b24166
 	github.com/dolthub/vitess v0.0.0-20260909054055-e9f1b2468025

--- a/go.sum
+++ b/go.sum
@@ -258,6 +258,8 @@ github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83 h1:FEMjCGEroD
 github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260909105556-71a5b2098e95 h1:n07hqiac4xime9TyEYDWfHbwUA7tyfKePCmsrj+//7E=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260909105556-71a5b2098e95/go.mod h1:dhOSHdtMpz0sxA087pU4jspKUlEVQ/A+QH/7jtp78J4=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260909191122-dd708156e10b h1:j9F1SUy8w4X2VSkD7y7Rx2p/ofKLHtf+XRPNNkLsFRw=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260909191122-dd708156e10b/go.mod h1:dhOSHdtMpz0sxA087pU4jspKUlEVQ/A+QH/7jtp78J4=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20260414231531-5f031e3e9037 h1:oIW9HwuWrhxv+4HZxA+QQSKHLqWFyXZ2FmNjUYwkdiM=

--- a/server/node/create_table.go
+++ b/server/node/create_table.go
@@ -33,6 +33,7 @@ type CreateTable struct {
 var _ sql.ExecBuilderNode = (*CreateTable)(nil)
 var _ sql.SchemaTarget = (*CreateTable)(nil)
 var _ sql.Expressioner = (*CreateTable)(nil)
+var _ plan.TableCopierCreateTableDestination = (*CreateTable)(nil)
 
 // NewCreateTable returns a new *CreateTable.
 func NewCreateTable(createTable *plan.CreateTable, sequences []*CreateSequence) *CreateTable {
@@ -60,6 +61,11 @@ func (c *CreateTable) Expressions() []sql.Expression {
 // IsReadOnly implements the interface sql.ExecBuilderNode.
 func (c *CreateTable) IsReadOnly() bool {
 	return false
+}
+
+// TableCopierDestinationName returns the name of the table created for a table copy operation.
+func (c *CreateTable) TableCopierDestinationName() string {
+	return c.gmsCreateTable.Name()
 }
 
 // Resolved implements the interface sql.ExecBuilderNode.

--- a/server/node/create_table.go
+++ b/server/node/create_table.go
@@ -33,7 +33,7 @@ type CreateTable struct {
 var _ sql.ExecBuilderNode = (*CreateTable)(nil)
 var _ sql.SchemaTarget = (*CreateTable)(nil)
 var _ sql.Expressioner = (*CreateTable)(nil)
-var _ plan.TableCopierCreateTableDestination = (*CreateTable)(nil)
+var _ sql.Nameable = (*CreateTable)(nil)
 
 // NewCreateTable returns a new *CreateTable.
 func NewCreateTable(createTable *plan.CreateTable, sequences []*CreateSequence) *CreateTable {
@@ -63,8 +63,8 @@ func (c *CreateTable) IsReadOnly() bool {
 	return false
 }
 
-// TableCopierDestinationName returns the name of the table created for a table copy operation.
-func (c *CreateTable) TableCopierDestinationName() string {
+// Name returns the name of the table being created.
+func (c *CreateTable) Name() string {
 	return c.gmsCreateTable.Name()
 }
 

--- a/testing/go/smoke_test.go
+++ b/testing/go/smoke_test.go
@@ -20,6 +20,43 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
+// TestCreateTableAs verifies CTAS execution and transaction rollback through Doltgres create-table wrappers.
+func TestCreateTableAs(t *testing.T) {
+	RunScripts(t, []ScriptTest{
+		{
+			Name: "create table as select",
+			SetUpScript: []string{
+				"CREATE TABLE t (id INT PRIMARY KEY, k INT)",
+				"INSERT INTO t VALUES (1, 10), (2, 99)",
+				"CREATE TABLE u (k INT PRIMARY KEY)",
+				"INSERT INTO u VALUES (10)",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "CREATE TABLE c AS SELECT id, k FROM t WHERE NOT EXISTS(SELECT COUNT(*) FROM u WHERE u.k = t.k)",
+				},
+				{
+					Query:    "SELECT id, k FROM c ORDER BY id",
+					Expected: []sql.Row{},
+				},
+				{
+					Query: "BEGIN",
+				},
+				{
+					Query: "CREATE TABLE rolled_back AS SELECT 1 AS v",
+				},
+				{
+					Query: "ROLLBACK",
+				},
+				{
+					Query:    "SELECT to_regclass('rolled_back')",
+					Expected: []sql.Row{{nil}},
+				},
+			},
+		},
+	})
+}
+
 func TestSmokeTests(t *testing.T) {
 	RunScripts(t, []ScriptTest{
 		{


### PR DESCRIPTION
Expose the underlying create-table name through the standard sql.Nameable contract so GMS TableCopier can create and populate CTAS destinations without bypassing Doltgres context handling.

Adds regression coverage for aggregate EXISTS CTAS results and transactional rollback, and pins the companion GMS change.

Part of [dolthub/dolt#11489](https://github.com/dolthub/dolt/issues/11489)

Depends on: [dolthub/go-mysql-server#3780](https://github.com/dolthub/go-mysql-server/pull/3780)