### PR TITLE
Test upsert RETURNING with CHECK constraints

### DIFF
--- a/testing/go/insert_test.go
+++ b/testing/go/insert_test.go
@@ -189,6 +189,23 @@ ON CONFLICT (id) do update set c1 = $4`,
 			},
 		},
 		{
+			Name: "on conflict update returning with check constraint",
+			SetUpScript: []string{
+				"CREATE TABLE checked_upsert (id INT PRIMARY KEY, a TEXT CHECK (a <> ''), b TEXT, c TEXT)",
+				"INSERT INTO checked_upsert VALUES (1, 'x', 'y', 'z')",
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    "INSERT INTO checked_upsert VALUES (1, 'x', 'y', 'z') ON CONFLICT (id) DO UPDATE SET a = 'n1', b = 'n2' RETURNING id, a, b",
+					Expected: []sql.Row{{1, "n1", "n2"}},
+				},
+				{
+					Query:    "INSERT INTO checked_upsert VALUES (2, 'x', 'y', 'z') ON CONFLICT (id) DO UPDATE SET a = 'n1', b = 'n2' RETURNING id, a, b",
+					Expected: []sql.Row{{2, "x", "y"}},
+				},
+			},
+		},
+		{
 			Name: "on conflict do nothing only ignores uniqueness conflicts",
 			SetUpScript: []string{
 				"CREATE TABLE conflict_parent (id INT PRIMARY KEY)",


### PR DESCRIPTION
Adds wire-level regression coverage for INSERT ... ON CONFLICT DO UPDATE ... RETURNING on a table with a CHECK constraint. The test covers both the conflicting update arm and the non-conflicting insert arm.

The underlying expression-slice aliasing bug was fixed by the merged go-mysql-server change in dolthub/go-mysql-server#3753 and is already present on main.

Fixes #3280