### PR TITLE
Map shared integer overflow errors

### DIFF
--- a/server/connection_handler.go
+++ b/server/connection_handler.go
@@ -1779,7 +1779,7 @@ func castSQLError(err error) *pgconn.PgError {
 	// Class 22 — Data Exception
 	case pgtypes.ErrDivisionByZero.Is(err):
 		code = pgcode.DivisionByZero
-	case sql.ErrValueOutOfRange.Is(err), pgtypes.ErrValueIsOutOfRangeForType.Is(err),
+	case sql.ErrValueOutOfRange.Is(err), sql.ErrIntegerOutOfRange.Is(err), pgtypes.ErrValueIsOutOfRangeForType.Is(err),
 		pgtypes.ErrOutOfRange.Is(err), pgtypes.ErrInputOutOfRange.Is(err),
 		errors.Is(err, pgtypes.ErrCastOutOfRange):
 		code = pgcode.NumericValueOutOfRange

--- a/server/connection_handler_test.go
+++ b/server/connection_handler_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/doltgresql/postgres/parser/pgcode"
+)
+
+// TestCastSQLErrorIntegerOutOfRange verifies shared-engine integer overflow uses PostgreSQL's data-exception code.
+func TestCastSQLErrorIntegerOutOfRange(t *testing.T) {
+	err := sql.ErrIntegerOutOfRange.New("BIGINT", "(value + 1)")
+	pgErr := castSQLError(err)
+	require.Equal(t, pgcode.NumericValueOutOfRange.String(), pgErr.Code)
+}

--- a/testing/go/sqlstate_test.go
+++ b/testing/go/sqlstate_test.go
@@ -49,6 +49,21 @@ func TestSQLStateCodes(t *testing.T) {
 					ExpectedErrCode: "22003",
 				},
 				{
+					Query:           "SELECT 9223372036854775807::int8 + 1",
+					ExpectedErr:     "bigint out of range",
+					ExpectedErrCode: "22003",
+				},
+				{
+					Query:           "SELECT (-9223372036854775807)::int8 - 2",
+					ExpectedErr:     "bigint out of range",
+					ExpectedErrCode: "22003",
+				},
+				{
+					Query:           "SELECT 3037000500::int8 * 3037000500::int8",
+					ExpectedErr:     "bigint out of range",
+					ExpectedErrCode: "22003",
+				},
+				{
 					Query:           "SELECT acos(2.0)",
 					ExpectedErr:     "input is out of range",
 					ExpectedErrCode: "22003",


### PR DESCRIPTION
Maps the shared engine's integer arithmetic overflow error to PostgreSQL SQLSTATE 22003 and adds native int8 addition, subtraction, and multiplication overflow coverage. The shared GMS correction is now included through Doltgres main's Dolt dependency.