### PR TITLE
server/plpgsql: Fix regression introduced by 3743010a5 which could break previously compiled triggers.

### DIFF
--- a/server/plpgsql/interpreter_logic.go
+++ b/server/plpgsql/interpreter_logic.go
@@ -80,8 +80,16 @@ func TriggerCall(ctx *sql.Context, iFunc InterpretedFunction, runner sql.Stateme
 	// Add the special variables
 	// These are declared under their folded names, the same as anything the function declares itself, so
 	// that a body may write them in any case (`NEW.x`, `new.x`) the way Postgres allows.
+	//
+	// These variables are specially marked as being reachable from the code by any casing. This is
+	// because a trigger which was compiled before references were folded will hold operations that
+	// refer to these by names which reflect the source text. Thus, the references will be `NEW.x`
+	// rather than `new.x`. For such a trigger to keep working, these go through a compatibility
+	// shim.
 	stack.NewRecord(TriggerOldRecordName, sch, oldRow)
 	stack.NewRecord(TriggerNewRecordName, sch, newRow)
+	stack.markUnfoldedName(TriggerOldRecordName)
+	stack.markUnfoldedName(TriggerNewRecordName)
 	for varName, val := range trigVars {
 		normalized := NormalizeIdentifier(varName)
 		varType, ok := triggerSpecialVariables[normalized]
@@ -89,6 +97,7 @@ func TriggerCall(ctx *sql.Context, iFunc InterpretedFunction, runner sql.Stateme
 			return nil, fmt.Errorf("unknown variable %s for trigger", varName)
 		}
 		stack.NewVariableWithValue(normalized, varType, val)
+		stack.markUnfoldedName(normalized)
 	}
 	return call(ctx, iFunc, stack)
 }

--- a/server/plpgsql/interpreter_stack.go
+++ b/server/plpgsql/interpreter_stack.go
@@ -160,6 +160,18 @@ type InterpreterStack struct {
 	returnQueryBuffer [][]pgtypes.RecordValue
 	// cursors holds the active FOR record IN query LOOP result sets
 	cursors map[string]*cursorState
+	// unfoldedNames holds the folded names of variables that go through special name resolution for
+	// compatibility with triggers that were compiled by older version of doltgres. These are names
+	// that are declared by the trigger itself --- NEW, OLD and TG_ variables. A body compiled before
+	// Doltgres folded references will refer to these by the identifiers as they appear in the source
+	// text. When these operations name `NEW`, and the the variable is now registered as `new`, the
+	// lookup will fail to find a direct match.
+	//
+	// A lookup that misses retries against this set case-insensitively. This keeps these triggers
+	// running without them needing to be recreated. Only these names are retried, since declared
+	// names, for example, were unfolded at both declare time and reference time by the previous
+	// code.
+	unfoldedNames map[string]struct{}
 }
 
 // NewInterpreterStack creates a new InterpreterStack.
@@ -170,10 +182,11 @@ func NewInterpreterStack(runner sql.StatementRunner) InterpreterStack {
 		variables: make(map[string]*interpreterVariable),
 	})
 	return InterpreterStack{
-		outParams: make([]string, 0),
-		stack:     stack,
-		runner:    runner,
-		cursors:   make(map[string]*cursorState),
+		outParams:     make([]string, 0),
+		stack:         stack,
+		runner:        runner,
+		cursors:       make(map[string]*cursorState),
+		unfoldedNames: make(map[string]struct{}),
 	}
 }
 
@@ -220,48 +233,78 @@ func (is *InterpreterStack) GetVariableWithError(name string) (InterpreterVariab
 		// still attached. Field lookup is case-insensitive here, so the quotes are all that need removing.
 		fieldName = strings.Trim(splitName[1], `"`)
 	}
-	for i := 0; i < is.stack.Len(); i++ {
-		if iv, ok := is.stack.PeekDepth(i).variables[name]; ok {
-			if len(fieldName) == 0 {
-				return InterpreterVariableReference{
-					Type:  iv.Type,
-					Value: &iv.Value,
-				}, nil
-			} else if len(iv.Record) > 0 {
-				fieldIdx := recordFieldIndex(iv.Record, fieldName)
-				if fieldIdx == -1 {
-					return InterpreterVariableReference{}, ErrRecordHasNoField.New(name, fieldName)
-				}
-				fieldType, ok := iv.Record[fieldIdx].Type.(*pgtypes.DoltgresType)
-				if !ok {
-					return InterpreterVariableReference{}, fmt.Errorf(
-						"field `%s` of record `%s` does not have a Postgres type", fieldName, name)
-				}
-				return InterpreterVariableReference{
-					Type:  fieldType,
-					Value: &(iv.Value.(sql.Row)[fieldIdx]),
-				}, nil
-			} else if iv.IsRecord {
-				// A record that has never been assigned has no shape, so there is no field to read.
-				return InterpreterVariableReference{}, ErrRecordNotAssigned.New(name)
-			} else if iv.Type != nil && iv.Type.IsCompositeType() {
-				for fieldIdx := range iv.Type.CompositeAttrs {
-					if iv.Type.CompositeAttrs[fieldIdx].Name == fieldName {
-						vals := iv.Value.([]pgtypes.RecordValue)
-						return InterpreterVariableReference{
-							Type:  vals[fieldIdx].Type.(*pgtypes.DoltgresType),
-							Value: &(vals[fieldIdx].Value),
-						}, nil
-					}
-				}
+	if iv := is.findVariable(name); iv != nil {
+		if len(fieldName) == 0 {
+			return InterpreterVariableReference{
+				Type:  iv.Type,
+				Value: &iv.Value,
+			}, nil
+		} else if len(iv.Record) > 0 {
+			fieldIdx := recordFieldIndex(iv.Record, fieldName)
+			if fieldIdx == -1 {
 				return InterpreterVariableReference{}, ErrRecordHasNoField.New(name, fieldName)
-			} else {
-				return InterpreterVariableReference{}, fmt.Errorf(
-					"could not identify column `%s` in variable `%s`", fieldName, name)
 			}
+			fieldType, ok := iv.Record[fieldIdx].Type.(*pgtypes.DoltgresType)
+			if !ok {
+				return InterpreterVariableReference{}, fmt.Errorf(
+					"field `%s` of record `%s` does not have a Postgres type", fieldName, name)
+			}
+			return InterpreterVariableReference{
+				Type:  fieldType,
+				Value: &(iv.Value.(sql.Row)[fieldIdx]),
+			}, nil
+		} else if iv.IsRecord {
+			// A record that has never been assigned has no shape, so there is no field to read.
+			return InterpreterVariableReference{}, ErrRecordNotAssigned.New(name)
+		} else if iv.Type != nil && iv.Type.IsCompositeType() {
+			for fieldIdx := range iv.Type.CompositeAttrs {
+				if iv.Type.CompositeAttrs[fieldIdx].Name == fieldName {
+					vals := iv.Value.([]pgtypes.RecordValue)
+					return InterpreterVariableReference{
+						Type:  vals[fieldIdx].Type.(*pgtypes.DoltgresType),
+						Value: &(vals[fieldIdx].Value),
+					}, nil
+				}
+			}
+			return InterpreterVariableReference{}, ErrRecordHasNoField.New(name, fieldName)
+		} else {
+			return InterpreterVariableReference{}, fmt.Errorf(
+				"could not identify column `%s` in variable `%s`", fieldName, name)
 		}
 	}
 	return InterpreterVariableReference{}, ErrVariableNotFound.New(fullName)
+}
+
+// findVariable returns the variable named |name|, searching from the top of the stack down so that an inner
+// declaration shadows an outer one. Returns nil when no scope holds the name. A name that matches nothing
+// exactly is retried folded when it names a caller-supplied variable, which is what lets operations compiled
+// before Doltgres folded references keep resolving; see the unfoldedNames field.
+func (is *InterpreterStack) findVariable(name string) *interpreterVariable {
+	for i := 0; i < is.stack.Len(); i++ {
+		if iv, ok := is.stack.PeekDepth(i).variables[name]; ok {
+			return iv
+		}
+	}
+	folded := strings.ToLower(name)
+	if folded == name {
+		return nil
+	}
+	if _, ok := is.unfoldedNames[folded]; !ok {
+		return nil
+	}
+	for i := 0; i < is.stack.Len(); i++ {
+		if iv, ok := is.stack.PeekDepth(i).variables[folded]; ok {
+			return iv
+		}
+	}
+	return nil
+}
+
+// markUnfoldedName records that the variable named |name|, which must already be folded, may also be reached
+// by any other casing of that name. It is for the variables a caller supplies to a function rather than ones
+// the function declares, since only those changed names when reference folding was introduced.
+func (is *InterpreterStack) markUnfoldedName(name string) {
+	is.unfoldedNames[name] = struct{}{}
 }
 
 // recordFieldIndex returns the index of the field named |fieldName| within |sch|, or -1 if there is no such
@@ -339,12 +382,9 @@ func (is *InterpreterStack) NewVariableWithValue(name string, typ *pgtypes.Doltg
 // NewVariableAlias creates a new variable alias, named |alias|, in the current frame of this stack,
 // pointing to the specified |variable|.
 func (is *InterpreterStack) NewVariableAlias(alias string, target string) {
-	for i := 0; i < is.stack.Len(); i++ {
-		if iv, ok := is.stack.PeekDepth(i).variables[target]; ok {
-			// TODO: this won't work for RECORD types
-			is.stack.Peek().variables[alias] = iv
-			break
-		}
+	if iv := is.findVariable(target); iv != nil {
+		// TODO: this won't work for RECORD types
+		is.stack.Peek().variables[alias] = iv
 	}
 }
 
@@ -487,13 +527,11 @@ func (is *InterpreterStack) UpdateRecord(name string, schema sql.Schema, val sql
 	if err != nil {
 		return err
 	}
-	for i := 0; i < is.stack.Len(); i++ {
-		if iv, ok := is.stack.PeekDepth(i).variables[name]; ok {
-			iv.Record = normalizedSchema
-			iv.Value = copyRecordRow(normalizedSchema, val)
-			iv.IsRecord = true
-			return nil
-		}
+	if iv := is.findVariable(name); iv != nil {
+		iv.Record = normalizedSchema
+		iv.Value = copyRecordRow(normalizedSchema, val)
+		iv.IsRecord = true
+		return nil
 	}
 	return fmt.Errorf("record variable `%s` could not be found", name)
 }

--- a/server/plpgsql/interpreter_stack_test.go
+++ b/server/plpgsql/interpreter_stack_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plpgsql
+
+import (
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/require"
+
+	pgtypes "github.com/dolthub/doltgresql/server/types"
+)
+
+// TestUnfoldedNameLookup covers the resolution of names that a trigger compiled by an older Doltgres left in
+// its stored operations. Such a body was compiled before references were folded, so its operations name the
+// trigger's records and TG_ variables as its source text spelled them, `NEW.v` where the variable is now
+// registered as `new`. The operations are persisted, so those spellings outlive the version that produced
+// them and have to keep resolving; only the names a caller supplies are matched this way, since a name the
+// function itself declares is compiled to its folded form and must still match exactly.
+func TestUnfoldedNameLookup(t *testing.T) {
+	sch := sql.Schema{
+		{Name: "pk", Type: pgtypes.Int32},
+		{Name: "v", Type: pgtypes.Int32},
+	}
+
+	t.Run("a trigger record resolves from the spelling an older version stored", func(t *testing.T) {
+		stack := NewInterpreterStack(nil)
+		stack.NewRecord(TriggerNewRecordName, sch, sql.Row{int32(1), int32(10)})
+		stack.markUnfoldedName(TriggerNewRecordName)
+
+		ref, err := stack.GetVariableWithError("NEW.v")
+		require.NoError(t, err)
+		require.NotNil(t, ref.Type)
+		require.Equal(t, int32(10), *ref.Value)
+
+		// The two spellings name one variable rather than two, so a write through the stored spelling is
+		// visible to a read through the folded one.
+		*ref.Value = int32(11)
+		folded, err := stack.GetVariableWithError("new.v")
+		require.NoError(t, err)
+		require.Equal(t, int32(11), *folded.Value)
+	})
+
+	t.Run("a trigger's TG_ variables resolve the same way", func(t *testing.T) {
+		stack := NewInterpreterStack(nil)
+		stack.NewVariableWithValue("tg_op", pgtypes.Text, "INSERT")
+		stack.markUnfoldedName("tg_op")
+
+		ref, err := stack.GetVariableWithError("TG_OP")
+		require.NoError(t, err)
+		require.Equal(t, "INSERT", *ref.Value)
+	})
+
+	t.Run("a declared name is still matched exactly", func(t *testing.T) {
+		stack := NewInterpreterStack(nil)
+		// A quoted declaration keeps its capitals, and an unquoted reference to it folds to a name that
+		// PostgreSQL leaves unresolved. Nothing marked it as caller-supplied, so it stays unresolved.
+		stack.NewVariableWithValue("MyVar", pgtypes.Int32, int32(1))
+
+		_, err := stack.GetVariableWithError("myvar")
+		require.Error(t, err)
+		require.True(t, ErrVariableNotFound.Is(err))
+	})
+
+	t.Run("an unmarked name that only differs in case stays unresolved", func(t *testing.T) {
+		stack := NewInterpreterStack(nil)
+		stack.NewRecord("new", sch, sql.Row{int32(1), int32(10)})
+
+		_, err := stack.GetVariableWithError("NEW.v")
+		require.Error(t, err)
+		require.True(t, ErrVariableNotFound.Is(err))
+	})
+
+	t.Run("a record assignment reaches the record under either spelling", func(t *testing.T) {
+		stack := NewInterpreterStack(nil)
+		stack.NewRecord(TriggerNewRecordName, sch, sql.Row{int32(1), int32(10)})
+		stack.markUnfoldedName(TriggerNewRecordName)
+
+		require.NoError(t, stack.UpdateRecord("NEW", sch, sql.Row{int32(2), int32(20)}))
+		ref, err := stack.GetVariableWithError("new.pk")
+		require.NoError(t, err)
+		require.Equal(t, int32(2), *ref.Value)
+	})
+}


### PR DESCRIPTION
Previously compiled triggers would compile and persist bytecode which encoded references to special variables like `NEW`, `OLD` and `TG_OP` by the casing in which they appeared in the source code. In 3743010a5, doltgres was changed to correctly fold unquoted identifiers at both declaration time and when they appear as variable references. This had the unintended side effect of breaking existing compiled triggers which referenced these special variables --- the variables started being introduced by the interpret in their folded form, but the references to them existed as compiled opcodes that already had the variable name persisted, and that name was not going through folding again as part of interpretation.

This adds a backup lookup path for these special variables, so that previously compiled triggers continue to work.