### PR TITLE
[no-release-notes] Simplify stale dependency bump cleanup

### DIFF
--- a/.github/workflows/bump-dependency.yaml
+++ b/.github/workflows/bump-dependency.yaml
@@ -265,21 +265,6 @@ jobs:
 
               if (pull.keepAlive) process.exit(0);
 
-              const checkSuiteRes = await github.rest.checks.listSuitesForRef({
-                owner,
-                repo,
-                ref: pull.headRef,
-              });
-
-              if (checkSuiteRes.data) {
-                for (const suite of checkSuiteRes.data.check_suites) {
-                  console.log("suite id:", suite.id);
-                  console.log("suite app slug:", suite.app.slug);
-                  console.log("suite status:", suite.status);
-                  console.log("suite conclusion:", suite.conclusion);
-                } 
-              }
-
               console.log(`Closing open pr ${pull.number}`);
               await github.rest.issues.createComment({
                 issue_number: pull.number,


### PR DESCRIPTION
Remove the unused check-suite lookup before closing superseded dependency bump PRs. Bump PRs marked `keep-alive` remain open; all other superseded bumps are commented on and closed immediately, matching Dolt.