### PR TITLE
Fix numeric SUM over COALESCE

### DIFF
--- a/server/analyzer/optimize_functions.go
+++ b/server/analyzer/optimize_functions.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/dolthub/doltgresql/server/functions/framework"
 	pgtransform "github.com/dolthub/doltgresql/server/transform"
+	pgtypes "github.com/dolthub/doltgresql/server/types"
 )
 
 // OptimizeFunctions replaces all functions that fit specific criteria with their optimized variants. Also handles
@@ -76,6 +77,10 @@ func OptimizeFunctions(ctx *sql.Context, a *analyzer.Analyzer, node sql.Node, sc
 		if !sameNode {
 			projectNode.Child = n
 		}
+		refreshedProjections, sameTypes, err := refreshProjectedAggregateTypes(ctx, projectNode.Child, projectNode.Projections)
+		if err != nil {
+			return nil, transform.SameTree, err
+		}
 
 		// insert node cannot have more than 1 row value if it has set returning function
 		if isInsertNode && hasMultipleExpressionTuples && hasSRF {
@@ -84,7 +89,7 @@ func OptimizeFunctions(ctx *sql.Context, a *analyzer.Analyzer, node sql.Node, sc
 
 		// Check if there is set returning function in the projection expressions (e.g. SELECT unnest() [FROM table/srf])
 		hasSRFInProjection := false
-		exprs, sameExprs, err := transform.Exprs(ctx, projectNode.Projections, func(ctx *sql.Context, expr sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
+		exprs, sameExprs, err := transform.Exprs(ctx, refreshedProjections, func(ctx *sql.Context, expr sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 			if compiledFunction, ok := expr.(*framework.CompiledFunction); ok {
 				hasSRFInProjection = hasSRFInProjection || compiledFunction.IsSRF()
 				if quickFunction := compiledFunction.GetQuickFunction(ctx); quickFunction != nil {
@@ -111,8 +116,12 @@ func OptimizeFunctions(ctx *sql.Context, a *analyzer.Analyzer, node sql.Node, sc
 		if err != nil {
 			return nil, transform.SameTree, err
 		}
-		if !sameExprs {
-			projectNode.Projections = exprs
+		if !sameTypes || !sameExprs {
+			n, err = projectNode.WithExpressions(ctx, exprs...)
+			if err != nil {
+				return nil, transform.SameTree, err
+			}
+			projectNode = n.(*plan.Project)
 		}
 
 		// nested iter is used for set returning functions in the projections only
@@ -123,8 +132,41 @@ func OptimizeFunctions(ctx *sql.Context, a *analyzer.Analyzer, node sql.Node, sc
 			projectNode = projectNode.WithIncludesNestedIters(true)
 		}
 
-		return projectNode, sameNode && sameExprs, err
+		return projectNode, sameNode && sameTypes && sameExprs, err
 	})
+}
+
+// refreshProjectedAggregateTypes updates fields whose aggregate type resolved after plan construction.
+func refreshProjectedAggregateTypes(ctx *sql.Context, child sql.Node, projections []sql.Expression) ([]sql.Expression, transform.TreeIdentity, error) {
+	return transform.Exprs(ctx, projections, func(ctx *sql.Context, expr sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
+		field, ok := expr.(*expression.GetField)
+		if !ok || field.Type(ctx) != pgtypes.Unknown {
+			return expr, transform.SameTree, nil
+		}
+		sourceType := resolvedAggregateType(ctx, child, field.Id())
+		if sourceType == nil {
+			return expr, transform.SameTree, nil
+		}
+		refreshed := expression.NewGetFieldWithTable(
+			field.Index(), int(field.TableId()), sourceType,
+			field.Database(), field.Table(), field.Name(), field.IsNullable(ctx),
+		).WithId(field.Id())
+		return refreshed, transform.NewTree, nil
+	})
+}
+
+// resolvedAggregateType returns the concrete type of the aggregate identified by id beneath node.
+func resolvedAggregateType(ctx *sql.Context, node sql.Node, id sql.ColumnId) sql.Type {
+	var typ sql.Type
+	transform.InspectExpressions(ctx, node, func(ctx *sql.Context, expr sql.Expression) bool {
+		agg, ok := expr.(framework.AggregateFunction)
+		if !ok || agg.Id() != id || agg.Type(ctx) == pgtypes.Unknown {
+			return true
+		}
+		typ = agg.Type(ctx)
+		return false
+	})
+	return typ
 }
 
 // getDefaultExpr takes the default value definition, parses, builds and returns sql.ColumnDefaultValue.

--- a/testing/go/functions_test.go
+++ b/testing/go/functions_test.go
@@ -643,6 +643,57 @@ func TestAggregateFunctions(t *testing.T) {
 			},
 		},
 		{
+			Name: "numeric SUM over COALESCE",
+			SetUpScript: []string{
+				`CREATE TABLE numeric_sum_values (grp INT, amount NUMERIC(10,2));`,
+				`INSERT INTO numeric_sum_values VALUES
+					(1, 12.50),
+					(1, NULL),
+					(2, NULL),
+					(3, 99999999.99),
+					(3, 0.01);`,
+				`CREATE TABLE numeric_sum_groups (id INT PRIMARY KEY);`,
+				`INSERT INTO numeric_sum_groups VALUES (1), (2);`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:    `SELECT count(*), sum(coalesce(amount, 0)), pg_typeof(sum(coalesce(amount, 0))) FROM numeric_sum_values;`,
+					Expected: []sql.Row{{int64(5), Numeric("100000012.50"), "numeric"}},
+				},
+				{
+					Query: `SELECT grp, sum(coalesce(amount, 0)), pg_typeof(sum(coalesce(amount, 0))) FROM numeric_sum_values GROUP BY grp ORDER BY grp;`,
+					Expected: []sql.Row{
+						{1, Numeric("12.50"), "numeric"},
+						{2, Numeric("0.00"), "numeric"},
+						{3, Numeric("100000000.00"), "numeric"},
+					},
+				},
+				{
+					Query: `SELECT grp, amount,
+						sum(coalesce(amount, 0)) OVER (PARTITION BY grp ORDER BY amount),
+						pg_typeof(sum(coalesce(amount, 0)) OVER (PARTITION BY grp ORDER BY amount))
+					FROM numeric_sum_values ORDER BY grp, amount;`,
+					Expected: []sql.Row{
+						{1, Numeric("12.50"), Numeric("12.50"), "numeric"},
+						{1, nil, Numeric("12.50"), "numeric"},
+						{2, nil, Numeric("0.00"), "numeric"},
+						{3, Numeric("0.01"), Numeric("0.01"), "numeric"},
+						{3, Numeric("99999999.99"), Numeric("100000000.00"), "numeric"},
+					},
+				},
+				{
+					Query: `SELECT id,
+						(SELECT sum(coalesce(amount, 0)) FROM numeric_sum_values WHERE grp = numeric_sum_groups.id),
+						pg_typeof((SELECT sum(coalesce(amount, 0)) FROM numeric_sum_values WHERE grp = numeric_sum_groups.id))
+					FROM numeric_sum_groups ORDER BY id;`,
+					Expected: []sql.Row{
+						{1, Numeric("12.50"), "numeric"},
+						{2, Numeric("0.00"), "numeric"},
+					},
+				},
+			},
+		},
+		{
 			Name: "var_pop/var_samp/stddev_pop/stddev_samp with infinite and NaN float8 input",
 			Assertions: []ScriptTestAssertion{
 				{


### PR DESCRIPTION
Numeric `SUM(COALESCE(amount, 0))` can return `unknown type received *apd.Decimal result` over the PostgreSQL protocol.

The aggregate resolves to `numeric` after plan construction, but its projected `GetField` retains the earlier `unknown` type. Although the aggregate correctly produces an `*apd.Decimal`, wire encoding consequently routes that value through `unknownout`.

Refresh unknown projected aggregate fields during the existing final `OptimizeFunctions` project pass when their matching aggregate ColumnId has acquired a concrete type. Projection changes use `Project.WithExpressions` so the cached schema is invalidated. Regression coverage includes grouped, ungrouped, all-NULL, windowed, and correlated scalar-subquery forms.