### PR TITLE
Reject DISTINCT window aggregates with PostgreSQL error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dolthub/dolt/go v0.40.5-0.20260909215223-b97cd470f16f
 	github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.20.1-0.20260909222302-ee57f9da2a81
+	github.com/dolthub/go-mysql-server v0.20.1-0.20260910171855-c06ff3d1f004
 	github.com/dolthub/pg_query_go/v6 v6.0.0-20251215122834-fb20be4254d1
 	github.com/dolthub/sqllogictest/go v0.0.0-20260624223518-788480b24166
 	github.com/dolthub/vitess v0.0.0-20260909054055-e9f1b2468025

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dolthub/dolt/go v0.40.5-0.20260909215223-b97cd470f16f
 	github.com/dolthub/eventsapi_schema v0.0.0-20260715220557-d9b4a1c6b4d4
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-mysql-server v0.20.1-0.20260910171855-c06ff3d1f004
+	github.com/dolthub/go-mysql-server v0.20.1-0.20260910182719-d68958d2617d
 	github.com/dolthub/pg_query_go/v6 v6.0.0-20251215122834-fb20be4254d1
 	github.com/dolthub/sqllogictest/go v0.0.0-20260624223518-788480b24166
 	github.com/dolthub/vitess v0.0.0-20260909054055-e9f1b2468025

--- a/go.sum
+++ b/go.sum
@@ -264,6 +264,8 @@ github.com/dolthub/go-mysql-server v0.20.1-0.20260910160548-c551c0217f88 h1:rIfh
 github.com/dolthub/go-mysql-server v0.20.1-0.20260910160548-c551c0217f88/go.mod h1:dhOSHdtMpz0sxA087pU4jspKUlEVQ/A+QH/7jtp78J4=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260910171855-c06ff3d1f004 h1:J/SLYGIojLHFK2aF+SsmUARPBBdPdREPx21P0cogE1U=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260910171855-c06ff3d1f004/go.mod h1:dhOSHdtMpz0sxA087pU4jspKUlEVQ/A+QH/7jtp78J4=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260910182719-d68958d2617d h1:Iq++J5qc8OTmFphJwcgPPdtfvuINhUbafqGLXBevnnk=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260910182719-d68958d2617d/go.mod h1:dhOSHdtMpz0sxA087pU4jspKUlEVQ/A+QH/7jtp78J4=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20260414231531-5f031e3e9037 h1:oIW9HwuWrhxv+4HZxA+QQSKHLqWFyXZ2FmNjUYwkdiM=

--- a/go.sum
+++ b/go.sum
@@ -260,6 +260,10 @@ github.com/dolthub/go-mysql-server v0.20.1-0.20260909203709-638e182d66f4 h1:NyWq
 github.com/dolthub/go-mysql-server v0.20.1-0.20260909203709-638e182d66f4/go.mod h1:dhOSHdtMpz0sxA087pU4jspKUlEVQ/A+QH/7jtp78J4=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260909222302-ee57f9da2a81 h1:syqzXk4vEB6Uaf4e0Ag8zwddFM5QwFEn5nXpbaGpYqo=
 github.com/dolthub/go-mysql-server v0.20.1-0.20260909222302-ee57f9da2a81/go.mod h1:dhOSHdtMpz0sxA087pU4jspKUlEVQ/A+QH/7jtp78J4=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260910160548-c551c0217f88 h1:rIfhhidmJxWhj62uhkkwrXvEcBtkfWoeSC0k/bVH5pM=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260910160548-c551c0217f88/go.mod h1:dhOSHdtMpz0sxA087pU4jspKUlEVQ/A+QH/7jtp78J4=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260910171855-c06ff3d1f004 h1:J/SLYGIojLHFK2aF+SsmUARPBBdPdREPx21P0cogE1U=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260910171855-c06ff3d1f004/go.mod h1:dhOSHdtMpz0sxA087pU4jspKUlEVQ/A+QH/7jtp78J4=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20260414231531-5f031e3e9037 h1:oIW9HwuWrhxv+4HZxA+QQSKHLqWFyXZ2FmNjUYwkdiM=

--- a/servercfg/config.go
+++ b/servercfg/config.go
@@ -24,6 +24,8 @@ import (
 	"github.com/dolthub/doltgresql/server/hook"
 
 	pgsql "github.com/dolthub/doltgresql/postgres/parser/parser/sql"
+	"github.com/dolthub/doltgresql/postgres/parser/pgcode"
+	"github.com/dolthub/doltgresql/postgres/parser/pgerror"
 	"github.com/dolthub/doltgresql/server/analyzer"
 	"github.com/dolthub/doltgresql/server/expression"
 	"github.com/dolthub/doltgresql/servercfg/cfgdetails"
@@ -48,6 +50,7 @@ func (*DoltgresConfig) Overrides() sql.EngineOverrides {
 			ScalarFunctionAliasAsColumn: true,
 			InsertIgnoreMode:            sql.InsertIgnoreModeDuplicateKeysOnly,
 			Parser:                      pgsql.NewPostgresParser(),
+			ValidateDistinctWindow:      validateDistinctWindow,
 		},
 		Hooks: sql.ExecutionHooks{
 			RenameTable: sql.RenameTable{
@@ -73,6 +76,19 @@ func (*DoltgresConfig) Overrides() sql.EngineOverrides {
 		SchemaFormatter:                 pgsql.NewPostgresSchemaFormatter(),
 		CostedIndexScanExpressionFilter: &analyzer.LogicTreeWalker{},
 	}
+}
+
+// validateDistinctWindow returns PostgreSQL's error for DISTINCT on native window expressions.
+func validateDistinctWindow(schema, name string, expr sql.Expression) error {
+	if _, ok := expr.(sql.WindowAdaptableExpression); ok {
+		return pgerror.New(pgcode.FeatureNotSupported, "DISTINCT is not implemented for window functions")
+	}
+	functionName := name
+	if schema != "" {
+		functionName = schema + "." + name
+	}
+	return pgerror.Newf(pgcode.WrongObjectType,
+		"DISTINCT specified, but %s is not an aggregate function", functionName)
 }
 
 // ToSqlServerConfig returns this configuration struct as an implementation of the Dolt interface.

--- a/testing/go/window_test.go
+++ b/testing/go/window_test.go
@@ -65,6 +65,11 @@ func TestWindowFunctions(t *testing.T) {
 			Name: "distinct window aggregates are unsupported",
 			Assertions: []ScriptTestAssertion{
 				{
+					Query:           "SELECT count(DISTINCT *) OVER () FROM (VALUES (1)) AS t(v)",
+					ExpectedErr:     `at or near "*": syntax error`,
+					ExpectedErrCode: "42601",
+				},
+				{
 					Query:           "SELECT count(DISTINCT v) OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM (VALUES (1, 1), (2, 1), (3, 2)) AS t(id, v)",
 					ExpectedErr:     "DISTINCT is not implemented for window functions",
 					ExpectedErrCode: "0A000",

--- a/testing/go/window_test.go
+++ b/testing/go/window_test.go
@@ -62,6 +62,36 @@ func TestWindowFunctions(t *testing.T) {
 			},
 		},
 		{
+			Name: "distinct window aggregates are unsupported",
+			Assertions: []ScriptTestAssertion{
+				{
+					Query:           "SELECT count(DISTINCT v) OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM (VALUES (1, 1), (2, 1), (3, 2)) AS t(id, v)",
+					ExpectedErr:     "DISTINCT is not implemented for window functions",
+					ExpectedErrCode: "0A000",
+				},
+				{
+					Query:           "SELECT sum(DISTINCT v) OVER (ORDER BY id ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) FROM (VALUES (1, 1), (2, 1), (3, 2)) AS t(id, v)",
+					ExpectedErr:     "DISTINCT is not implemented for window functions",
+					ExpectedErrCode: "0A000",
+				},
+				{
+					Query:           "SELECT avg(DISTINCT v) OVER (ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM (VALUES (1, 1.00::numeric), (2, 1.00::numeric), (3, 4.00::numeric)) AS t(id, v)",
+					ExpectedErr:     "DISTINCT is not implemented for window functions",
+					ExpectedErrCode: "0A000",
+				},
+				{
+					Query:           "SELECT min(DISTINCT v) OVER (ORDER BY id ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) FROM (VALUES (1, 1), (2, 1), (3, 2)) AS t(id, v)",
+					ExpectedErr:     "DISTINCT is not implemented for window functions",
+					ExpectedErrCode: "0A000",
+				},
+				{
+					Query:           "SELECT max(DISTINCT v) OVER (ORDER BY id ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) FROM (VALUES (1, 1), (2, 1), (3, 2)) AS t(id, v)",
+					ExpectedErr:     "DISTINCT is not implemented for window functions",
+					ExpectedErrCode: "0A000",
+				},
+			},
+		},
+		{
 			// https://github.com/dolthub/doltgresql/issues/1796
 			Name: "basic window functions",
 			SetUpScript: []string{


### PR DESCRIPTION
Returns PostgreSQL's `0A000` feature-not-supported error for `DISTINCT` aggregate window calls, including `COUNT`, `SUM`, `AVG`, `MIN`, and `MAX`.

Adds native Doltgres integration coverage validated against PostgreSQL 15.17 and pins the supporting GMS planner override.

Depends on: [go-mysql-server #3852](https://github.com/dolthub/go-mysql-server/pull/3852)